### PR TITLE
Finalize migration to contextual logging from cluster-autoscaler repo.

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
@@ -17,6 +17,7 @@ limitations under the License.
 package alicloud
 
 import (
+	"context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -36,24 +37,24 @@ type Asg struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (asg *Asg) MaxSize() int {
+func (asg *Asg) MaxSize(ctx context.Context) int {
 	return asg.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (asg *Asg) MinSize() int {
+func (asg *Asg) MinSize(ctx context.Context) int {
 	return asg.minSize
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (asg *Asg) TargetSize() (int, error) {
+func (asg *Asg) TargetSize(ctx context.Context) (int, error) {
 	size, err := asg.manager.GetAsgSize(asg)
 	return int(size), err
 }
 
 // IncreaseSize increases Asg size
-func (asg *Asg) IncreaseSize(delta int) error {
+func (asg *Asg) IncreaseSize(ctx context.Context, delta int) error {
 	klog.Infof("increase ASG:%s with %d nodes", asg.Id(), delta)
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
@@ -63,14 +64,14 @@ func (asg *Asg) IncreaseSize(delta int) error {
 		klog.Errorf("failed to get ASG size because of %s", err.Error())
 		return err
 	}
-	if int(size)+delta > asg.MaxSize() {
-		return fmt.Errorf("size increase is too large - desired:%d max:%d", int(size)+delta, asg.MaxSize())
+	if int(size)+delta > asg.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase is too large - desired:%d max:%d", int(size)+delta, asg.MaxSize(context.TODO()))
 	}
 	return asg.manager.SetAsgSize(asg, size+int64(delta))
 }
 
 // AtomicIncreaseSize is not implemented.
-func (asg *Asg) AtomicIncreaseSize(delta int) error {
+func (asg *Asg) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -79,7 +80,7 @@ func (asg *Asg) AtomicIncreaseSize(delta int) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes if the size
 // when there is an option to just decrease the target.
-func (asg *Asg) DecreaseTargetSize(delta int) error {
+func (asg *Asg) DecreaseTargetSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("Aliyun: DecreaseTargetSize() with args: %v", delta)
 	if delta >= 0 {
 		return fmt.Errorf("size decrease size must be negative")
@@ -121,13 +122,13 @@ func (asg *Asg) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *Asg) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	size, err := asg.manager.GetAsgSize(asg)
 	if err != nil {
 		klog.Errorf("failed to get ASG size because of %s", err.Error())
 		return err
 	}
-	if int(size) <= asg.MinSize() {
+	if int(size) <= asg.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 	nodeIds := make([]string, 0, len(nodes))
@@ -151,7 +152,7 @@ func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (asg *Asg) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (asg *Asg) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -166,12 +167,12 @@ func (asg *Asg) RegionId() string {
 }
 
 // Debug returns a debug string for the Asg.
-func (asg *Asg) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(), asg.MaxSize())
+func (asg *Asg) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(context.TODO()), asg.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (asg *Asg) Nodes() ([]cloudprovider.Instance, error) {
+func (asg *Asg) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	instanceNames, err := asg.manager.GetAsgNodes(asg)
 	if err != nil {
 		return nil, err
@@ -184,7 +185,7 @@ func (asg *Asg) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (asg *Asg) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (asg *Asg) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	template, err := asg.manager.getAsgTemplate(asg.id)
 	if err != nil {
 		return nil, err
@@ -202,28 +203,28 @@ func (asg *Asg) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (asg *Asg) Exist() bool {
+func (asg *Asg) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (asg *Asg) Create() (cloudprovider.NodeGroup, error) {
+func (asg *Asg) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (asg *Asg) Autoprovisioned() bool {
+func (asg *Asg) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (asg *Asg) Delete() error {
+func (asg *Asg) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (asg *Asg) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (asg *Asg) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package alicloud
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -113,22 +114,22 @@ func (ali *aliCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (ali *aliCloudProvider) GPULabel() string {
+func (ali *aliCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (ali *aliCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (ali *aliCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (ali *aliCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(ali, node)
+func (ali *aliCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), ali, node)
 }
 
-func (ali *aliCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (ali *aliCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	result := make([]cloudprovider.NodeGroup, 0, len(ali.asgs))
 	for _, asg := range ali.asgs {
 		result = append(result, asg)
@@ -137,7 +138,7 @@ func (ali *aliCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (ali *aliCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (ali *aliCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	if len(node.Spec.ProviderID) == 0 {
 		klog.Warningf("Node %v has no providerId", node.Name)
 		return nil, nil
@@ -158,39 +159,39 @@ func (ali *aliCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (ali *aliCloudProvider) HasInstance(*apiv1.Node) (bool, error) {
+func (ali *aliCloudProvider) HasInstance(context.Context, *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (ali *aliCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (ali *aliCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
-func (ali *aliCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (ali *aliCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (ali *aliCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (ali *aliCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (ali *aliCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (ali *aliCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return ali.resourceLimiter, nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (ali *aliCloudProvider) Refresh() error {
+func (ali *aliCloudProvider) Refresh(ctx context.Context) error {
 	return nil
 }
 
 // Cleanup stops the go routine that is handling the current view of the ASGs in the form of a cache
-func (ali *aliCloudProvider) Cleanup() error {
+func (ali *aliCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -84,7 +85,7 @@ func BuildAwsCloudProvider(awsManager *AwsManager, resourceLimiter *cloudprovide
 }
 
 // Cleanup stops the go routine that is handling the current view of the ASGs in the form of a cache
-func (aws *awsCloudProvider) Cleanup() error {
+func (aws *awsCloudProvider) Cleanup(ctx context.Context) error {
 	aws.awsManager.Cleanup()
 	return nil
 }
@@ -95,23 +96,23 @@ func (aws *awsCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (aws *awsCloudProvider) GPULabel() string {
+func (aws *awsCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (aws *awsCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (aws *awsCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (aws *awsCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(aws, node)
+func (aws *awsCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), aws, node)
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (aws *awsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (aws *awsCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	asgs := aws.awsManager.getAsgs()
 	ngs := make([]cloudprovider.NodeGroup, 0, len(asgs))
 	for _, asg := range asgs {
@@ -125,7 +126,7 @@ func (aws *awsCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (aws *awsCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	if len(node.Spec.ProviderID) == 0 {
 		klog.Warningf("Node %v has no providerId", node.Name)
 		return nil, nil
@@ -149,7 +150,7 @@ func (aws *awsCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (aws *awsCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (aws *awsCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	// we haven't implemented a way to check if a fargate instance
 	// exists in the cloud provider
 	// returning 'true' because we are assuming the node exists in AWS
@@ -181,30 +182,30 @@ func (aws *awsCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (aws *awsCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (aws *awsCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
-func (aws *awsCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (aws *awsCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (aws *awsCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (aws *awsCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (aws *awsCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (aws *awsCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return aws.resourceLimiter, nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (aws *awsCloudProvider) Refresh() error {
+func (aws *awsCloudProvider) Refresh(ctx context.Context) error {
 	return aws.awsManager.Refresh()
 }
 
@@ -241,46 +242,46 @@ type AwsNodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (ng *AwsNodeGroup) MaxSize() int {
+func (ng *AwsNodeGroup) MaxSize(ctx context.Context) int {
 	return ng.asg.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (ng *AwsNodeGroup) MinSize() int {
+func (ng *AwsNodeGroup) MinSize(ctx context.Context) int {
 	return ng.asg.minSize
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (ng *AwsNodeGroup) TargetSize() (int, error) {
+func (ng *AwsNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return ng.asg.curSize, nil
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (ng *AwsNodeGroup) Exist() bool {
+func (ng *AwsNodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (ng *AwsNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *AwsNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (ng *AwsNodeGroup) Autoprovisioned() bool {
+func (ng *AwsNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (ng *AwsNodeGroup) Delete() error {
+func (ng *AwsNodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (ng *AwsNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *AwsNodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	if ng.asg == nil || ng.asg.Tags == nil || len(ng.asg.Tags) == 0 {
 		return &defaults, nil
 	}
@@ -288,7 +289,7 @@ func (ng *AwsNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) 
 }
 
 // IncreaseSize increases Asg size
-func (ng *AwsNodeGroup) IncreaseSize(delta int) error {
+func (ng *AwsNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -300,7 +301,7 @@ func (ng *AwsNodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ng *AwsNodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *AwsNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -309,7 +310,7 @@ func (ng *AwsNodeGroup) AtomicIncreaseSize(delta int) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes if the size
 // when there is an option to just decrease the target.
-func (ng *AwsNodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *AwsNodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease size must be negative")
 	}
@@ -343,9 +344,9 @@ func (ng *AwsNodeGroup) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (ng *AwsNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *AwsNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	size := ng.asg.curSize
-	if int(size) <= ng.MinSize() {
+	if int(size) <= ng.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 	refs := make([]*AwsInstanceRef, 0, len(nodes))
@@ -367,7 +368,7 @@ func (ng *AwsNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ng *AwsNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ng *AwsNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -377,12 +378,12 @@ func (ng *AwsNodeGroup) Id() string {
 }
 
 // Debug returns a debug string for the Asg.
-func (ng *AwsNodeGroup) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", ng.Id(), ng.MinSize(), ng.MaxSize())
+func (ng *AwsNodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", ng.Id(), ng.MinSize(context.TODO()), ng.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (ng *AwsNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *AwsNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	asgNodes, err := ng.awsManager.GetAsgNodes(ng.asg.AwsRef)
 	if err != nil {
 		return nil, err
@@ -414,7 +415,7 @@ func (ng *AwsNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (ng *AwsNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *AwsNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	template, err := ng.awsManager.getAsgTemplate(ng.asg)
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -152,11 +153,11 @@ func TestName(t *testing.T) {
 func TestNodeGroups(t *testing.T) {
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, testAwsService, nil, []string{"1:5:test-asg"}))
 
-	nodeGroups := provider.NodeGroups()
+	nodeGroups := provider.NodeGroups(context.Background())
 	assert.Equal(t, len(nodeGroups), 1)
 	assert.Equal(t, nodeGroups[0].Id(), "test-asg")
-	assert.Equal(t, nodeGroups[0].MinSize(), 1)
-	assert.Equal(t, nodeGroups[0].MaxSize(), 5)
+	assert.Equal(t, nodeGroups[0].MinSize(context.Background()), 1)
+	assert.Equal(t, nodeGroups[0].MaxSize(context.Background()), 5)
 }
 
 func TestAutoDiscoveredNodeGroups(t *testing.T) {
@@ -177,13 +178,13 @@ func TestAutoDiscoveredNodeGroups(t *testing.T) {
 		},
 	).Return(testNamedDescribeAutoScalingGroupsOutput("auto-asg", 1, "test-instance-id"), nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	nodeGroups := provider.NodeGroups()
+	nodeGroups := provider.NodeGroups(context.Background())
 	assert.Equal(t, len(nodeGroups), 1)
 	assert.Equal(t, nodeGroups[0].Id(), "auto-asg")
-	assert.Equal(t, nodeGroups[0].MinSize(), 1)
-	assert.Equal(t, nodeGroups[0].MaxSize(), 5)
+	assert.Equal(t, nodeGroups[0].MinSize(context.Background()), 1)
+	assert.Equal(t, nodeGroups[0].MaxSize(context.Background()), 5)
 }
 
 func TestNodeGroupForNode(t *testing.T) {
@@ -203,16 +204,16 @@ func TestNodeGroupForNode(t *testing.T) {
 		},
 	).Return(testNamedDescribeAutoScalingGroupsOutput("test-asg", 1, "test-instance-id"), nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	group, err := provider.NodeGroupForNode(node)
+	group, err := provider.NodeGroupForNode(context.Background(), node)
 
 	assert.NoError(t, err)
 	assert.Equal(t, group.Id(), "test-asg")
-	assert.Equal(t, group.MinSize(), 1)
-	assert.Equal(t, group.MaxSize(), 5)
+	assert.Equal(t, group.MinSize(context.Background()), 1)
+	assert.Equal(t, group.MaxSize(context.Background()), 5)
 
-	nodes, err := group.Nodes()
+	nodes, err := group.Nodes(context.Background())
 
 	assert.NoError(t, err)
 
@@ -226,7 +227,7 @@ func TestNodeGroupForNode(t *testing.T) {
 		},
 	}
 
-	group, err = provider.NodeGroupForNode(nodeNotInGroup)
+	group, err = provider.NodeGroupForNode(context.Background(), nodeNotInGroup)
 
 	assert.NoError(t, err)
 	assert.Nil(t, group)
@@ -241,7 +242,7 @@ func TestNodeGroupForNodeWithNoProviderId(t *testing.T) {
 	}
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	group, err := provider.NodeGroupForNode(node)
+	group, err := provider.NodeGroupForNode(context.Background(), node)
 
 	assert.NoError(t, err)
 	assert.Equal(t, group, nil)
@@ -255,7 +256,7 @@ func TestNodeGroupForNodeWithHybridNode(t *testing.T) {
 	}
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	group, err := provider.NodeGroupForNode(hybridNode)
+	group, err := provider.NodeGroupForNode(context.Background(), hybridNode)
 
 	assert.NoError(t, err)
 	assert.Nil(t, group)
@@ -317,7 +318,7 @@ func TestAwsRefFromProviderId(t *testing.T) {
 func TestTargetSize(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 
 	a.On("DescribeAutoScalingGroups",
 		mock.Anything,
@@ -327,9 +328,9 @@ func TestTargetSize(t *testing.T) {
 		},
 	).Return(testNamedDescribeAutoScalingGroupsOutput("test-asg", 2, "test-instance-id", "second-test-instance-id"), nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	targetSize, err := asgs[0].TargetSize()
+	targetSize, err := asgs[0].TargetSize(context.Background())
 	assert.Equal(t, targetSize, 2)
 	assert.NoError(t, err)
 
@@ -339,7 +340,7 @@ func TestTargetSize(t *testing.T) {
 func TestIncreaseSize(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 
 	a.On("SetDesiredCapacity", mock.Anything,
 		&autoscaling.SetDesiredCapacityInput{
@@ -356,18 +357,18 @@ func TestIncreaseSize(t *testing.T) {
 		},
 	).Return(testNamedDescribeAutoScalingGroupsOutput("test-asg", 2, "test-instance-id", "second-test-instance-id"), nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	initialSize, err := asgs[0].TargetSize()
+	initialSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, initialSize)
 
-	err = asgs[0].IncreaseSize(1)
+	err = asgs[0].IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 	a.AssertNumberOfCalls(t, "SetDesiredCapacity", 1)
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 1)
 
-	newSize, err := asgs[0].TargetSize()
+	newSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, newSize)
 }
@@ -375,7 +376,7 @@ func TestIncreaseSize(t *testing.T) {
 func TestBelongs(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 
 	a.On("DescribeAutoScalingGroups",
 		mock.Anything,
@@ -385,7 +386,7 @@ func TestBelongs(t *testing.T) {
 		},
 	).Return(testNamedDescribeAutoScalingGroupsOutput("test-asg", 1, "test-instance-id"), nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
 	invalidNode := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
@@ -413,7 +414,7 @@ func TestBelongs(t *testing.T) {
 func TestDeleteNodes(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 	var expectedInstancesCount int32 = 2
 
 	a.On("TerminateInstanceInAutoScalingGroup",
@@ -438,9 +439,9 @@ func TestDeleteNodes(t *testing.T) {
 	},
 	).Return(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	initialSize, err := asgs[0].TargetSize()
+	initialSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, initialSize)
 
@@ -449,12 +450,12 @@ func TestDeleteNodes(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id",
 		},
 	}
-	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	err = asgs[0].DeleteNodes(context.Background(), []*apiv1.Node{node})
 	assert.NoError(t, err)
 	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 1)
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 1)
 
-	newSize, err := asgs[0].TargetSize()
+	newSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, newSize)
 }
@@ -462,7 +463,7 @@ func TestDeleteNodes(t *testing.T) {
 func TestDeleteNodesTerminatingInstances(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 
 	a.On("TerminateInstanceInAutoScalingGroup",
 		mock.Anything,
@@ -490,9 +491,9 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 		expectedInstancesCount = 1
 	}).Return(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), autoscalingtypes.LifecycleStateTerminatingWait), nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	initialSize, err := asgs[0].TargetSize()
+	initialSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, initialSize)
 
@@ -501,12 +502,12 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id",
 		},
 	}
-	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	err = asgs[0].DeleteNodes(context.Background(), []*apiv1.Node{node})
 	assert.NoError(t, err)
 	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 0) // instances which are terminating don't need to be terminated again
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 1)
 
-	newSize, err := asgs[0].TargetSize()
+	newSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, newSize)
 }
@@ -514,7 +515,7 @@ func TestDeleteNodesTerminatingInstances(t *testing.T) {
 func TestDeleteNodesTerminatedInstances(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 
 	a.On("TerminateInstanceInAutoScalingGroup",
 		mock.Anything,
@@ -539,9 +540,9 @@ func TestDeleteNodesTerminatedInstances(t *testing.T) {
 	).Return(testSetASGInstanceLifecycle(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id", "second-test-instance-id"), autoscalingtypes.LifecycleStateTerminated), nil)
 
 	// load ASG state into cache
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	initialSize, err := asgs[0].TargetSize()
+	initialSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInstancesCount, int32(initialSize))
 
@@ -552,14 +553,14 @@ func TestDeleteNodesTerminatedInstances(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id",
 		},
 	}
-	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	err = asgs[0].DeleteNodes(context.Background(), []*apiv1.Node{node})
 	assert.NoError(t, err)
 	// we expect no calls to TerminateInstanceInAutoScalingGroup,
 	// because the Node we tried to Delete was already terminating.
 	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 0)
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 1)
 
-	newSize, err := asgs[0].TargetSize()
+	newSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	// we expect TargetSize to stay the same, even though there are
 	// two instances in Terminated state - TargetSize was already
@@ -570,7 +571,7 @@ func TestDeleteNodesTerminatedInstances(t *testing.T) {
 func TestDeleteNodesWithPlaceholder(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 
 	a.On("SetDesiredCapacity",
 		mock.Anything,
@@ -604,9 +605,9 @@ func TestDeleteNodesWithPlaceholder(t *testing.T) {
 		nil,
 	)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	initialSize, err := asgs[0].TargetSize()
+	initialSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, initialSize)
 
@@ -615,12 +616,12 @@ func TestDeleteNodesWithPlaceholder(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/i-placeholder-test-asg-1",
 		},
 	}
-	err = asgs[0].DeleteNodes([]*apiv1.Node{node})
+	err = asgs[0].DeleteNodes(context.Background(), []*apiv1.Node{node})
 	assert.NoError(t, err)
 	a.AssertNumberOfCalls(t, "SetDesiredCapacity", 1)
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 2)
 
-	newSize, err := asgs[0].TargetSize()
+	newSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, newSize)
 }
@@ -629,7 +630,7 @@ func TestDeleteNodesAfterMultipleRefreshes(t *testing.T) {
 	a := &autoScalingMock{}
 	manager := newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"})
 	provider := testProvider(t, manager)
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 
 	a.On("TerminateInstanceInAutoScalingGroup",
 		mock.Anything,
@@ -653,7 +654,7 @@ func TestDeleteNodesAfterMultipleRefreshes(t *testing.T) {
 		},
 	).Return(testNamedDescribeAutoScalingGroupsOutput("test-asg", 2, "test-instance-id", "second-test-instance-id"), nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 	// Call the manager directly as otherwise the call would be a noop as its within less then 60s
 	manager.forceRefresh()
 
@@ -662,7 +663,7 @@ func TestDeleteNodesAfterMultipleRefreshes(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id",
 		},
 	}
-	err := asgs[0].DeleteNodes([]*apiv1.Node{node})
+	err := asgs[0].DeleteNodes(context.Background(), []*apiv1.Node{node})
 	assert.NoError(t, err)
 }
 
@@ -672,13 +673,13 @@ func TestGetResourceLimiter(t *testing.T) {
 	m := newTestAwsManagerWithMockServices(mockAutoScaling, mockEC2, nil, nil, nil)
 
 	provider := testProvider(t, m)
-	_, err := provider.GetResourceLimiter()
+	_, err := provider.GetResourceLimiter(context.Background())
 	assert.NoError(t, err)
 }
 
 func TestCleanup(t *testing.T) {
 	provider := testProvider(t, testAwsManager)
-	err := provider.Cleanup()
+	err := provider.Cleanup(context.Background())
 	assert.NoError(t, err)
 }
 
@@ -711,7 +712,7 @@ func TestHasInstance(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id",
 		},
 	}
-	present, err := provider.HasInstance(node1)
+	present, err := provider.HasInstance(context.Background(), node1)
 	assert.NoError(t, err)
 	assert.True(t, present)
 
@@ -724,7 +725,7 @@ func TestHasInstance(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id",
 		},
 	}
-	present, err = provider.HasInstance(node2)
+	present, err = provider.HasInstance(context.Background(), node2)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 	assert.True(t, present)
 
@@ -737,7 +738,7 @@ func TestHasInstance(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id-2",
 		},
 	}
-	present, err = provider.HasInstance(node3)
+	present, err = provider.HasInstance(context.Background(), node3)
 	assert.ErrorContains(t, err, nodeNotPresentErr)
 	assert.False(t, present)
 
@@ -753,7 +754,7 @@ func TestHasInstance(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id-2",
 		},
 	}
-	present, err = provider.HasInstance(node4)
+	present, err = provider.HasInstance(context.Background(), node4)
 	assert.NoError(t, err)
 	assert.False(t, present)
 }
@@ -766,11 +767,11 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:10:test-asg"}))
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 	commonAsg := &asg{
 		AwsRef:  AwsRef{Name: asgs[0].Id()},
-		minSize: asgs[0].MinSize(),
-		maxSize: asgs[0].MaxSize(),
+		minSize: asgs[0].MinSize(context.Background()),
+		maxSize: asgs[0].MaxSize(context.Background()),
 	}
 
 	// desired capacity will be set as 6 as ASG has 4 placeholders
@@ -802,9 +803,9 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 		},
 	).Return(&autoscaling.DescribeScalingActivitiesOutput{}, nil)
 
-	provider.Refresh()
+	provider.Refresh(context.Background())
 
-	initialSize, err := asgs[0].TargetSize()
+	initialSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 10, initialSize)
 
@@ -863,7 +864,7 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 	provider.awsManager.asgCache.instanceToAsg = instanceToAsg
 
 	// calling delete nodes 2 nodes and remaining placeholders
-	err = asgs[0].DeleteNodes(nodes)
+	err = asgs[0].DeleteNodes(context.Background(), nodes)
 	assert.NoError(t, err)
 	a.AssertNumberOfCalls(t, "SetDesiredCapacity", 1)
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 2)

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -94,40 +95,40 @@ func (as *AgentPool) initialize() error {
 }
 
 // MinSize returns minimum size of the node group.
-func (as *AgentPool) MinSize() int {
+func (as *AgentPool) MinSize(ctx context.Context) int {
 	return as.minSize
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (as *AgentPool) Exist() bool {
+func (as *AgentPool) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (as *AgentPool) Create() (cloudprovider.NodeGroup, error) {
+func (as *AgentPool) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (as *AgentPool) Delete() error {
+func (as *AgentPool) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (as *AgentPool) Autoprovisioned() bool {
+func (as *AgentPool) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (as *AgentPool) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (as *AgentPool) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // MaxSize returns maximum size of the node group.
-func (as *AgentPool) MaxSize() int {
+func (as *AgentPool) MaxSize(ctx context.Context) int {
 	return as.maxSize
 }
 
@@ -209,7 +210,7 @@ func (as *AgentPool) getCurSize() (int64, error) {
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (as *AgentPool) TargetSize() (int, error) {
+func (as *AgentPool) TargetSize(ctx context.Context) (int, error) {
 	size, err := as.getCurSize()
 	if err != nil {
 		return -1, err
@@ -290,7 +291,7 @@ func (as *AgentPool) deleteOutdatedDeployments() (err error) {
 }
 
 // IncreaseSize increases agent pool size
-func (as *AgentPool) IncreaseSize(delta int) error {
+func (as *AgentPool) IncreaseSize(ctx context.Context, delta int) error {
 	as.mutex.Lock()
 	defer as.mutex.Unlock()
 
@@ -316,8 +317,8 @@ func (as *AgentPool) IncreaseSize(delta int) error {
 	}
 
 	curSize := len(indexes)
-	if curSize+delta > as.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", curSize+delta, as.MaxSize())
+	if curSize+delta > as.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", curSize+delta, as.MaxSize(context.TODO()))
 	}
 
 	highestUsedIndex := indexes[len(indexes)-1]
@@ -356,7 +357,7 @@ func (as *AgentPool) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (as *AgentPool) AtomicIncreaseSize(delta int) error {
+func (as *AgentPool) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -365,7 +366,7 @@ func (as *AgentPool) AtomicIncreaseSize(delta int) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes if the size
 // when there is an option to just decrease the target.
-func (as *AgentPool) DecreaseTargetSize(delta int) error {
+func (as *AgentPool) DecreaseTargetSize(ctx context.Context, delta int) error {
 	as.mutex.Lock()
 	defer as.mutex.Unlock()
 
@@ -455,22 +456,22 @@ func (as *AgentPool) DeleteInstances(instances []*azureRef) error {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
+func (as *AgentPool) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	klog.V(3).Infof("Delete nodes requested: %v\n", nodes)
 	indexes, _, err := as.GetVMIndexes()
 	if err != nil {
 		return err
 	}
 
-	if len(indexes) <= as.MinSize() {
+	if len(indexes) <= as.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
-	return as.ForceDeleteNodes(nodes)
+	return as.ForceDeleteNodes(context.TODO(), nodes)
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (as *AgentPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (as *AgentPool) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	refs := make([]*azureRef, 0, len(nodes))
 	for _, node := range nodes {
 		belongs, err := as.Belongs(node)
@@ -497,17 +498,17 @@ func (as *AgentPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // Debug returns a debug string for the agent pool.
-func (as *AgentPool) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", as.Name, as.MinSize(), as.MaxSize())
+func (as *AgentPool) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", as.Name, as.MinSize(context.TODO()), as.MaxSize(context.TODO()))
 }
 
 // TemplateNodeInfo returns a node template for this agent pool.
-func (as *AgentPool) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (as *AgentPool) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (as *AgentPool) Nodes() ([]cloudprovider.Instance, error) {
+func (as *AgentPool) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	instances, err := as.getVMsFromCache()
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
@@ -287,17 +287,17 @@ func TestAgentPoolIncreaseSize(t *testing.T) {
 	assert.NoError(t, err)
 	as.manager.azureCache = ac
 
-	err = as.IncreaseSize(-1)
+	err = as.IncreaseSize(context.Background(), -1)
 	expectedErr := fmt.Errorf("size increase must be positive")
 	assert.Equal(t, expectedErr, err)
 
 	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil).MaxTimes(2)
 	err = as.manager.Refresh()
 	assert.NoError(t, err)
-	err = as.IncreaseSize(4)
+	err = as.IncreaseSize(context.Background(), 4)
 	expectedErr = fmt.Errorf("size increase too large - desired:6 max:5")
 
-	err = as.IncreaseSize(2)
+	err = as.IncreaseSize(context.Background(), 2)
 	assert.NoError(t, err)
 }
 
@@ -316,14 +316,14 @@ func TestAgentPoolDecreaseTargetSize(t *testing.T) {
 	assert.NoError(t, err)
 	as.manager.azureCache = ac
 
-	err = as.DecreaseTargetSize(-1)
+	err = as.DecreaseTargetSize(context.Background(), -1)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), as.curSize)
 
 	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil).MaxTimes(2)
 	err = as.manager.Refresh()
 	assert.NoError(t, err)
-	err = as.DecreaseTargetSize(-1)
+	err = as.DecreaseTargetSize(context.Background(), -1)
 	expectedErr := fmt.Errorf("attempt to delete existing nodes targetSize:2 delta:-1 existingNodes: 2")
 	assert.Equal(t, expectedErr, err)
 }
@@ -420,7 +420,7 @@ func TestForceDeleteNodes(t *testing.T) {
 	mockSAClient := NewMockStorageAccountClient(ctrl)
 	as.manager.azClient.storageAccountsClient = mockSAClient
 
-	err := as.ForceDeleteNodes([]*apiv1.Node{})
+	err := as.ForceDeleteNodes(context.Background(), []*apiv1.Node{})
 	assert.NoError(t, err)
 
 	nodes := []*apiv1.Node{
@@ -429,7 +429,7 @@ func TestForceDeleteNodes(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{Name: "node"},
 		},
 	}
-	err = as.ForceDeleteNodes(nodes)
+	err = as.ForceDeleteNodes(context.Background(), nodes)
 	expectedErr := fmt.Errorf("resource name was missing from identifier")
 	assert.Equal(t, expectedErr, err)
 
@@ -439,7 +439,7 @@ func TestForceDeleteNodes(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{Name: "node1"},
 		},
 	}
-	err = as.ForceDeleteNodes(nodes)
+	err = as.ForceDeleteNodes(context.Background(), nodes)
 	expectedErr = fmt.Errorf("node1 belongs to a different asg than as")
 	assert.Equal(t, expectedErr, err)
 }
@@ -462,7 +462,7 @@ func TestAgentPoolDeleteNodes(t *testing.T) {
 	assert.NoError(t, err)
 	as.manager.azureCache = ac
 
-	err = as.DeleteNodes([]*apiv1.Node{
+	err = as.DeleteNodes(context.Background(), []*apiv1.Node{
 		{
 			Spec:       apiv1.NodeSpec{ProviderID: testInvalidProviderID},
 			ObjectMeta: v1.ObjectMeta{Name: "node"},
@@ -473,7 +473,7 @@ func TestAgentPoolDeleteNodes(t *testing.T) {
 
 	as1 := newTestAgentPool(newTestAzureManager(t), "as1")
 	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as1
-	err = as.DeleteNodes([]*apiv1.Node{
+	err = as.DeleteNodes(context.Background(), []*apiv1.Node{
 		{
 			Spec:       apiv1.NodeSpec{ProviderID: testValidProviderID0},
 			ObjectMeta: v1.ObjectMeta{Name: "node"},
@@ -483,7 +483,7 @@ func TestAgentPoolDeleteNodes(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 
 	as.minSize = 3
-	err = as.DeleteNodes([]*apiv1.Node{})
+	err = as.DeleteNodes(context.Background(), []*apiv1.Node{})
 	expectedErr = fmt.Errorf("min size reached, nodes will not be deleted")
 	assert.Equal(t, expectedErr, err)
 }
@@ -515,14 +515,14 @@ func TestAgentPoolNodes(t *testing.T) {
 	assert.NoError(t, err)
 	as.manager.azureCache = ac
 
-	nodes, err := as.Nodes()
+	nodes, err := as.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(nodes))
 	assert.Equal(t, cloudprovider.InstanceRunning, nodes[0].Status.State)
 
 	expectedVMs[1].Properties = &armcompute.VirtualMachineProperties{ProvisioningState: ptr.To(VMProvisioningStateDeleting)}
 	as.manager.azureCache.virtualMachines["as"] = expectedVMs
-	nodes, err = as.Nodes()
+	nodes, err = as.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, cloudprovider.InstanceDeleting, nodes[0].Status.State)
 
@@ -535,7 +535,7 @@ func TestAgentPoolNodes(t *testing.T) {
 	mockVMClient.EXPECT().List(gomock.Any(), as.manager.config.ResourceGroup).Return(expectedVMs, nil)
 	err = as.manager.forceRefresh()
 	assert.NoError(t, err)
-	nodes, err = as.Nodes()
+	nodes, err = as.Nodes(context.Background())
 	expectedErr := fmt.Errorf("\"azure://foo\" isn't in Azure resource ID format")
 	assert.Equal(t, expectedErr, err)
 	assert.Nil(t, nodes)

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -201,7 +201,7 @@ func (m *azureCache) regenerate() error {
 	newInstanceStates := make(map[azureRef]cloudprovider.InstanceState)
 	for _, ng := range m.registeredNodeGroups {
 		klog.V(4).Infof("regenerate: finding nodes for node group %s", ng.Id())
-		instances, err := ng.Nodes()
+		instances, err := ng.Nodes(context.TODO())
 		if err != nil {
 			return err
 		}
@@ -387,7 +387,7 @@ func (m *azureCache) Register(nodeGroup cloudprovider.NodeGroup) bool {
 
 	for i := range m.registeredNodeGroups {
 		if existing := m.registeredNodeGroups[i]; strings.EqualFold(existing.Id(), nodeGroup.Id()) {
-			if existing.MinSize() == nodeGroup.MinSize() && existing.MaxSize() == nodeGroup.MaxSize() {
+			if existing.MinSize(context.TODO()) == nodeGroup.MinSize(context.TODO()) && existing.MaxSize(context.TODO()) == nodeGroup.MaxSize(context.TODO()) {
 				// Node group is already registered and min/max size haven't changed, no action required.
 				return false
 			}

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -76,7 +77,7 @@ func BuildAzureCloudProvider(azureManager *AzureManager, resourceLimiter *cloudp
 }
 
 // Cleanup stops the go routine that is handling the current view of the ASGs in the form of a cache
-func (azure *AzureCloudProvider) Cleanup() error {
+func (azure *AzureCloudProvider) Cleanup(ctx context.Context) error {
 	azure.azureManager.Cleanup()
 	return nil
 }
@@ -87,24 +88,24 @@ func (azure *AzureCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (azure *AzureCloudProvider) GPULabel() string {
+func (azure *AzureCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (azure *AzureCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (azure *AzureCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (azure *AzureCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(azure, node)
+func (azure *AzureCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), azure, node)
 
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (azure *AzureCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (azure *AzureCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	asgs := azure.azureManager.getNodeGroups()
 
 	ngs := make([]cloudprovider.NodeGroup, len(asgs))
@@ -115,7 +116,7 @@ func (azure *AzureCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (azure *AzureCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	klog.V(6).Infof("NodeGroupForNode: starts")
 	if node.Spec.ProviderID == "" {
 		klog.V(6).Infof("Skipping the search for node group for the node '%s' because it has no spec.ProviderID", node.ObjectMeta.Name)
@@ -144,7 +145,7 @@ func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider.
-func (azure *AzureCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (azure *AzureCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	if node.Spec.ProviderID == "" {
 		return false, fmt.Errorf("ProviderID for node: %s is empty, skipped", node.Name)
 	}
@@ -156,30 +157,30 @@ func (azure *AzureCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (azure *AzureCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (azure *AzureCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
-func (azure *AzureCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (azure *AzureCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (azure *AzureCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (azure *AzureCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (azure *AzureCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (azure *AzureCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return azure.resourceLimiter, nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (azure *AzureCloudProvider) Refresh() error {
+func (azure *AzureCloudProvider) Refresh(ctx context.Context) error {
 	return azure.azureManager.Refresh()
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -136,7 +137,7 @@ func TestName(t *testing.T) {
 
 func TestNodeGroups(t *testing.T) {
 	provider := newTestProvider(t)
-	assert.Equal(t, len(provider.NodeGroups()), 0)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 0)
 
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"),
@@ -146,7 +147,7 @@ func TestNodeGroups(t *testing.T) {
 		newTestVMsPool(provider.azureManager),
 	)
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 2)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 2)
 }
 
 func TestHasInstance(t *testing.T) {
@@ -190,7 +191,7 @@ func TestHasInstance(t *testing.T) {
 		Return(fakeAPListPager).AnyTimes()
 
 	// Register node groups
-	assert.Equal(t, len(provider.NodeGroups()), 0)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 0)
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"),
 	)
@@ -202,7 +203,7 @@ func TestHasInstance(t *testing.T) {
 	)
 	provider.azureManager.explicitlyConfigured[vmsNodeGroupName] = true
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 2)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 2)
 
 	// Refresh cache
 	provider.azureManager.forceRefresh()
@@ -276,7 +277,7 @@ func TestHasInstanceReportsDeletingNodesAsGone(t *testing.T) {
 
 			scaleSet, ok := manager.azureCache.registeredNodeGroups[0].(*ScaleSet)
 			assert.True(t, ok)
-			assert.NoError(t, scaleSet.DeleteNodes([]*apiv1.Node{deletedNode}))
+			assert.NoError(t, scaleSet.DeleteNodes(context.Background(), []*apiv1.Node{deletedNode}))
 
 			// In non-strict mode, deleting state is proactive. In strict mode, it is
 			// only reflected after refresh from Azure.
@@ -352,7 +353,7 @@ func TestHasInstanceProviderIDErrorValidation(t *testing.T) {
 			ProviderID: "",
 		},
 	}
-	_, err := provider.HasInstance(nodeWithoutValidProviderID)
+	_, err := provider.HasInstance(context.Background(), nodeWithoutValidProviderID)
 	assert.Equal(t, "ProviderID for node: test-node is empty, skipped", err.Error())
 
 	// Test cases: Nodes with invalid ProviderID prefixes
@@ -372,7 +373,7 @@ func TestHasInstanceProviderIDErrorValidation(t *testing.T) {
 				ProviderID: providerID,
 			},
 		}
-		_, err := provider.HasInstance(invalidProviderIDNode)
+		_, err := provider.HasInstance(context.Background(), invalidProviderIDNode)
 		assert.Equal(t, "invalid azure ProviderID prefix for node: test-node, skipped", err.Error())
 	}
 }
@@ -413,7 +414,7 @@ func TestMixedNodeGroups(t *testing.T) {
 	mockAgentpoolclient.EXPECT().NewListPager(provider.azureManager.azureCache.clusterResourceGroup, provider.azureManager.azureCache.clusterName, nil).
 		Return(fakeAPListPager).AnyTimes()
 
-	assert.Equal(t, len(provider.NodeGroups()), 0)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 0)
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"),
 	)
@@ -425,28 +426,28 @@ func TestMixedNodeGroups(t *testing.T) {
 	)
 	provider.azureManager.explicitlyConfigured[vmsNodeGroupName] = true
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 2)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 2)
 
 	// refresh cache
 	provider.azureManager.forceRefresh()
 
 	// node from vmss pool
 	node := newApiNode(armcompute.OrchestrationModeUniform, 0)
-	group, err := provider.NodeGroupForNode(node)
+	group, err := provider.NodeGroupForNode(context.Background(), node)
 	assert.NoError(t, err)
 	assert.NotNil(t, group, "Group should not be nil")
 	assert.Equal(t, group.Id(), "test-asg")
-	assert.Equal(t, group.MinSize(), 1)
-	assert.Equal(t, group.MaxSize(), 5)
+	assert.Equal(t, group.MinSize(context.Background()), 1)
+	assert.Equal(t, group.MaxSize(context.Background()), 5)
 
 	// node from vms pool
 	vmsPoolNode := newVMsNode(0)
-	group, err = provider.NodeGroupForNode(vmsPoolNode)
+	group, err = provider.NodeGroupForNode(context.Background(), vmsPoolNode)
 	assert.NoError(t, err)
 	assert.NotNil(t, group, "Group should not be nil")
 	assert.Equal(t, group.Id(), vmsNodeGroupName)
-	assert.Equal(t, group.MinSize(), 3)
-	assert.Equal(t, group.MaxSize(), 10)
+	assert.Equal(t, group.MinSize(context.Background()), 3)
+	assert.Equal(t, group.MaxSize(context.Background()), 10)
 }
 
 func TestNodeGroupForNode(t *testing.T) {
@@ -482,19 +483,19 @@ func TestNodeGroupForNode(t *testing.T) {
 				newTestScaleSet(provider.azureManager, "test-asg"))
 			provider.azureManager.explicitlyConfigured["test-asg"] = true
 			assert.True(t, registered)
-			assert.Equal(t, len(provider.NodeGroups()), 1)
+			assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
 
 			node := newApiNode(orchMode, 0)
 			// refresh cache
 			provider.azureManager.forceRefresh()
-			group, err := provider.NodeGroupForNode(node)
+			group, err := provider.NodeGroupForNode(context.Background(), node)
 			assert.NoError(t, err)
 			assert.NotNil(t, group, "Group should not be nil")
 			assert.Equal(t, group.Id(), "test-asg")
-			assert.Equal(t, group.MinSize(), 1)
-			assert.Equal(t, group.MaxSize(), 5)
+			assert.Equal(t, group.MinSize(context.Background()), 1)
+			assert.Equal(t, group.MaxSize(context.Background()), 5)
 
-			hasInstance, err := provider.HasInstance(node)
+			hasInstance, err := provider.HasInstance(context.Background(), node)
 			assert.True(t, hasInstance)
 			assert.NoError(t, err)
 
@@ -504,11 +505,11 @@ func TestNodeGroupForNode(t *testing.T) {
 					ProviderID: "azure:///subscriptions/subscription/resourceGroups/test-resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/test/virtualMachines/test-instance-id-not-in-group",
 				},
 			}
-			group, err = provider.NodeGroupForNode(nodeNotInGroup)
+			group, err = provider.NodeGroupForNode(context.Background(), nodeNotInGroup)
 			assert.NoError(t, err)
 			assert.Nil(t, group)
 
-			hasInstance, err = provider.HasInstance(nodeNotInGroup)
+			hasInstance, err = provider.HasInstance(context.Background(), nodeNotInGroup)
 			assert.False(t, hasInstance)
 			assert.Error(t, err)
 			assert.Equal(t, err, cloudprovider.ErrNotImplemented)
@@ -521,14 +522,14 @@ func TestNodeGroupForNodeWithNoProviderId(t *testing.T) {
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
 
 	node := &apiv1.Node{
 		Spec: apiv1.NodeSpec{
 			ProviderID: "",
 		},
 	}
-	group, err := provider.NodeGroupForNode(node)
+	group, err := provider.NodeGroupForNode(context.Background(), node)
 
 	assert.NoError(t, err)
 	assert.Equal(t, group, nil)

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -805,8 +806,8 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 		asgs := manager.azureCache.getRegisteredNodeGroups()
 		assert.Equal(t, 1, len(asgs))
 		assert.Equal(t, name, asgs[0].Id())
-		assert.Equal(t, min, asgs[0].MinSize())
-		assert.Equal(t, max, asgs[0].MaxSize())
+		assert.Equal(t, min, asgs[0].MinSize(context.Background()))
+		assert.Equal(t, max, asgs[0].MaxSize(context.Background()))
 	}
 
 	// test vmTypeStandard
@@ -1020,8 +1021,8 @@ func TestFetchAutoAsgsVmss(t *testing.T) {
 	asgs = manager.azureCache.getRegisteredNodeGroups()
 	assert.Equal(t, 1, len(asgs))
 	assert.Equal(t, vmssName, asgs[0].Id())
-	assert.Equal(t, minVal, asgs[0].MinSize())
-	assert.Equal(t, maxVal, asgs[0].MaxSize())
+	assert.Equal(t, minVal, asgs[0].MinSize(context.Background()))
+	assert.Equal(t, maxVal, asgs[0].MaxSize(context.Background()))
 
 	// test explicitlyConfigured
 	manager.explicitlyConfigured[vmssName] = true

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -146,35 +146,35 @@ func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager, curSize int64, d
 }
 
 // MinSize returns minimum size of the node group.
-func (scaleSet *ScaleSet) MinSize() int {
+func (scaleSet *ScaleSet) MinSize(ctx context.Context) int {
 	return scaleSet.minSize
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (scaleSet *ScaleSet) Exist() bool {
+func (scaleSet *ScaleSet) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (scaleSet *ScaleSet) Create() (cloudprovider.NodeGroup, error) {
+func (scaleSet *ScaleSet) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (scaleSet *ScaleSet) Delete() error {
+func (scaleSet *ScaleSet) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (scaleSet *ScaleSet) Autoprovisioned() bool {
+func (scaleSet *ScaleSet) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (scaleSet *ScaleSet) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (scaleSet *ScaleSet) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	template, err := scaleSet.getVMSSFromCache()
 	if err != nil {
 		klog.Errorf("failed to get information for VMSS: %s", scaleSet.Name)
@@ -188,7 +188,7 @@ func (scaleSet *ScaleSet) GetOptions(defaults config.NodeGroupAutoscalingOptions
 }
 
 // MaxSize returns maximum size of the node group.
-func (scaleSet *ScaleSet) MaxSize() int {
+func (scaleSet *ScaleSet) MaxSize(ctx context.Context) int {
 	return scaleSet.maxSize
 }
 
@@ -314,7 +314,7 @@ func (scaleSet *ScaleSet) setScaleSetSize(size int64, delta int) error {
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (scaleSet *ScaleSet) TargetSize() (int, error) {
+func (scaleSet *ScaleSet) TargetSize(ctx context.Context) (int, error) {
 	size, err := scaleSet.getScaleSetSize()
 	return int(size), err
 }
@@ -336,15 +336,15 @@ func (scaleSet *ScaleSet) canIncreaseSize(delta int) (int64, error) {
 		return size, fmt.Errorf("the scale set %s is under initialization, skipping IncreaseSize", scaleSet.Name)
 	}
 
-	if int(size)+delta > scaleSet.MaxSize() {
-		return size, fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize())
+	if int(size)+delta > scaleSet.MaxSize(context.TODO()) {
+		return size, fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize(context.TODO()))
 	}
 
 	return size, nil
 }
 
 // IncreaseSize increases Scale Set size
-func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
+func (scaleSet *ScaleSet) IncreaseSize(ctx context.Context, delta int) error {
 	size, err := scaleSet.canIncreaseSize(delta)
 	if err != nil {
 		return err
@@ -365,7 +365,7 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 // "doesn't wait until the new instances appear" — the blocking behavior is required
 // for atomic-scale-up ProvisioningRequest support to provide a capacity guarantee
 // before workloads are admitted.
-func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
+func (scaleSet *ScaleSet) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	size, err := scaleSet.canIncreaseSize(delta)
 	if err != nil {
 		return err
@@ -480,7 +480,7 @@ func (scaleSet *ScaleSet) GetFlexibleScaleSetVms() ([]*armcompute.VirtualMachine
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes if the size
 // when there is an option to just decrease the target.
-func (scaleSet *ScaleSet) DecreaseTargetSize(delta int) error {
+func (scaleSet *ScaleSet) DecreaseTargetSize(ctx context.Context, delta int) error {
 	// VMSS size should be changed automatically after the Node deletion, hence this operation is not required.
 	// To prevent some unreproducible bugs, an extra refresh of cache is needed.
 	scaleSet.invalidateInstanceCache()
@@ -883,7 +883,7 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
+func (scaleSet *ScaleSet) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	klog.V(3).Infof("Delete nodes requested: %q\n", nodes)
 	size, err := scaleSet.getScaleSetSize()
 	if err != nil {
@@ -893,14 +893,14 @@ func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 	// This only catches callers already at min size. A future change should also reject
 	// batches that would go below min size; create-error cleanup fallback is the only
 	// currently known path that can reach this check without regular scale-down filtering.
-	if int(size) <= scaleSet.MinSize() {
+	if int(size) <= scaleSet.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
-	return scaleSet.ForceDeleteNodes(nodes)
+	return scaleSet.ForceDeleteNodes(context.TODO(), nodes)
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (scaleSet *ScaleSet) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (scaleSet *ScaleSet) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	klog.V(3).Infof("Delete nodes requested: %q\n", nodes)
 	refs := make([]*azureRef, 0, len(nodes))
 	hasUnregisteredNodes := false
@@ -932,12 +932,12 @@ func (scaleSet *ScaleSet) Id() string {
 }
 
 // Debug returns a debug string for the Scale Set.
-func (scaleSet *ScaleSet) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", scaleSet.Id(), scaleSet.MinSize(), scaleSet.MaxSize())
+func (scaleSet *ScaleSet) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", scaleSet.Id(), scaleSet.MinSize(context.TODO()), scaleSet.MaxSize(context.TODO()))
 }
 
 // TemplateNodeInfo returns a node template for this scale set.
-func (scaleSet *ScaleSet) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (scaleSet *ScaleSet) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	vmss, err := scaleSet.getVMSSFromCache()
 	if err != nil {
 		return nil, err
@@ -959,7 +959,7 @@ func (scaleSet *ScaleSet) TemplateNodeInfo() (*framework.NodeInfo, error) {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (scaleSet *ScaleSet) Nodes() ([]cloudprovider.Instance, error) {
+func (scaleSet *ScaleSet) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	curSize, getVMSSError := scaleSet.getCurSize()
 	if getVMSSError != nil {
 		klog.Errorf("Failed to get current size for vmss %q: %v", scaleSet.Name, getVMSSError.error)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -161,8 +161,8 @@ func TestScaleSetMaxSize(t *testing.T) {
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
-	assert.Equal(t, provider.NodeGroups()[0].MaxSize(), 5)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
+	assert.Equal(t, provider.NodeGroups(context.Background())[0].MaxSize(context.Background()), 5)
 }
 
 func TestScaleSetMinSize(t *testing.T) {
@@ -170,8 +170,8 @@ func TestScaleSetMinSize(t *testing.T) {
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
-	assert.Equal(t, provider.NodeGroups()[0].MinSize(), 1)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
+	assert.Equal(t, provider.NodeGroups(context.Background())[0].MinSize(context.Background()), 1)
 }
 
 func TestScaleSetMinSizeZero(t *testing.T) {
@@ -179,8 +179,8 @@ func TestScaleSetMinSizeZero(t *testing.T) {
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSetMinSizeZero(provider.azureManager, testASG))
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
-	assert.Equal(t, provider.NodeGroups()[0].MinSize(), 0)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
+	assert.Equal(t, provider.NodeGroups(context.Background())[0].MinSize(context.Background()), 0)
 }
 
 func TestScaleSetTargetSize(t *testing.T) {
@@ -233,13 +233,13 @@ func TestScaleSetTargetSize(t *testing.T) {
 		registered := provider.azureManager.RegisterNodeGroup(
 			newTestScaleSet(provider.azureManager, testASG))
 		assert.True(t, registered)
-		assert.Equal(t, len(provider.NodeGroups()), 1)
+		assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
 
-		targetSize, err := provider.NodeGroups()[0].TargetSize()
+		targetSize, err := provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 3, targetSize)
 
-		targetSize, err = provider.NodeGroups()[0].TargetSize()
+		targetSize, err = provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 3, targetSize)
 
@@ -247,9 +247,9 @@ func TestScaleSetTargetSize(t *testing.T) {
 		spotNodeGroup := newTestScaleSet(provider.azureManager, "spot-vmss")
 		registered = provider.azureManager.RegisterNodeGroup(spotNodeGroup)
 		assert.True(t, registered)
-		assert.Equal(t, len(provider.NodeGroups()), 2)
+		assert.Equal(t, len(provider.NodeGroups(context.Background())), 2)
 
-		targetSize, err = provider.NodeGroups()[1].TargetSize()
+		targetSize, err = provider.NodeGroups(context.Background())[1].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 1, targetSize)
 	}
@@ -265,7 +265,7 @@ func TestScaleSetTargetSizeReturnsErrorForCachedNegativeSize(t *testing.T) {
 	scaleSet.lastSizeRefresh = time.Now()
 	scaleSet.sizeRefreshPeriod = time.Hour
 
-	size, err := scaleSet.TargetSize()
+	size, err := scaleSet.TargetSize(context.Background())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cached size is -1 without provider error")
 	assert.Equal(t, -1, size)
@@ -327,26 +327,26 @@ func TestScaleSetIncreaseSize(t *testing.T) {
 		assert.NoError(t, err)
 
 		ss := newTestScaleSet(provider.azureManager, "test-asg-doesnt-exist")
-		err = ss.IncreaseSize(100)
+		err = ss.IncreaseSize(context.Background(), 100)
 		expectedErr := fmt.Errorf("could not find vmss: test-asg-doesnt-exist")
 		assert.Equal(t, expectedErr, err)
 
 		registered := provider.azureManager.RegisterNodeGroup(
 			newTestScaleSet(provider.azureManager, testASG))
 		assert.True(t, registered)
-		assert.Equal(t, len(provider.NodeGroups()), 1)
+		assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
 
 		// Current target size is 3.
-		targetSize, err := provider.NodeGroups()[0].TargetSize()
+		targetSize, err := provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 3, targetSize)
 
 		// Increase 2 nodes.
-		err = provider.NodeGroups()[0].IncreaseSize(2)
+		err = provider.NodeGroups(context.Background())[0].IncreaseSize(context.Background(), 2)
 		assert.NoError(t, err)
 
 		// New target size should be 5.
-		targetSize, err = provider.NodeGroups()[0].TargetSize()
+		targetSize, err = provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 5, targetSize)
 
@@ -354,18 +354,18 @@ func TestScaleSetIncreaseSize(t *testing.T) {
 		registeredForEdgeZone := provider.azureManager.RegisterNodeGroup(
 			newTestScaleSet(provider.azureManager, "edgezone-vmss"))
 		assert.True(t, registeredForEdgeZone)
-		assert.Equal(t, len(provider.NodeGroups()), 2)
+		assert.Equal(t, len(provider.NodeGroups(context.Background())), 2)
 
-		targetSizeForEdgeZone, err := provider.NodeGroups()[1].TargetSize()
+		targetSizeForEdgeZone, err := provider.NodeGroups(context.Background())[1].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 3, targetSizeForEdgeZone)
 
 		mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), provider.azureManager.config.ResourceGroup,
 			"edgezone-vmss", gomock.Any()).Return(nil, nil).AnyTimes()
-		err = provider.NodeGroups()[1].IncreaseSize(2)
+		err = provider.NodeGroups(context.Background())[1].IncreaseSize(context.Background(), 2)
 		assert.NoError(t, err)
 
-		targetSizeForEdgeZone, err = provider.NodeGroups()[1].TargetSize()
+		targetSizeForEdgeZone, err = provider.NodeGroups(context.Background())[1].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 5, targetSizeForEdgeZone)
 
@@ -373,20 +373,20 @@ func TestScaleSetIncreaseSize(t *testing.T) {
 		registeredForEdgeZoneMinZero := provider.azureManager.RegisterNodeGroup(
 			newTestScaleSetMinSizeZero(provider.azureManager, "edgezone-minzero-vmss"))
 		assert.True(t, registeredForEdgeZoneMinZero)
-		assert.Equal(t, len(provider.NodeGroups()), 3)
+		assert.Equal(t, len(provider.NodeGroups(context.Background())), 3)
 
 		// Current target size is 0.
-		targetSizeForEdgeZoneMinZero, err := provider.NodeGroups()[2].TargetSize()
+		targetSizeForEdgeZoneMinZero, err := provider.NodeGroups(context.Background())[2].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 0, targetSizeForEdgeZoneMinZero)
 
 		mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), provider.azureManager.config.ResourceGroup,
 			"edgezone-minzero-vmss", gomock.Any()).Return(nil, nil).AnyTimes()
-		err = provider.NodeGroups()[2].IncreaseSize(2)
+		err = provider.NodeGroups(context.Background())[2].IncreaseSize(context.Background(), 2)
 		assert.NoError(t, err)
 
 		// New target size should be 2.
-		targetSizeForEdgeZoneMinZero, err = provider.NodeGroups()[2].TargetSize()
+		targetSizeForEdgeZoneMinZero, err = provider.NodeGroups(context.Background())[2].TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 2, targetSizeForEdgeZoneMinZero)
 	}
@@ -442,12 +442,12 @@ func TestScaleSetIncreaseSizeRaceCondition(t *testing.T) {
 		newTestScaleSet(provider.azureManager, testASG))
 	assert.True(t, registered)
 
-	ng := provider.NodeGroups()[0]
+	ng := provider.NodeGroups(context.Background())[0]
 
 	// Kick off the writer (non-atomic IncreaseSize -> createOrUpdateInstances).
 	increaseDone := make(chan error, 1)
 	go func() {
-		increaseDone <- ng.IncreaseSize(2)
+		increaseDone <- ng.IncreaseSize(context.Background(), 2)
 	}()
 
 	// Wait until createOrUpdateInstances is parked inside BeginCreateOrUpdate
@@ -469,7 +469,7 @@ func TestScaleSetIncreaseSizeRaceCondition(t *testing.T) {
 				case <-stop:
 					return
 				default:
-					_, _ = ng.TargetSize()
+					_, _ = ng.TargetSize(context.Background())
 				}
 			}
 		}()
@@ -527,7 +527,7 @@ func TestScaleSetAtomicIncreaseSize(t *testing.T) {
 
 	// Error: non-existent scale set
 	ss := newTestScaleSet(provider.azureManager, "test-asg-doesnt-exist")
-	err = ss.AtomicIncreaseSize(1)
+	err = ss.AtomicIncreaseSize(context.Background(), 1)
 	expectedErr := fmt.Errorf("could not find vmss: test-asg-doesnt-exist")
 	assert.Equal(t, expectedErr, err)
 
@@ -536,31 +536,31 @@ func TestScaleSetAtomicIncreaseSize(t *testing.T) {
 	assert.True(t, registered)
 
 	// Error: negative delta
-	err = provider.NodeGroups()[0].AtomicIncreaseSize(-1)
+	err = provider.NodeGroups(context.Background())[0].AtomicIncreaseSize(context.Background(), -1)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "size increase must be positive")
 
 	// Error: zero delta
-	err = provider.NodeGroups()[0].AtomicIncreaseSize(0)
+	err = provider.NodeGroups(context.Background())[0].AtomicIncreaseSize(context.Background(), 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "size increase must be positive")
 
 	// Error: exceeds max size (max is 5, current is 3, delta 3 = 6 > 5)
-	err = provider.NodeGroups()[0].AtomicIncreaseSize(3)
+	err = provider.NodeGroups(context.Background())[0].AtomicIncreaseSize(context.Background(), 3)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "size increase too large")
 
 	// Current target size is 3.
-	targetSize, err := provider.NodeGroups()[0].TargetSize()
+	targetSize, err := provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 
 	// Success: atomic increase by 2 (blocks until complete, nil poller = immediate).
-	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
+	err = provider.NodeGroups(context.Background())[0].AtomicIncreaseSize(context.Background(), 2)
 	assert.NoError(t, err)
 
 	// New target size should be 5.
-	targetSize, err = provider.NodeGroups()[0].TargetSize()
+	targetSize, err = provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 5, targetSize)
 }
@@ -606,12 +606,12 @@ func TestScaleSetAtomicIncreaseSizeFailure(t *testing.T) {
 	assert.True(t, registered)
 
 	// BeginCreateOrUpdate fails — size should NOT be updated.
-	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
+	err = provider.NodeGroups(context.Background())[0].AtomicIncreaseSize(context.Background(), 2)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "azure capacity unavailable")
 
 	// Target size should remain 3 (not updated on failure).
-	targetSize, err := provider.NodeGroups()[0].TargetSize()
+	targetSize, err := provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 }
@@ -686,17 +686,17 @@ func TestScaleSetAtomicIncreaseSizePollerFailure(t *testing.T) {
 	assert.True(t, registered)
 
 	// Current target size is 3.
-	targetSize, err := provider.NodeGroups()[0].TargetSize()
+	targetSize, err := provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 
 	// PollUntilDone fails — size should NOT be updated.
-	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
+	err = provider.NodeGroups(context.Background())[0].AtomicIncreaseSize(context.Background(), 2)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "long running operation failed")
 
 	// Target size should remain 3 (not updated on poller failure).
-	targetSize, err = provider.NodeGroups()[0].TargetSize()
+	targetSize, err = provider.NodeGroups(context.Background())[0].TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 }
@@ -775,14 +775,14 @@ func TestScaleSetIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
 			provider, err := BuildAzureCloudProvider(manager, nil)
 			assert.NoError(t, err)
 
-			scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+			scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 			assert.True(t, ok)
 
 			// Increase size by one, but the new node fails provisioning
-			err = scaleSet.IncreaseSize(1)
+			err = scaleSet.IncreaseSize(context.Background(), 1)
 			assert.NoError(t, err)
 
-			nodes, err := scaleSet.Nodes()
+			nodes, err := scaleSet.Nodes(context.Background())
 			assert.NoError(t, err)
 
 			assert.Equal(t, 3, len(nodes))
@@ -869,14 +869,14 @@ func TestIncreaseSizeOnVMProvisioningFailedWithFastDelete(t *testing.T) {
 			provider, err := BuildAzureCloudProvider(manager, nil)
 			assert.NoError(t, err)
 
-			scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+			scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 			assert.True(t, ok)
 
 			// Increase size by one, but the new node fails provisioning
-			err = scaleSet.IncreaseSize(1)
+			err = scaleSet.IncreaseSize(context.Background(), 1)
 			assert.NoError(t, err)
 
-			nodes, err := scaleSet.Nodes()
+			nodes, err := scaleSet.Nodes(context.Background())
 			assert.NoError(t, err)
 
 			assert.Equal(t, 3, len(nodes))
@@ -938,9 +938,9 @@ func TestScaleSetIncreaseSizeOnVMSSUpdating(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Scaling should continue even VMSS is under updating.
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+	scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 	assert.True(t, ok)
-	err = scaleSet.IncreaseSize(1)
+	err = scaleSet.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 }
 
@@ -976,7 +976,7 @@ func TestScaleSetBelongs(t *testing.T) {
 			newTestScaleSet(provider.azureManager, testASG))
 		assert.True(t, registered)
 
-		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 		assert.True(t, ok)
 		provider.azureManager.explicitlyConfigured["test-asg"] = true
 		err := provider.azureManager.forceRefresh()
@@ -1084,10 +1084,10 @@ func TestScaleSetDeleteNodes(t *testing.T) {
 		err = manager.forceRefresh()
 		assert.NoError(t, err)
 
-		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 		assert.True(t, ok)
 
-		targetSize, err := scaleSet.TargetSize()
+		targetSize, err := scaleSet.TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 3, targetSize)
 
@@ -1096,7 +1096,7 @@ func TestScaleSetDeleteNodes(t *testing.T) {
 			newApiNode(orchMode, 0),
 			newApiNode(orchMode, 2),
 		}
-		err = scaleSet.DeleteNodes(nodesToDelete)
+		err = scaleSet.DeleteNodes(context.Background(), nodesToDelete)
 		assert.NoError(t, err)
 
 		// create scale set with vmss capacity 1
@@ -1118,7 +1118,7 @@ func TestScaleSetDeleteNodes(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Ensure the the cached size has been proactively decremented by 2
-		targetSize, err = scaleSet.TargetSize()
+		targetSize, err = scaleSet.TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 1, targetSize)
 
@@ -1183,10 +1183,10 @@ func TestScaleSetForceDeleteNodesDoesNotPublishNegativeCachedSize(t *testing.T) 
 	err = manager.forceRefresh()
 	assert.NoError(t, err)
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+	scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 	assert.True(t, ok)
 
-	targetSize, err := scaleSet.TargetSize()
+	targetSize, err := scaleSet.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 
@@ -1198,7 +1198,7 @@ func TestScaleSetForceDeleteNodesDoesNotPublishNegativeCachedSize(t *testing.T) 
 		newApiNode(orchMode, 0),
 		newApiNode(orchMode, 2),
 	}
-	err = scaleSet.ForceDeleteNodes(nodesToDelete)
+	err = scaleSet.ForceDeleteNodes(context.Background(), nodesToDelete)
 	assert.NoError(t, err)
 
 	scaleSet.sizeMutex.Lock()
@@ -1208,7 +1208,7 @@ func TestScaleSetForceDeleteNodesDoesNotPublishNegativeCachedSize(t *testing.T) 
 	assert.Equal(t, int64(1), curSize)
 	assert.True(t, lastSizeRefresh.IsZero())
 
-	targetSize, err = scaleSet.TargetSize()
+	targetSize, err = scaleSet.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 }
@@ -1296,11 +1296,11 @@ func TestScaleSetDeleteNodeUnregistered(t *testing.T) {
 		err = manager.forceRefresh()
 		assert.NoError(t, err)
 
-		scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+		scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 		assert.True(t, ok)
 		scaleSet.instancesRefreshPeriod = defaultVmssInstancesRefreshPeriod
 
-		targetSize, err := scaleSet.TargetSize()
+		targetSize, err := scaleSet.TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 2, targetSize)
 
@@ -1313,11 +1313,11 @@ func TestScaleSetDeleteNodeUnregistered(t *testing.T) {
 		}
 		nodesToDelete[0].ObjectMeta.Annotations = annotations
 
-		err = scaleSet.DeleteNodes(nodesToDelete)
+		err = scaleSet.DeleteNodes(context.Background(), nodesToDelete)
 		assert.NoError(t, err)
 
 		// Ensure the the cached size has NOT been proactively decremented
-		targetSize, err = scaleSet.TargetSize()
+		targetSize, err = scaleSet.TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, 2, targetSize)
 
@@ -1387,10 +1387,10 @@ func TestScaleSetDeleteInstancesWithForceDeleteEnabled(t *testing.T) {
 	err = manager.forceRefresh()
 	assert.NoError(t, err)
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+	scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 	assert.True(t, ok)
 
-	targetSize, err := scaleSet.TargetSize()
+	targetSize, err := scaleSet.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 
@@ -1407,7 +1407,7 @@ func TestScaleSetDeleteInstancesWithForceDeleteEnabled(t *testing.T) {
 			},
 		},
 	}
-	err = scaleSet.DeleteNodes(nodesToDelete)
+	err = scaleSet.DeleteNodes(context.Background(), nodesToDelete)
 	assert.NoError(t, err)
 	vmssCapacity = 1
 	orchMode = armcompute.OrchestrationModeUniform
@@ -1430,7 +1430,7 @@ func TestScaleSetDeleteInstancesWithForceDeleteEnabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Ensure the the cached size has been proactively decremented by 2
-	targetSize, err = scaleSet.TargetSize()
+	targetSize, err = scaleSet.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, targetSize)
 
@@ -1507,10 +1507,10 @@ func TestScaleSetDeleteNoConflictRequest(t *testing.T) {
 		},
 	}
 
-	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+	scaleSet, ok := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 	assert.True(t, ok)
 
-	err = scaleSet.DeleteNodes([]*apiv1.Node{node})
+	err = scaleSet.DeleteNodes(context.Background(), []*apiv1.Node{node})
 }
 
 func TestScaleSetId(t *testing.T) {
@@ -1518,8 +1518,8 @@ func TestScaleSetId(t *testing.T) {
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
-	assert.Equal(t, provider.NodeGroups()[0].Id(), "test-asg")
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
+	assert.Equal(t, provider.NodeGroups(context.Background())[0].Id(), "test-asg")
 }
 
 func TestAgentPoolDebug(t *testing.T) {
@@ -1529,7 +1529,7 @@ func TestAgentPoolDebug(t *testing.T) {
 		maxSize: 55,
 	}
 	asg.Name = "test-scale-set"
-	assert.Equal(t, asg.Debug(), "test-scale-set (5:55)")
+	assert.Equal(t, asg.Debug(context.Background()), "test-scale-set (5:55)")
 }
 
 func TestScaleSetNodes(t *testing.T) {
@@ -1569,21 +1569,21 @@ func TestScaleSetNodes(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, registered)
-		assert.Equal(t, len(provider.NodeGroups()), 1)
+		assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
 
 		node := newApiNode(orchMode, 0)
-		group, err := provider.NodeGroupForNode(node)
+		group, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.NotNil(t, group, "Group should not be nil")
 		assert.Equal(t, group.Id(), testASG)
-		assert.Equal(t, group.MinSize(), 1)
-		assert.Equal(t, group.MaxSize(), 5)
+		assert.Equal(t, group.MinSize(context.Background()), 1)
+		assert.Equal(t, group.MaxSize(context.Background()), 5)
 
 		ss, ok := group.(*ScaleSet)
 		ss.lastInstanceRefresh = time.Now()
 		assert.True(t, ok)
 		assert.NotNil(t, ss)
-		instances, err := group.Nodes()
+		instances, err := group.Nodes(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, len(instances), 3)
 
@@ -1650,7 +1650,7 @@ func TestScaleSetTemplateNodeInfo(t *testing.T) {
 	registered := provider.azureManager.RegisterNodeGroup(
 		newTestScaleSet(provider.azureManager, "test-asg"))
 	assert.True(t, registered)
-	assert.Equal(t, len(provider.NodeGroups()), 1)
+	assert.Equal(t, len(provider.NodeGroups(context.Background())), 1)
 
 	asg := ScaleSet{
 		manager: provider.azureManager,
@@ -1666,7 +1666,7 @@ func TestScaleSetTemplateNodeInfo(t *testing.T) {
 	t.Run("Checking fallback to static because dynamic list is empty", func(t *testing.T) {
 		asg.enableDynamicInstanceList = true
 
-		nodeInfo, err := asg.TemplateNodeInfo()
+		nodeInfo, err := asg.TemplateNodeInfo(context.Background())
 		assert.NoError(t, err)
 		assert.NotNil(t, nodeInfo)
 		assert.NotEmpty(t, nodeInfo.Pods())
@@ -1687,7 +1687,7 @@ func TestScaleSetTemplateNodeInfo(t *testing.T) {
 			vmssType.MemoryMb = 3
 			return vmssType, nil
 		}
-		nodeInfo, err := asg.TemplateNodeInfo()
+		nodeInfo, err := asg.TemplateNodeInfo(context.Background())
 		assert.Equal(t, *nodeInfo.Node().Status.Capacity.Cpu(), *resource.NewQuantity(1, resource.DecimalSI))
 		assert.Equal(t, *nodeInfo.Node().Status.Capacity.Memory(), *resource.NewQuantity(3*1024*1024, resource.DecimalSI))
 		assert.NoError(t, err)
@@ -1708,7 +1708,7 @@ func TestScaleSetTemplateNodeInfo(t *testing.T) {
 			vmssType.MemoryMb = 3
 			return &vmssType, nil
 		}
-		nodeInfo, err := asg.TemplateNodeInfo()
+		nodeInfo, err := asg.TemplateNodeInfo(context.Background())
 		assert.Equal(t, *nodeInfo.Node().Status.Capacity.Cpu(), *resource.NewQuantity(1, resource.DecimalSI))
 		assert.Equal(t, *nodeInfo.Node().Status.Capacity.Memory(), *resource.NewQuantity(3*1024*1024, resource.DecimalSI))
 		assert.NoError(t, err)
@@ -1725,7 +1725,7 @@ func TestScaleSetTemplateNodeInfo(t *testing.T) {
 		GetInstanceTypeStatically = func(template NodeTemplate) (*InstanceType, error) {
 			return &InstanceType{}, fmt.Errorf("static error exists")
 		}
-		nodeInfo, err := asg.TemplateNodeInfo()
+		nodeInfo, err := asg.TemplateNodeInfo(context.Background())
 		assert.Empty(t, nodeInfo)
 		assert.Equal(t, err, fmt.Errorf("static error exists"))
 	})
@@ -1742,7 +1742,7 @@ func TestScaleSetTemplateNodeInfo(t *testing.T) {
 			vmssType.MemoryMb = 3
 			return &vmssType, nil
 		}
-		nodeInfo, err := asg.TemplateNodeInfo()
+		nodeInfo, err := asg.TemplateNodeInfo(context.Background())
 		assert.Equal(t, *nodeInfo.Node().Status.Capacity.Cpu(), *resource.NewQuantity(1, resource.DecimalSI))
 		assert.Equal(t, *nodeInfo.Node().Status.Capacity.Memory(), *resource.NewQuantity(3*1024*1024, resource.DecimalSI))
 		assert.NoError(t, err)
@@ -1753,7 +1753,7 @@ func TestScaleSetTemplateNodeInfo(t *testing.T) {
 	t.Run("Checking static-only workflow with built-in SKU list", func(t *testing.T) {
 		asg.enableDynamicInstanceList = false
 
-		nodeInfo, err := asg.TemplateNodeInfo()
+		nodeInfo, err := asg.TemplateNodeInfo(context.Background())
 		assert.NoError(t, err)
 		assert.NotNil(t, nodeInfo)
 		assert.NotEmpty(t, nodeInfo.Pods())
@@ -1792,7 +1792,7 @@ func TestScaleSetCseErrors(t *testing.T) {
 	manager.RegisterNodeGroup(
 		newTestScaleSet(manager, "test-asg"))
 	manager.explicitlyConfigured["test-asg"] = true
-	scaleSet, _ := provider.NodeGroups()[0].(*ScaleSet)
+	scaleSet, _ := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 
 	t.Run("getCSEErrorMessages test with CSE error in VM extensions", func(t *testing.T) {
 		expectedCSEWErrorMessage := "Error Message Test"
@@ -2089,7 +2089,7 @@ func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
 			// Assert: BeginDeleteInstances was never called. gomock.Times(0) enforces this.
 			// Assert: caches were invalidated so TargetSize refreshes from VMSS capacity.
 			assert.False(t, scaleSet.lastInstanceRefresh.IsZero())
-			targetSize, err := scaleSet.TargetSize()
+			targetSize, err := scaleSet.TargetSize(context.Background())
 			assert.NoError(t, err)
 			assert.Equal(t, 3, targetSize)
 		})
@@ -2307,9 +2307,9 @@ func TestScaleSetIncreaseSizeWithETag(t *testing.T) {
 
 			provider, err := BuildAzureCloudProvider(manager, nil)
 			assert.NoError(t, err)
-			scaleSet := provider.NodeGroups()[0].(*ScaleSet)
+			scaleSet := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 
-			err = scaleSet.IncreaseSize(1)
+			err = scaleSet.IncreaseSize(context.Background(), 1)
 			assert.NoError(t, err)
 
 			if tc.expectIfMatch == nil {
@@ -2375,7 +2375,7 @@ func TestScaleSetETagPreconditionFailureInvalidatesSizeCache(t *testing.T) {
 	scaleSet := newTestScaleSet(manager, vmssName)
 	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
 
-	err := scaleSet.IncreaseSize(1)
+	err := scaleSet.IncreaseSize(context.Background(), 1)
 	assert.Error(t, err)
 
 	// Simulate an out-of-band capacity change observed on the next cache fetch.
@@ -2388,7 +2388,7 @@ func TestScaleSetETagPreconditionFailureInvalidatesSizeCache(t *testing.T) {
 		Etag: ptr.To(`W/"new"`),
 	})
 
-	target, err := scaleSet.TargetSize()
+	target, err := scaleSet.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 5, target)
 }
@@ -2440,12 +2440,12 @@ func TestScaleSetETagPreconditionFailureRollsBackCapacity(t *testing.T) {
 	scaleSet := newTestScaleSet(manager, vmssName)
 	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
 
-	err := scaleSet.IncreaseSize(1)
+	err := scaleSet.IncreaseSize(context.Background(), 1)
 	assert.Error(t, err)
 
 	// Without the rejected mutation, TargetSize must still report the prior size (3),
 	// not the desired size (4) that was never accepted.
-	target, err := scaleSet.TargetSize()
+	target, err := scaleSet.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, target)
 }
@@ -2508,7 +2508,7 @@ func TestScaleSetETagRetrySucceedsAfterPreconditionFailure(t *testing.T) {
 	scaleSet := newTestScaleSet(manager, vmssName)
 	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
 
-	err := scaleSet.IncreaseSize(1)
+	err := scaleSet.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	if assert.Len(t, ifMatches, 2) {
@@ -2576,7 +2576,7 @@ func TestScaleSetETagRetrySkippedWhenAlreadyAtTarget(t *testing.T) {
 	scaleSet := newTestScaleSet(manager, vmssName)
 	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
 
-	err := scaleSet.IncreaseSize(1)
+	err := scaleSet.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, putCalls, "expected no second PUT when VMSS already at target")
 }
@@ -2713,7 +2713,7 @@ func TestScaleSetETagReconcilesConcurrentWriter(t *testing.T) {
 	scaleSet := newTestScaleSet(manager, vmssName)
 	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
 
-	err := scaleSet.IncreaseSize(1)
+	err := scaleSet.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	if assert.Len(t, ifMatches, 2) {
@@ -2866,7 +2866,7 @@ func TestScaleSetETagRetrySkipPublishesFreshCapacity(t *testing.T) {
 	scaleSet := newTestScaleSet(manager, vmssName)
 	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
 
-	err := scaleSet.IncreaseSize(1)
+	err := scaleSet.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, putCalls, "expected no second PUT when VMSS already above target")
 
@@ -2988,9 +2988,9 @@ func TestAtomicIncreaseSizeWithETag(t *testing.T) {
 
 			provider, err := BuildAzureCloudProvider(manager, nil)
 			assert.NoError(t, err)
-			scaleSet := provider.NodeGroups()[0].(*ScaleSet)
+			scaleSet := provider.NodeGroups(context.Background())[0].(*ScaleSet)
 
-			err = scaleSet.AtomicIncreaseSize(1)
+			err = scaleSet.AtomicIncreaseSize(context.Background(), 1)
 			assert.NoError(t, err)
 
 			if tc.expectIfMatch == nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -71,52 +72,52 @@ func NewVMPool(spec *dynamic.NodeGroupSpec, am *AzureManager, agentPoolName stri
 
 // MinSize returns the minimum size the vmPool is allowed to scaled down
 // to as provided by the node spec in --node parameter.
-func (vmPool *VMPool) MinSize() int {
+func (vmPool *VMPool) MinSize(ctx context.Context) int {
 	return vmPool.minSize
 }
 
 // Exist is always true since we are initialized with an existing vmPool
-func (vmPool *VMPool) Exist() bool {
+func (vmPool *VMPool) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (vmPool *VMPool) Create() (cloudprovider.NodeGroup, error) {
+func (vmPool *VMPool) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.
-func (vmPool *VMPool) Delete() error {
+func (vmPool *VMPool) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (vmPool *VMPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (vmPool *VMPool) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned is always false since we are initialized with an existing agentpool
-func (vmPool *VMPool) Autoprovisioned() bool {
+func (vmPool *VMPool) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (vmPool *VMPool) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (vmPool *VMPool) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	// TODO(wenxuan): implement this method when vmPool can fully support GPU nodepool
 	return nil, nil
 }
 
 // MaxSize returns the maximum size scale limit provided by --node
 // parameter to the autoscaler main
-func (vmPool *VMPool) MaxSize() int {
+func (vmPool *VMPool) MaxSize(ctx context.Context) int {
 	return vmPool.maxSize
 }
 
 // TargetSize returns the current target size of the node group. This value represents
 // the desired number of nodes in the VMPool, which may differ from the actual number
 // of nodes currently present.
-func (vmPool *VMPool) TargetSize() (int, error) {
+func (vmPool *VMPool) TargetSize(ctx context.Context) (int, error) {
 	// VMs in the "Deleting" state are not counted towards the target size.
 	size, err := vmPool.getCurSize(skipOption{skipDeleting: true, skipFailed: false})
 	return int(size), err
@@ -124,7 +125,7 @@ func (vmPool *VMPool) TargetSize() (int, error) {
 
 // IncreaseSize increases the size of the VMPool by sending a PUT request to update the agent pool.
 // This method waits until the asynchronous PUT operation completes or the client-side timeout is reached.
-func (vmPool *VMPool) IncreaseSize(delta int) error {
+func (vmPool *VMPool) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive, current delta: %d", delta)
 	}
@@ -135,8 +136,8 @@ func (vmPool *VMPool) IncreaseSize(delta int) error {
 		return err
 	}
 
-	if int(currentSize)+delta > vmPool.MaxSize() {
-		return fmt.Errorf("size-increasing request of %d is bigger than max size %d", int(currentSize)+delta, vmPool.MaxSize())
+	if int(currentSize)+delta > vmPool.MaxSize(context.TODO()) {
+		return fmt.Errorf("size-increasing request of %d is bigger than max size %d", int(currentSize)+delta, vmPool.MaxSize(context.TODO()))
 	}
 
 	updateCtx, cancel := getContextWithTimeout(vmsAsyncContextTimeout)
@@ -225,15 +226,15 @@ func buildRequestBodyForScaleUp(agentpool armcontainerservice.AgentPool, count i
 // and performing the appropriate delete or deallocate operation based on the agent pool's
 // scale-down policy. This method waits for the asynchronous delete operation to complete,
 // with a client-side timeout.
-func (vmPool *VMPool) DeleteNodes(nodes []*apiv1.Node) error {
+func (vmPool *VMPool) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	// Ensure we don't scale below the minimum size by excluding VMs in the "Deleting" state.
 	currentSize, err := vmPool.getCurSize(skipOption{skipDeleting: true, skipFailed: false})
 	if err != nil {
 		return fmt.Errorf("unable to retrieve current size: %w", err)
 	}
 
-	if int(currentSize) <= vmPool.MinSize() {
-		return fmt.Errorf("cannot delete nodes as minimum size of %d has been reached", vmPool.MinSize())
+	if int(currentSize) <= vmPool.MinSize(context.TODO()) {
+		return fmt.Errorf("cannot delete nodes as minimum size of %d has been reached", vmPool.MinSize(context.TODO()))
 	}
 
 	providerIDs, err := vmPool.getProviderIDsForNodes(nodes)
@@ -335,7 +336,7 @@ func (vmPool *VMPool) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DecreaseTargetSize decreases the target size of the node group.
-func (vmPool *VMPool) DecreaseTargetSize(delta int) error {
+func (vmPool *VMPool) DecreaseTargetSize(ctx context.Context, delta int) error {
 	// The TargetSize of a VMPool is automatically adjusted after node deletions.
 	// This method is invoked in scenarios such as (see details in clusterstate.go):
 	// - len(readiness.Registered) > acceptableRange.CurrentTarget
@@ -359,8 +360,8 @@ func (vmPool *VMPool) Id() string {
 }
 
 // Debug returns a string with basic details of the agentPool
-func (vmPool *VMPool) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", vmPool.Id(), vmPool.MinSize(), vmPool.MaxSize())
+func (vmPool *VMPool) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", vmPool.Id(), vmPool.MinSize(context.TODO()), vmPool.MaxSize(context.TODO()))
 }
 
 func isSpotAgentPool(ap armcontainerservice.AgentPool) bool {
@@ -454,7 +455,7 @@ func (vmPool *VMPool) getVMsFromCache(op skipOption) ([]*armcompute.VirtualMachi
 }
 
 // Nodes returns the list of nodes in the vms agentPool.
-func (vmPool *VMPool) Nodes() ([]cloudprovider.Instance, error) {
+func (vmPool *VMPool) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	vms, err := vmPool.getVMsFromCache(skipOption{}) // no skip option, get all VMs
 	if err != nil {
 		return nil, err
@@ -485,7 +486,7 @@ func (vmPool *VMPool) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // TemplateNodeInfo returns a NodeInfo object that can be used to create a new node in the vmPool.
-func (vmPool *VMPool) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (vmPool *VMPool) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	ap, err := vmPool.getAgentpoolFromCache()
 	if err != nil {
 		return nil, err
@@ -537,6 +538,6 @@ func (vmPool *VMPool) getAgentpoolFromAzure() (armcontainerservice.AgentPool, er
 // before returning. This blocking behavior is required for atomic-scale-up
 // ProvisioningRequest support to provide a capacity guarantee before workloads
 // are admitted.
-func (vmPool *VMPool) AtomicIncreaseSize(delta int) error {
-	return vmPool.IncreaseSize(delta)
+func (vmPool *VMPool) AtomicIncreaseSize(ctx context.Context, delta int) error {
+	return vmPool.IncreaseSize(context.TODO(), delta)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
@@ -151,18 +151,18 @@ func TestMinSize(t *testing.T) {
 		minSize: 1,
 	}
 
-	assert.Equal(t, 1, agentPool.MinSize())
+	assert.Equal(t, 1, agentPool.MinSize(context.Background()))
 }
 
 func TestExist(t *testing.T) {
 	agentPool := &VMPool{}
 
-	assert.True(t, agentPool.Exist())
+	assert.True(t, agentPool.Exist(context.Background()))
 }
 func TestCreate(t *testing.T) {
 	agentPool := &VMPool{}
 
-	nodeGroup, err := agentPool.Create()
+	nodeGroup, err := agentPool.Create(context.Background())
 	assert.Nil(t, nodeGroup)
 	assert.Equal(t, cloudprovider.ErrAlreadyExist, err)
 }
@@ -170,21 +170,21 @@ func TestCreate(t *testing.T) {
 func TestDelete(t *testing.T) {
 	agentPool := &VMPool{}
 
-	err := agentPool.Delete()
+	err := agentPool.Delete(context.Background())
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
 func TestAutoprovisioned(t *testing.T) {
 	agentPool := &VMPool{}
 
-	assert.False(t, agentPool.Autoprovisioned())
+	assert.False(t, agentPool.Autoprovisioned(context.Background()))
 }
 
 func TestGetOptions(t *testing.T) {
 	agentPool := &VMPool{}
 	defaults := config.NodeGroupAutoscalingOptions{}
 
-	options, err := agentPool.GetOptions(defaults)
+	options, err := agentPool.GetOptions(context.Background(), defaults)
 	assert.Nil(t, options)
 	assert.Nil(t, err)
 }
@@ -193,13 +193,13 @@ func TestMaxSize(t *testing.T) {
 		maxSize: 10,
 	}
 
-	assert.Equal(t, 10, agentPool.MaxSize())
+	assert.Equal(t, 10, agentPool.MaxSize(context.Background()))
 }
 
 func TestDecreaseTargetSize(t *testing.T) {
 	agentPool := newTestVMsPool(newTestAzureManager(t))
 
-	err := agentPool.DecreaseTargetSize(1)
+	err := agentPool.DecreaseTargetSize(context.Background(), 1)
 	assert.Nil(t, err)
 }
 
@@ -223,7 +223,7 @@ func TestDebug(t *testing.T) {
 	}
 
 	expectedDebugString := "test-debug (1:5)"
-	assert.Equal(t, expectedDebugString, agentPool.Debug())
+	assert.Equal(t, expectedDebugString, agentPool.Debug(context.Background()))
 }
 func TestTemplateNodeInfo(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -242,7 +242,7 @@ func TestTemplateNodeInfo(t *testing.T) {
 	assert.NoError(t, err)
 	ap.manager.azureCache = ac
 
-	nodeInfo, err := ap.TemplateNodeInfo()
+	nodeInfo, err := ap.TemplateNodeInfo(context.Background())
 	assert.NotNil(t, nodeInfo)
 	assert.Nil(t, err)
 }
@@ -289,17 +289,17 @@ func TestAtomicIncreaseSize(t *testing.T) {
 		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
 
 	// Before scale-up, target size matches the initial VM count.
-	targetSize, err := ap.TargetSize()
+	targetSize, err := ap.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 
-	err = ap.AtomicIncreaseSize(1)
+	err = ap.AtomicIncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	// Simulate Azure having created the new VM by seeding the cache with the
 	// post-scale VM list, then assert the pool reports the new target size.
 	ap.manager.azureCache.virtualMachines[vmsAgentPoolName] = newTestVMsPoolVMList(4)
-	targetSize, err = ap.TargetSize()
+	targetSize, err = ap.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 4, targetSize)
 }
@@ -307,7 +307,7 @@ func TestAtomicIncreaseSize(t *testing.T) {
 func TestAtomicIncreaseSizeNegativeDelta(t *testing.T) {
 	ap := newTestVMsPool(newTestAzureManager(t))
 
-	err := ap.AtomicIncreaseSize(-1)
+	err := ap.AtomicIncreaseSize(context.Background(), -1)
 	assert.Equal(t, fmt.Errorf("size increase must be positive, current delta: -1"), err)
 }
 
@@ -350,7 +350,7 @@ func TestAtomicIncreaseSizePollerFailure(t *testing.T) {
 		vmsAgentPoolName,
 		gomock.Any(), gomock.Any()).Return(failingPoller, nil)
 
-	err = ap.AtomicIncreaseSize(1)
+	err = ap.AtomicIncreaseSize(context.Background(), 1)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "long running operation failed")
 }
@@ -510,7 +510,7 @@ func TestNodes(t *testing.T) {
 	assert.NoError(t, err)
 	ap.manager.azureCache = ac
 
-	vms, err := ap.Nodes()
+	vms, err := ap.Nodes(context.Background())
 	assert.Equal(t, 2, len(vms))
 	assert.NoError(t, err)
 }
@@ -568,12 +568,12 @@ func TestVMsPoolIncreaseSize(t *testing.T) {
 	ap.manager.azureCache = ac
 
 	// failure case 1
-	err1 := ap.IncreaseSize(-1)
+	err1 := ap.IncreaseSize(context.Background(), -1)
 	expectedErr := fmt.Errorf("size increase must be positive, current delta: -1")
 	assert.Equal(t, expectedErr, err1)
 
 	// failure case 2
-	err2 := ap.IncreaseSize(8)
+	err2 := ap.IncreaseSize(context.Background(), 8)
 	expectedErr = fmt.Errorf("size-increasing request of 11 is bigger than max size 10")
 	assert.Equal(t, expectedErr, err2)
 
@@ -597,7 +597,7 @@ func TestVMsPoolIncreaseSize(t *testing.T) {
 		vmsAgentPoolName,
 		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
 
-	err3 := ap.IncreaseSize(1)
+	err3 := ap.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err3)
 }
 
@@ -626,7 +626,7 @@ func TestDeleteVMsPoolNodes_Failed(t *testing.T) {
 	ap.manager.forceRefresh()
 
 	// failure case
-	deleteErr := ap.DeleteNodes([]*apiv1.Node{node})
+	deleteErr := ap.DeleteNodes(context.Background(), []*apiv1.Node{node})
 	assert.Error(t, deleteErr)
 	assert.Contains(t, deleteErr.Error(), "cannot delete nodes as minimum size of 3 has been reached")
 }
@@ -672,7 +672,7 @@ func TestDeleteVMsPoolNodes_Success(t *testing.T) {
 		vmsAgentPoolName,
 		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
 	node := newVMsNode(0)
-	derr := ap.DeleteNodes([]*apiv1.Node{node})
+	derr := ap.DeleteNodes(context.Background(), []*apiv1.Node{node})
 	assert.NoError(t, derr)
 }
 
@@ -684,7 +684,7 @@ func TestVMsPoolNodesReportsProvisioningState(t *testing.T) {
 	vms[0].Properties.ProvisioningState = ptr.To(VMProvisioningStateDeleting)
 	manager.azureCache.virtualMachines[vmsAgentPoolName] = vms
 
-	instances, err := ap.Nodes()
+	instances, err := ap.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Len(t, instances, 3)
 
@@ -752,7 +752,7 @@ func TestDeleteVMsPoolNodesProactivelyMarksDeletion(t *testing.T) {
 		vmsAgentPoolName,
 		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
 
-	assert.NoError(t, ap.DeleteNodes([]*apiv1.Node{deletingNode}))
+	assert.NoError(t, ap.DeleteNodes(context.Background(), []*apiv1.Node{deletingNode}))
 
 	// The deleted node is proactively reported as gone (false, nil), while other
 	// nodes remain reported as present.
@@ -810,7 +810,7 @@ func TestDeleteVMsPoolNodesStrictCacheDoesNotProactivelyMarkDeletion(t *testing.
 		vmsAgentPoolName,
 		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
 
-	assert.NoError(t, ap.DeleteNodes([]*apiv1.Node{deletingNode}))
+	assert.NoError(t, ap.DeleteNodes(context.Background(), []*apiv1.Node{deletingNode}))
 
 	// Strict cache mode should not mark deleting nodes as gone before a refresh.
 	hasInstance, err = ap.manager.azureCache.HasInstance(deletingNode.Spec.ProviderID)

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package baiducloud
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -164,7 +165,7 @@ func (baiducloud *baiducloudCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (baiducloud *baiducloudCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (baiducloud *baiducloudCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	result := make([]cloudprovider.NodeGroup, 0, len(baiducloud.asgs))
 	for _, asg := range baiducloud.asgs {
 		result = append(result, asg)
@@ -173,25 +174,25 @@ func (baiducloud *baiducloudCloudProvider) NodeGroups() []cloudprovider.NodeGrou
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (baiducloud *baiducloudCloudProvider) GPULabel() string {
+func (baiducloud *baiducloudCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes returns all available GPU types cloud provider supports.
-func (baiducloud *baiducloudCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (baiducloud *baiducloudCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (baiducloud *baiducloudCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(baiducloud, node)
+func (baiducloud *baiducloudCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), baiducloud, node)
 }
 
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (baiducloud *baiducloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (baiducloud *baiducloudCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	splitted := strings.Split(node.Spec.ProviderID, "//")
 	if len(splitted) != 2 {
 		return nil, fmt.Errorf("parse ProviderID failed: %v", node.Spec.ProviderID)
@@ -207,43 +208,43 @@ func (baiducloud *baiducloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (c
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (baiducloud *baiducloudCloudProvider) HasInstance(*apiv1.Node) (bool, error) {
+func (baiducloud *baiducloudCloudProvider) HasInstance(context.Context, *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (baiducloud *baiducloudCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (baiducloud *baiducloudCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (baiducloud *baiducloudCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (baiducloud *baiducloudCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (baiducloud *baiducloudCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (baiducloud *baiducloudCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (baiducloud *baiducloudCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (baiducloud *baiducloudCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return baiducloud.resourceLimiter, nil
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (baiducloud *baiducloudCloudProvider) Cleanup() error {
+func (baiducloud *baiducloudCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (baiducloud *baiducloudCloudProvider) Refresh() error {
+func (baiducloud *baiducloudCloudProvider) Refresh(ctx context.Context) error {
 	return nil
 }
 
@@ -262,12 +263,12 @@ type Asg struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (asg *Asg) MaxSize() int {
+func (asg *Asg) MaxSize(ctx context.Context) int {
 	return asg.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (asg *Asg) MinSize() int {
+func (asg *Asg) MinSize(ctx context.Context) int {
 	return asg.minSize
 }
 
@@ -275,7 +276,7 @@ func (asg *Asg) MinSize() int {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (asg *Asg) TargetSize() (int, error) {
+func (asg *Asg) TargetSize(ctx context.Context) (int, error) {
 	size, err := asg.baiducloudManager.GetAsgSize(asg)
 	return int(size), err
 }
@@ -283,7 +284,7 @@ func (asg *Asg) TargetSize() (int, error) {
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (asg *Asg) IncreaseSize(delta int) error {
+func (asg *Asg) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -291,26 +292,26 @@ func (asg *Asg) IncreaseSize(delta int) error {
 	if err != nil {
 		return err
 	}
-	if int(size)+delta > asg.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, asg.MaxSize())
+	if int(size)+delta > asg.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, asg.MaxSize(context.TODO()))
 	}
 	return asg.baiducloudManager.ScaleUpCluster(delta, asg.Name)
 }
 
 // AtomicIncreaseSize is not implemented.
-func (asg *Asg) AtomicIncreaseSize(delta int) error {
+func (asg *Asg) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *Asg) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	size, err := asg.baiducloudManager.GetAsgSize(asg)
 	if err != nil {
 		return err
 	}
-	if int(size) <= asg.MinSize() {
+	if int(size) <= asg.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 	nodeID := make([]string, len(nodes))
@@ -335,7 +336,7 @@ func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (asg *Asg) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (asg *Asg) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -359,7 +360,7 @@ func (asg *Asg) Belongs(instanceID string) (bool, error) {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (asg *Asg) DecreaseTargetSize(delta int) error {
+func (asg *Asg) DecreaseTargetSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -369,14 +370,14 @@ func (asg *Asg) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (asg *Asg) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(), asg.MaxSize())
+func (asg *Asg) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(context.TODO()), asg.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
-func (asg *Asg) Nodes() ([]cloudprovider.Instance, error) {
+func (asg *Asg) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	asgNodes, err := asg.baiducloudManager.GetAsgNodes(asg)
 	if err != nil {
 		return nil, err
@@ -395,7 +396,7 @@ func (asg *Asg) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (asg *Asg) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (asg *Asg) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	template, err := asg.baiducloudManager.getAsgTemplate(asg.Name)
 	if err != nil {
 		return nil, err
@@ -410,30 +411,30 @@ func (asg *Asg) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (asg *Asg) Exist() bool {
+func (asg *Asg) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (asg *Asg) Create() (cloudprovider.NodeGroup, error) {
+func (asg *Asg) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (asg *Asg) Delete() error {
+func (asg *Asg) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (asg *Asg) Autoprovisioned() bool {
+func (asg *Asg) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (asg *Asg) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (asg *Asg) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package baiducloud
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,27 +63,27 @@ func TestName(t *testing.T) {
 func TestNodeGroups(t *testing.T) {
 	provider := testProvider(t, testBaiducloudManager)
 
-	nodeGroups := provider.NodeGroups()
+	nodeGroups := provider.NodeGroups(context.Background())
 	assert.Equal(t, len(nodeGroups), 1)
 	assert.Equal(t, nodeGroups[0].Id(), "k8s-worker-asg-1")
-	assert.Equal(t, nodeGroups[0].MinSize(), 1)
-	assert.Equal(t, nodeGroups[0].MaxSize(), 10)
+	assert.Equal(t, nodeGroups[0].MinSize(context.Background()), 1)
+	assert.Equal(t, nodeGroups[0].MaxSize(context.Background()), 10)
 }
 
 func TestGPULabel(t *testing.T) {
 	provider := testProvider(t, testBaiducloudManager)
-	GPULabel := provider.GPULabel()
+	GPULabel := provider.GPULabel(context.Background())
 	assert.Equal(t, GPULabel, "baidu/nvidia_name")
 }
 
 func TestCleanup(t *testing.T) {
 	provider := testProvider(t, testBaiducloudManager)
-	err := provider.Cleanup()
+	err := provider.Cleanup(context.Background())
 	assert.NoError(t, err)
 }
 
 func TestRefresh(t *testing.T) {
 	provider := testProvider(t, testBaiducloudManager)
-	err := provider.Refresh()
+	err := provider.Refresh(context.Background())
 	assert.NoError(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bizflycloud
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -71,7 +72,7 @@ func (d *bizflycloudCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (d *bizflycloudCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (d *bizflycloudCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodeGroups := make([]cloudprovider.NodeGroup, len(d.manager.nodeGroups))
 	for i, ng := range d.manager.nodeGroups {
 		nodeGroups[i] = ng
@@ -82,7 +83,7 @@ func (d *bizflycloudCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (d *bizflycloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (d *bizflycloudCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	providerID := node.Spec.ProviderID
 	nodeID := toNodeID(providerID)
 
@@ -93,7 +94,7 @@ func (d *bizflycloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 	// proceed with this.
 	for _, group := range d.manager.nodeGroups {
 		klog.V(5).Infof("iterating over node group %q", group.Id())
-		nodes, err := group.Nodes()
+		nodes, err := group.Nodes(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -118,19 +119,19 @@ func (d *bizflycloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (d *bizflycloudCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (d *bizflycloudCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
-func (d *bizflycloudCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (d *bizflycloudCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from
 // the cloud provider. Implementation optional.
-func (d *bizflycloudCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (d *bizflycloudCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
@@ -138,7 +139,7 @@ func (d *bizflycloudCloudProvider) GetAvailableMachineTypes() ([]string, error) 
 // provided. The node group is not automatically created on the cloud provider
 // side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (d *bizflycloudCloudProvider) NewNodeGroup(
+func (d *bizflycloudCloudProvider) NewNodeGroup(ctx context.Context,
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
@@ -150,36 +151,36 @@ func (d *bizflycloudCloudProvider) NewNodeGroup(
 
 // GetResourceLimiter returns struct containing limits (max, min) for
 // resources (cores, memory etc.).
-func (d *bizflycloudCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (d *bizflycloudCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return d.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (d *bizflycloudCloudProvider) GPULabel() string {
+func (d *bizflycloudCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (d *bizflycloudCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (d *bizflycloudCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (d *bizflycloudCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(d, node)
+func (d *bizflycloudCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), d, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed,
 // i.e. go routines etc.
-func (d *bizflycloudCloudProvider) Cleanup() error {
+func (d *bizflycloudCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically
 // update cloud provider state. In particular the list of node groups returned
 // by NodeGroups() can change as a result of CloudProvider.Refresh().
-func (d *bizflycloudCloudProvider) Refresh() error {
+func (d *bizflycloudCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Info("Refreshing node group cache")
 	return d.manager.Refresh()
 }

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider_test.go
@@ -103,7 +103,7 @@ func TestBizflyCloudProvider_NodeGroups(t *testing.T) {
 
 	t.Run("zero groups", func(t *testing.T) {
 		provider.manager.nodeGroups = []*NodeGroup{}
-		nodes := provider.NodeGroups()
+		nodes := provider.NodeGroups(context.Background())
 		assert.Equal(t, len(nodes), 0, "number of nodes do not match")
 	})
 }
@@ -127,7 +127,7 @@ func TestBizflyCloudProvider_NodeGroupForNode(t *testing.T) {
 				ProviderID: toProviderID("droplet-4"),
 			},
 		}
-		nodeGroup, err := provider.NodeGroupForNode(node)
+		nodeGroup, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.Nil(t, nodeGroup)
 	})
@@ -148,7 +148,7 @@ func TestBizflyCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		nodeGroup, err := provider.NodeGroupForNode(node)
+		nodeGroup, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.Nil(t, nodeGroup)
 	})

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
@@ -89,8 +89,11 @@ func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 		DesiredSize: targetSize,
 	}
 
-	ctx2 := context.Background()
-	err := n.client.UpdateClusterWorkerPool(ctx2, n.clusterID, n.id, req)
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
+	err := n.client.UpdateClusterWorkerPool(emptyCtx, n.clusterID, n.id, req)
 	if err != nil {
 		return err
 	}
@@ -110,7 +113,10 @@ func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
 func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
-	ctx2 := context.Background()
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
 	for _, node := range nodes {
 		nodeID, ok := node.Labels[nodeIDLabel]
 		if !ok {
@@ -119,7 +125,7 @@ func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error 
 			// this point.
 			return fmt.Errorf("cannot delete node %q with provider ID %q on node pool %q: node ID label %q is missing", node.Name, node.Spec.ProviderID, n.id, nodeIDLabel)
 		}
-		err := n.client.DeleteClusterWorkerPoolNode(ctx2, n.clusterID, n.id, nodeID)
+		err := n.client.DeleteClusterWorkerPoolNode(emptyCtx, n.clusterID, n.id, nodeID)
 		if err != nil {
 			return fmt.Errorf("deleting node failed for cluster: %q node pool: %q node: %q: %s",
 				n.clusterID, n.id, nodeID, err)
@@ -157,8 +163,11 @@ func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 		DesiredSize: targetSize,
 	}
 
-	ctx2 := context.Background()
-	err := n.client.UpdateClusterWorkerPool(ctx2, n.clusterID, n.id, req)
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
+	err := n.client.UpdateClusterWorkerPool(emptyCtx, n.clusterID, n.id, req)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
@@ -52,12 +52,12 @@ type NodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *NodeGroup) MaxSize() int {
+func (n *NodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *NodeGroup) MinSize() int {
+func (n *NodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
@@ -66,31 +66,31 @@ func (n *NodeGroup) MinSize() int {
 // be equal to Size() once everything stabilizes (new nodes finish startup and
 // registration or removed nodes are deleted completely). Implementation
 // required.
-func (n *NodeGroup) TargetSize() (int, error) {
+func (n *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return n.nodePool.DesiredSize, nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *NodeGroup) IncreaseSize(delta int) error {
+func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
 
 	targetSize := n.nodePool.DesiredSize + delta
 
-	if targetSize > n.MaxSize() {
+	if targetSize > n.MaxSize(context.TODO()) {
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			n.nodePool.DesiredSize, targetSize, n.MaxSize())
+			n.nodePool.DesiredSize, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	req := &gobizfly.UpdateWorkerPoolRequest{
 		DesiredSize: targetSize,
 	}
 
-	ctx := context.Background()
-	err := n.client.UpdateClusterWorkerPool(ctx, n.clusterID, n.id, req)
+	ctx2 := context.Background()
+	err := n.client.UpdateClusterWorkerPool(ctx2, n.clusterID, n.id, req)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -109,8 +109,8 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
-	ctx := context.Background()
+func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
+	ctx2 := context.Background()
 	for _, node := range nodes {
 		nodeID, ok := node.Labels[nodeIDLabel]
 		if !ok {
@@ -119,7 +119,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 			// this point.
 			return fmt.Errorf("cannot delete node %q with provider ID %q on node pool %q: node ID label %q is missing", node.Name, node.Spec.ProviderID, n.id, nodeIDLabel)
 		}
-		err := n.client.DeleteClusterWorkerPoolNode(ctx, n.clusterID, n.id, nodeID)
+		err := n.client.DeleteClusterWorkerPoolNode(ctx2, n.clusterID, n.id, nodeID)
 		if err != nil {
 			return fmt.Errorf("deleting node failed for cluster: %q node pool: %q node: %q: %s",
 				n.clusterID, n.id, nodeID, err)
@@ -133,7 +133,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -142,23 +142,23 @@ func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *NodeGroup) DecreaseTargetSize(delta int) error {
+func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("delta must be negative, have: %d", delta)
 	}
 
 	targetSize := n.nodePool.DesiredSize + delta
-	if targetSize < n.MinSize() {
+	if targetSize < n.MinSize(context.TODO()) {
 		return fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
-			n.nodePool.DesiredSize, targetSize, n.MinSize())
+			n.nodePool.DesiredSize, targetSize, n.MinSize(context.TODO()))
 	}
 
 	req := &gobizfly.UpdateWorkerPoolRequest{
 		DesiredSize: targetSize,
 	}
 
-	ctx := context.Background()
-	err := n.client.UpdateClusterWorkerPool(ctx, n.clusterID, n.id, req)
+	ctx2 := context.Background()
+	err := n.client.UpdateClusterWorkerPool(ctx2, n.clusterID, n.id, req)
 	if err != nil {
 		return err
 	}
@@ -174,14 +174,14 @@ func (n *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroup) Debug() string {
-	return fmt.Sprintf("cluster ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *NodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("cluster ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.  It is
 // required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
-func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	if n.nodePool == nil {
 		return nil, errors.New("node pool instance is not created")
 	}
@@ -195,39 +195,39 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // all of the labels, capacity and allocatable information as well as all pods
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
-func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Exist checks if the node group really exists on the cloud provider side.
 // Allows to tell the theoretical node group from the real one. Implementation
 // required.
-func (n *NodeGroup) Exist() bool {
+func (n *NodeGroup) Exist(ctx context.Context) bool {
 	return n.nodePool != nil
 }
 
 // Create creates the node group on the cloud provider side. Implementation
 // optional.
-func (n *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.  This will be
 // executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroup) Delete() error {
+func (n *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroup) Autoprovisioned() bool {
+func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group_test.go
@@ -43,7 +43,7 @@ func TestNodeGroup_TargetSize(t *testing.T) {
 			},
 		})
 
-		size, err := ng.TargetSize()
+		size, err := ng.TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, numberOfNodes, size, "target size is not correct")
 	})
@@ -72,7 +72,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		},
 			nil).Return(nil).Once()
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -97,7 +97,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			DesiredSize: newCount,
 		}, nil).Return(nil).Once()
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -112,7 +112,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 				},
 			},
 		})
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
@@ -132,7 +132,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
 	})
 
@@ -150,9 +150,9 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		})
 
 		exp := fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			numberOfNodes, numberOfNodes+delta, ng.MaxSize())
+			numberOfNodes, numberOfNodes+delta, ng.MaxSize(context.Background()))
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase is too large")
 	})
 }
@@ -179,7 +179,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		}, nil,
 		).Return(nil).Once()
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -203,7 +203,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		}, nil,
 		).Return(nil).Once()
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -219,7 +219,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		})
 
 		delta := 1
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be negative, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease must be negative")
@@ -239,7 +239,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		delta := 0
 		exp := fmt.Errorf("delta must be negative, have: %d", delta)
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease must be negative")
 	})
 
@@ -258,8 +258,8 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		})
 
 		exp := fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
-			numberOfNodes, numberOfNodes+delta, ng.MinSize())
-		err := ng.DecreaseTargetSize(delta)
+			numberOfNodes, numberOfNodes+delta, ng.MinSize(context.Background()))
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease is too small")
 	})
 }
@@ -288,7 +288,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		client.On("DeleteClusterWorkerPoolNode", ctx, ng.clusterID, ng.id, "2", nil).Return(nil).Once()
 		client.On("DeleteClusterWorkerPoolNode", ctx, ng.clusterID, ng.id, "3", nil).Return(nil).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.NoError(t, err)
 	})
 
@@ -314,7 +314,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		client.On("DeleteClusterWorkerPoolNode", ctx, ng.clusterID, ng.id, "1", nil).Return(nil).Once()
 		client.On("DeleteClusterWorkerPoolNode", ctx, ng.clusterID, ng.id, "2", nil).Return(errors.New("random error")).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.Error(t, err)
 	})
 }
@@ -347,7 +347,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 			},
 		}
 
-		nodes, err := ng.Nodes()
+		nodes, err := ng.Nodes(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, exp, nodes, "nodes do not match")
 	})
@@ -356,7 +356,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 		client := &bizflyClientMock{}
 		ng := testNodeGroup(client, nil)
 
-		_, err := ng.Nodes()
+		_, err := ng.Nodes(context.Background())
 		assert.Error(t, err, "Nodes() should return an error")
 	})
 }
@@ -374,7 +374,7 @@ func TestNodeGroup_Debug(t *testing.T) {
 			},
 		})
 
-		d := ng.Debug()
+		d := ng.Debug(context.Background())
 		exp := "cluster ID: 1 (min:1 max:200)"
 		assert.Equal(t, exp, d, "debug string do not match")
 	})
@@ -391,7 +391,7 @@ func TestNodeGroup_Exist(t *testing.T) {
 			},
 		})
 
-		exist := ng.Exist()
+		exist := ng.Exist(context.Background())
 		assert.Equal(t, true, exist, "node pool should exist")
 	})
 
@@ -399,7 +399,7 @@ func TestNodeGroup_Exist(t *testing.T) {
 		client := &bizflyClientMock{}
 		ng := testNodeGroup(client, nil)
 
-		exist := ng.Exist()
+		exist := ng.Exist(context.Background())
 		assert.Equal(t, false, exist, "node pool should not exist")
 	})
 }

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
@@ -71,7 +71,7 @@ func (b *brightboxCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (b *brightboxCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (b *brightboxCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	klog.V(4).Info("NodeGroups")
 	// Duplicate the stored nodegroup elements and return it
 	//return append(b.nodeGroups[:0:0], b.nodeGroups...)
@@ -82,7 +82,7 @@ func (b *brightboxCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if
 // the node should not be processed by cluster autoscaler, or non-nil
 // error if such occurred. Must be implemented.
-func (b *brightboxCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (b *brightboxCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	klog.V(4).Info("NodeGroupForNode")
 	klog.V(4).Infof("Looking for %v", node.Spec.ProviderID)
 	groupID, ok := b.nodeMap[k8ssdk.MapProviderIDToServerID(node.Spec.ProviderID)]
@@ -95,7 +95,7 @@ func (b *brightboxCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (b *brightboxCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (b *brightboxCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
@@ -103,7 +103,7 @@ func (b *brightboxCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 // update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can
 // change as a result of CloudProvider.Refresh().
-func (b *brightboxCloudProvider) Refresh() error {
+func (b *brightboxCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Info("Refresh")
 	configmaps, err := b.GetConfigMaps()
 	if err != nil {
@@ -174,7 +174,7 @@ func (b *brightboxCloudProvider) Refresh() error {
 // Pricing returns pricing model for this cloud provider or error if
 // not available.
 // Implementation optional.
-func (b *brightboxCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (b *brightboxCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	klog.V(4).Info("Pricing")
 	return nil, cloudprovider.ErrNotImplemented
 }
@@ -182,7 +182,7 @@ func (b *brightboxCloudProvider) Pricing() (cloudprovider.PricingModel, errors.A
 // GetAvailableMachineTypes get all machine types that can be requested
 // from the cloud provider.
 // Implementation optional.
-func (b *brightboxCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (b *brightboxCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	klog.V(4).Info("GetAvailableMachineTypes")
 	return nil, cloudprovider.ErrNotImplemented
 }
@@ -192,41 +192,41 @@ func (b *brightboxCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // the cloud provider side. The node group is not returned by NodeGroups()
 // until it is created.
 // Implementation optional.
-func (b *brightboxCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (b *brightboxCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	klog.V(4).Info("newNodeGroup")
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for
 // resources (cores, memory etc.).
-func (b *brightboxCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (b *brightboxCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	klog.V(4).Info("GetResourceLimiter")
 	return b.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (b *brightboxCloudProvider) GPULabel() string {
+func (b *brightboxCloudProvider) GPULabel(ctx context.Context) string {
 	klog.V(4).Info("GPULabel")
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider
 // supports.
-func (b *brightboxCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (b *brightboxCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	klog.V(4).Info("GetAvailableGPUTypes")
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (b *brightboxCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+func (b *brightboxCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
 	klog.V(4).Info("GetNodeGpuConfig")
-	return gpu.GetNodeGPUFromCloudProvider(b, node)
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), b, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is
 // destroyed, i.e. go routines etc.
-func (b *brightboxCloudProvider) Cleanup() error {
+func (b *brightboxCloudProvider) Cleanup(ctx context.Context) error {
 	klog.V(4).Info("Cleanup")
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package brightbox
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"os"
@@ -72,51 +73,51 @@ func TestName(t *testing.T) {
 }
 
 func TestGPULabel(t *testing.T) {
-	assert.Equal(t, makeFakeCloudProvider(nil).GPULabel(), GPULabel)
+	assert.Equal(t, makeFakeCloudProvider(nil).GPULabel(context.Background()), GPULabel)
 }
 
 func TestGetAvailableGPUTypes(t *testing.T) {
-	assert.Equal(t, makeFakeCloudProvider(nil).GetAvailableGPUTypes(), availableGPUTypes)
+	assert.Equal(t, makeFakeCloudProvider(nil).GetAvailableGPUTypes(context.Background()), availableGPUTypes)
 }
 
 func TestPricing(t *testing.T) {
-	obj, err := makeFakeCloudProvider(nil).Pricing()
+	obj, err := makeFakeCloudProvider(nil).Pricing(context.Background())
 	assert.Equal(t, err, cloudprovider.ErrNotImplemented)
 	assert.Nil(t, obj)
 }
 
 func TestGetAvailableMachineTypes(t *testing.T) {
-	obj, err := makeFakeCloudProvider(nil).GetAvailableMachineTypes()
+	obj, err := makeFakeCloudProvider(nil).GetAvailableMachineTypes(context.Background())
 	assert.Equal(t, err, cloudprovider.ErrNotImplemented)
 	assert.Nil(t, obj)
 }
 
 func TestNewNodeGroup(t *testing.T) {
-	obj, err := makeFakeCloudProvider(nil).NewNodeGroup("", nil, nil, nil, nil)
+	obj, err := makeFakeCloudProvider(nil).NewNodeGroup(context.Background(), "", nil, nil, nil, nil)
 	assert.Equal(t, err, cloudprovider.ErrNotImplemented)
 	assert.Nil(t, obj)
 }
 
 func TestCleanUp(t *testing.T) {
-	assert.Nil(t, makeFakeCloudProvider(nil).Cleanup())
+	assert.Nil(t, makeFakeCloudProvider(nil).Cleanup(context.Background()))
 }
 
 func TestResourceLimiter(t *testing.T) {
 	client := makeFakeCloudProvider(nil)
-	obj, err := client.GetResourceLimiter()
+	obj, err := client.GetResourceLimiter(context.Background())
 	assert.Equal(t, obj, client.resourceLimiter)
 	assert.NoError(t, err)
 }
 
 func TestNodeGroups(t *testing.T) {
 	client := makeFakeCloudProvider(nil)
-	assert.Zero(t, client.NodeGroups())
+	assert.Zero(t, client.NodeGroups(context.Background()))
 	client.nodeGroups = make([]cloudprovider.NodeGroup, 0)
-	assert.NotZero(t, client.NodeGroups())
-	assert.Empty(t, client.NodeGroups())
+	assert.NotZero(t, client.NodeGroups(context.Background()))
+	assert.Empty(t, client.NodeGroups(context.Background()))
 	nodeGroup := &brightboxNodeGroup{}
 	client.nodeGroups = append(client.nodeGroups, nodeGroup)
-	newGroups := client.NodeGroups()
+	newGroups := client.NodeGroups(context.Background())
 	assert.Len(t, newGroups, 1)
 	assert.Same(t, newGroups[0], client.nodeGroups[0])
 }
@@ -125,10 +126,10 @@ func TestNodeGroupForNode(t *testing.T) {
 	client := makeFakeCloudProvider(nil)
 	client.nodeGroups = fakeNodeGroups
 	client.nodeMap = fakeNodeMap
-	nodeGroup, err := client.NodeGroupForNode(makeNode(fakeServer))
+	nodeGroup, err := client.NodeGroupForNode(context.Background(), makeNode(fakeServer))
 	assert.Equal(t, fakeNodeGroup, nodeGroup)
 	assert.NoError(t, err)
-	nodeGroup, err = client.NodeGroupForNode(makeNode(missingServer))
+	nodeGroup, err = client.NodeGroupForNode(context.Background(), makeNode(missingServer))
 	assert.Nil(t, nodeGroup)
 	assert.NoError(t, err)
 }
@@ -147,7 +148,7 @@ func TestBuildBrightBox(t *testing.T) {
 	}
 	cloud := BuildBrightbox(opts, do, rl)
 	assert.Equal(t, cloud.Name(), ProviderName)
-	obj, err := cloud.GetResourceLimiter()
+	obj, err := cloud.GetResourceLimiter(context.Background())
 	assert.Equal(t, rl, obj)
 	assert.NoError(t, err)
 }
@@ -190,15 +191,15 @@ func TestRefresh(t *testing.T) {
 	mockclient.On("ServerGroup", "grp-sda44").Return(fakeServerGroupsda44(), nil)
 	mockclient.On("ConfigMaps").Return(fakeConfigMaps(), nil)
 	mockclient.On("ConfigMap", "cfg-502vh").Return(fakeConfigMap502vh(), nil)
-	err := provider.Refresh()
+	err := provider.Refresh(context.Background())
 	require.NoError(t, err)
 	assert.Len(t, provider.nodeGroups, 1)
 	assert.NotEmpty(t, provider.nodeMap)
-	node, err := provider.NodeGroupForNode(makeNode("srv-lv426"))
+	node, err := provider.NodeGroupForNode(context.Background(), makeNode("srv-lv426"))
 	assert.NoError(t, err)
 	require.NotNil(t, node)
 	assert.Equal(t, node.Id(), groups[0].Id)
-	node, err = provider.NodeGroupForNode(makeNode("srv-rp897"))
+	node, err = provider.NodeGroupForNode(context.Background(), makeNode("srv-rp897"))
 	assert.NoError(t, err)
 	require.NotNil(t, node)
 	assert.Equal(t, node.Id(), groups[0].Id)

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
@@ -61,13 +61,13 @@ type brightboxNodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (ng *brightboxNodeGroup) MaxSize() int {
+func (ng *brightboxNodeGroup) MaxSize(ctx context.Context) int {
 	klog.V(4).Info("MaxSize")
 	return ng.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (ng *brightboxNodeGroup) MinSize() int {
+func (ng *brightboxNodeGroup) MinSize(ctx context.Context) int {
 	klog.V(4).Info("MinSize")
 	return ng.minSize
 }
@@ -77,7 +77,7 @@ func (ng *brightboxNodeGroup) MinSize() int {
 // the moment but should be equal to Size() once everything stabilizes
 // (new nodes finish startup and registration or removed nodes are deleted
 // completely). Implementation required.
-func (ng *brightboxNodeGroup) TargetSize() (int, error) {
+func (ng *brightboxNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	klog.V(4).Info("TargetSize")
 	group, err := ng.GetServerGroup(ng.Id())
 	if err != nil {
@@ -91,24 +91,24 @@ func (ng *brightboxNodeGroup) CurrentSize() (int, error) {
 	klog.V(4).Info("CurrentSize")
 	// The implementation is currently synchronous, so
 	// CurrentSize and TargetSize will be identical at all times
-	return ng.TargetSize()
+	return ng.TargetSize(context.TODO())
 }
 
 // IncreaseSize increases the size of the node group. To delete a node
 // you need to explicitly name it and use DeleteNode. This function should
 // wait until node group size is updated. Implementation required.
-func (ng *brightboxNodeGroup) IncreaseSize(delta int) error {
+func (ng *brightboxNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("IncreaseSize: %v", delta)
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.TODO())
 	if err != nil {
 		return err
 	}
 	desiredSize := size + delta
-	if desiredSize > ng.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", desiredSize, ng.MaxSize())
+	if desiredSize > ng.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", desiredSize, ng.MaxSize(context.TODO()))
 	}
 	err = ng.createServers(delta)
 	if err != nil {
@@ -118,14 +118,14 @@ func (ng *brightboxNodeGroup) IncreaseSize(delta int) error {
 		checkInterval,
 		checkTimeout,
 		func() (bool, error) {
-			size, err := ng.TargetSize()
+			size, err := ng.TargetSize(context.TODO())
 			return err == nil && size >= desiredSize, err
 		},
 	)
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ng *brightboxNodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *brightboxNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -133,7 +133,7 @@ func (ng *brightboxNodeGroup) AtomicIncreaseSize(delta int) error {
 // either on failure or if the given node doesn't belong to this
 // node group. This function should wait until node group size is
 // updated. Implementation required.
-func (ng *brightboxNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *brightboxNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	klog.V(4).Info("DeleteNodes")
 	klog.V(4).Infof("Nodes: %+v", nodes)
 	for _, node := range nodes {
@@ -141,7 +141,7 @@ func (ng *brightboxNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		if err != nil {
 			return err
 		}
-		if size <= ng.MinSize() {
+		if size <= ng.MinSize(context.TODO()) {
 			return fmt.Errorf("min size reached, no further nodes will be deleted")
 		}
 		serverID := k8ssdk.MapProviderIDToServerID(node.Spec.ProviderID)
@@ -154,7 +154,7 @@ func (ng *brightboxNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ng *brightboxNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ng *brightboxNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -165,12 +165,12 @@ func (ng *brightboxNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // It is assumed that cloud provider will not delete the existing nodes
 // when there is an option to just decrease the target. Implementation
 // required.
-func (ng *brightboxNodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *brightboxNodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("DecreaseTargetSize: %v", delta)
 	if delta >= 0 {
 		return fmt.Errorf("decrease size must be negative")
 	}
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func (ng *brightboxNodeGroup) Id() string {
 
 // Debug returns a string containing all information regarding this
 // node group.
-func (ng *brightboxNodeGroup) Debug() string {
+func (ng *brightboxNodeGroup) Debug(ctx context.Context) string {
 	klog.V(4).Info("Debug")
 	return fmt.Sprintf("brightboxNodeGroup %+v", *ng)
 }
@@ -202,7 +202,7 @@ func (ng *brightboxNodeGroup) Debug() string {
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id
 // field set.  Other fields are optional.
-func (ng *brightboxNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *brightboxNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	klog.V(4).Info("Nodes")
 	group, err := ng.GetServerGroup(ng.Id())
 	if err != nil {
@@ -239,7 +239,7 @@ func (ng *brightboxNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // Exist checks if the node group really exists on the cloud provider
 // side. Allows to tell the theoretical node group from the real
 // one. Implementation required.
-func (ng *brightboxNodeGroup) Exist() bool {
+func (ng *brightboxNodeGroup) Exist(ctx context.Context) bool {
 	klog.V(4).Info("Exist")
 	_, err := ng.GetServerGroup(ng.Id())
 	return err == nil
@@ -251,7 +251,7 @@ func (ng *brightboxNodeGroup) Exist() bool {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (ng *brightboxNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *brightboxNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	klog.V(4).Info("TemplateNodeInfo")
 	klog.V(4).Infof("Looking for server type %q", ng.serverOptions.ServerType)
 	serverType, err := ng.findServerType()
@@ -298,7 +298,7 @@ func resourceList(r *schedulerframework.Resource) v1.ResourceList {
 
 // Create creates the node group on the cloud provider
 // side. Implementation optional.
-func (ng *brightboxNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *brightboxNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	klog.V(4).Info("Create")
 	return nil, cloudprovider.ErrNotImplemented
 }
@@ -306,21 +306,21 @@ func (ng *brightboxNodeGroup) Create() (cloudprovider.NodeGroup, error) {
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once
 // their size drops to 0.  Implementation optional.
-func (ng *brightboxNodeGroup) Delete() error {
+func (ng *brightboxNodeGroup) Delete(ctx context.Context) error {
 	klog.V(4).Info("Delete")
 	return cloudprovider.ErrNotImplemented
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (ng *brightboxNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *brightboxNodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled
 // to 0.
-func (ng *brightboxNodeGroup) Autoprovisioned() bool {
+func (ng *brightboxNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	klog.V(4).Info("Autoprovisioned")
 	return false
 }
@@ -386,7 +386,7 @@ func makeNodeGroupFromAPIDetails(
 		ServerGroups: mergeServerGroups(mapData),
 	}
 	ng.serverOptions = options
-	klog.V(4).Info(ng.Debug())
+	klog.V(4).Info(ng.Debug(context.TODO()))
 	return &ng, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package brightbox
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"strings"
@@ -118,11 +119,11 @@ var (
 )
 
 func TestMaxSize(t *testing.T) {
-	assert.Equal(t, makeFakeNodeGroup(t, nil).MaxSize(), fakeMaxSize)
+	assert.Equal(t, makeFakeNodeGroup(t, nil).MaxSize(context.Background()), fakeMaxSize)
 }
 
 func TestMinSize(t *testing.T) {
-	assert.Equal(t, makeFakeNodeGroup(t, nil).MinSize(), fakeMinSize)
+	assert.Equal(t, makeFakeNodeGroup(t, nil).MinSize(context.Background()), fakeMinSize)
 }
 
 func TestSize(t *testing.T) {
@@ -133,14 +134,14 @@ func TestSize(t *testing.T) {
 	t.Run("TargetSize", func(t *testing.T) {
 		mockclient.On("ServerGroup", fakeNodeGroupID).
 			Return(fakeServerGroup, nil).Once()
-		size, err := nodeGroup.TargetSize()
+		size, err := nodeGroup.TargetSize(context.Background())
 		assert.Equal(t, 2, size)
 		assert.NoError(t, err)
 	})
 	t.Run("TargetSizeFail", func(t *testing.T) {
 		mockclient.On("ServerGroup", fakeNodeGroupID).
 			Return(nil, ErrFake).Once()
-		size, err := nodeGroup.TargetSize()
+		size, err := nodeGroup.TargetSize(context.Background())
 		assert.Error(t, err)
 		assert.Zero(t, size)
 	})
@@ -161,11 +162,11 @@ func TestSize(t *testing.T) {
 	mockclient.On("ServerGroup", fakeNodeGroupID).
 		Return(fakeServerGroup, nil)
 	t.Run("DecreaseTargetSizePositive", func(t *testing.T) {
-		err := nodeGroup.DecreaseTargetSize(0)
+		err := nodeGroup.DecreaseTargetSize(context.Background(), 0)
 		assert.Error(t, err)
 	})
 	t.Run("DecreaseTargetSizeFail", func(t *testing.T) {
-		err := nodeGroup.DecreaseTargetSize(-1)
+		err := nodeGroup.DecreaseTargetSize(context.Background(), -1)
 		assert.Error(t, err)
 	})
 	mockclient.AssertExpectations(t)
@@ -185,14 +186,14 @@ func TestIncreaseSize(t *testing.T) {
 		assert.Equal(t, fakeNodeGroupUserData, *nodeGroup.serverOptions.UserData)
 	})
 	t.Run("Require positive delta", func(t *testing.T) {
-		err := nodeGroup.IncreaseSize(0)
+		err := nodeGroup.IncreaseSize(context.Background(), 0)
 		assert.Error(t, err)
 	})
 	fakeServerGroup := &fakeGroups()[0]
 	t.Run("Don't exceed max size", func(t *testing.T) {
 		mockclient.On("ServerGroup", fakeNodeGroupID).
 			Return(fakeServerGroup, nil).Once()
-		err := nodeGroup.IncreaseSize(4)
+		err := nodeGroup.IncreaseSize(context.Background(), 4)
 		assert.Error(t, err)
 	})
 	t.Run("Fail to create one new server", func(t *testing.T) {
@@ -200,7 +201,7 @@ func TestIncreaseSize(t *testing.T) {
 			Return(fakeServerGroup, nil).Once()
 		mockclient.On("CreateServer", mock.Anything).
 			Return(nil, ErrFake).Once()
-		err := nodeGroup.IncreaseSize(1)
+		err := nodeGroup.IncreaseSize(context.Background(), 1)
 		assert.Error(t, err)
 	})
 	t.Run("Create one new server", func(t *testing.T) {
@@ -210,7 +211,7 @@ func TestIncreaseSize(t *testing.T) {
 			Return(nil, nil).Once()
 		mockclient.On("ServerGroup", fakeNodeGroupID).
 			Return(&fakeServerGroupsPlusOne()[0], nil).Once()
-		err := nodeGroup.IncreaseSize(1)
+		err := nodeGroup.IncreaseSize(context.Background(), 1)
 		assert.NoError(t, err)
 	})
 }
@@ -225,11 +226,11 @@ func TestDeleteNodes(t *testing.T) {
 		On("Server", fakeServer).
 		Return(fakeServertesty(), nil)
 	t.Run("Empty Nodes", func(t *testing.T) {
-		err := nodeGroup.DeleteNodes(nil)
+		err := nodeGroup.DeleteNodes(context.Background(), nil)
 		assert.NoError(t, err)
 	})
 	t.Run("Foreign Node", func(t *testing.T) {
-		err := nodeGroup.DeleteNodes([]*v1.Node{makeNode(fakeServer)})
+		err := nodeGroup.DeleteNodes(context.Background(), []*v1.Node{makeNode(fakeServer)})
 		assert.Error(t, err)
 	})
 	t.Run("Delete Node", func(t *testing.T) {
@@ -240,7 +241,7 @@ func TestDeleteNodes(t *testing.T) {
 			Once().
 			On("DestroyServer", "srv-rp897").
 			Return(nil).Once()
-		err := nodeGroup.DeleteNodes([]*v1.Node{makeNode("srv-rp897")})
+		err := nodeGroup.DeleteNodes(context.Background(), []*v1.Node{makeNode("srv-rp897")})
 		assert.NoError(t, err)
 	})
 	t.Run("Delete All Nodes", func(t *testing.T) {
@@ -252,7 +253,7 @@ func TestDeleteNodes(t *testing.T) {
 			Once().
 			On("DestroyServer", "srv-rp897").
 			Return(nil).Once().Run(truncateServers)
-		err := nodeGroup.DeleteNodes([]*v1.Node{
+		err := nodeGroup.DeleteNodes(context.Background(), []*v1.Node{
 			makeNode("srv-rp897"),
 			makeNode("srv-lv426"),
 		})
@@ -269,12 +270,12 @@ func TestExist(t *testing.T) {
 	t.Run("Find Group", func(t *testing.T) {
 		mockclient.On("ServerGroup", nodeGroup.Id()).
 			Return(fakeServerGroup, nil).Once()
-		assert.True(t, nodeGroup.Exist())
+		assert.True(t, nodeGroup.Exist(context.Background()))
 	})
 	t.Run("Fail to Find Group", func(t *testing.T) {
 		mockclient.On("ServerGroup", nodeGroup.Id()).
 			Return(nil, serverNotFoundError(nodeGroup.Id()))
-		assert.False(t, nodeGroup.Exist())
+		assert.False(t, nodeGroup.Exist(context.Background()))
 	})
 	mockclient.AssertExpectations(t)
 }
@@ -289,21 +290,21 @@ func TestNodes(t *testing.T) {
 	t.Run("Both Active", func(t *testing.T) {
 		fakeServerGroup.Servers[0].Status = "active"
 		fakeServerGroup.Servers[1].Status = "active"
-		nodes, err := nodeGroup.Nodes()
+		nodes, err := nodeGroup.Nodes(context.Background())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, fakeInstances, nodes)
 	})
 	t.Run("Creating and Deleting", func(t *testing.T) {
 		fakeServerGroup.Servers[0].Status = "creating"
 		fakeServerGroup.Servers[1].Status = "deleting"
-		nodes, err := nodeGroup.Nodes()
+		nodes, err := nodeGroup.Nodes(context.Background())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, fakeTransitionInstances, nodes)
 	})
 	t.Run("Inactive and Unavailable", func(t *testing.T) {
 		fakeServerGroup.Servers[0].Status = "inactive"
 		fakeServerGroup.Servers[1].Status = "unavailable"
-		nodes, err := nodeGroup.Nodes()
+		nodes, err := nodeGroup.Nodes(context.Background())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, ErrFakeInstances, nodes)
 	})
@@ -314,7 +315,7 @@ func TestTemplateNodeInfo(t *testing.T) {
 	testclient := k8ssdk.MakeTestClient(mockclient, nil)
 	mockclient.On("ServerType", fakeNodeGroupServerTypeID).
 		Return(fakeServerTypezx45f(), nil)
-	obj, err := makeFakeNodeGroup(t, testclient).TemplateNodeInfo()
+	obj, err := makeFakeNodeGroup(t, testclient).TemplateNodeInfo(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, fakeResource(), obj.GetAllocatable())
 }
@@ -414,17 +415,17 @@ func TestMultipleGroups(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	obj, err := makeFakeNodeGroup(t, nil).Create()
+	obj, err := makeFakeNodeGroup(t, nil).Create(context.Background())
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 	assert.Nil(t, obj)
 }
 
 func TestDelete(t *testing.T) {
-	assert.Equal(t, cloudprovider.ErrNotImplemented, makeFakeNodeGroup(t, nil).Delete())
+	assert.Equal(t, cloudprovider.ErrNotImplemented, makeFakeNodeGroup(t, nil).Delete(context.Background()))
 }
 
 func TestAutoprovisioned(t *testing.T) {
-	assert.False(t, makeFakeNodeGroup(t, nil).Autoprovisioned())
+	assert.False(t, makeFakeNodeGroup(t, nil).Autoprovisioned(context.Background()))
 }
 
 func fakeResource() *schedulerframework.Resource {

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cherryservers
 
 import (
+	"context"
 	"io"
 	"os"
 	"regexp"
@@ -86,23 +87,23 @@ func (ccp *cherryCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (ccp *cherryCloudProvider) GPULabel() string {
+func (ccp *cherryCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (ccp *cherryCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (ccp *cherryCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (ccp *cherryCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(ccp, node)
+func (ccp *cherryCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), ccp, node)
 }
 
 // NodeGroups returns all node groups managed by this cloud provider.
-func (ccp *cherryCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (ccp *cherryCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	groups := make([]cloudprovider.NodeGroup, len(ccp.nodeGroups))
 	for i := range ccp.nodeGroups {
 		groups[i] = &ccp.nodeGroups[i]
@@ -118,7 +119,7 @@ func (ccp *cherryCloudProvider) AddNodeGroup(group cherryNodeGroup) {
 // NodeGroupForNode returns the node group that a given node belongs to.
 //
 // Since only a single node group is currently supported, the first node group is always returned.
-func (ccp *cherryCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (ccp *cherryCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	// ignore control plane nodes
 	if _, found := node.ObjectMeta.Labels[ccp.controllerNodeLabel]; found {
 		return nil, nil
@@ -139,43 +140,43 @@ func (ccp *cherryCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (ccp *cherryCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (ccp *cherryCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (ccp *cherryCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (ccp *cherryCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes is not implemented.
-func (ccp *cherryCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (ccp *cherryCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup is not implemented.
-func (ccp *cherryCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (ccp *cherryCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns resource constraints for the cloud provider
-func (ccp *cherryCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (ccp *cherryCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return ccp.resourceLimiter, nil
 }
 
 // Refresh is called before every autoscaler main loop.
 //
 // Currently only prints debug information.
-func (ccp *cherryCloudProvider) Refresh() error {
+func (ccp *cherryCloudProvider) Refresh(ctx context.Context) error {
 	for _, nodegroup := range ccp.nodeGroups {
-		klog.V(3).Info(nodegroup.Debug())
+		klog.V(3).Info(nodegroup.Debug(context.TODO()))
 	}
 	return nil
 }
 
 // Cleanup currently does nothing.
-func (ccp *cherryCloudProvider) Cleanup() error {
+func (ccp *cherryCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cherryservers
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -86,7 +87,7 @@ func newCherryNodeGroup(manager cherryManager, name string, minSize, maxSize, ta
 //
 // Takes precautions so that the cluster is not modified while in an UPDATE_IN_PROGRESS state.
 // Blocks until the cluster has reached UPDATE_COMPLETE.
-func (ng *cherryNodeGroup) IncreaseSize(delta int) error {
+func (ng *cherryNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	ng.clusterUpdateMutex.Lock()
 	defer ng.clusterUpdateMutex.Unlock()
 
@@ -98,8 +99,8 @@ func (ng *cherryNodeGroup) IncreaseSize(delta int) error {
 	if err != nil {
 		return fmt.Errorf("could not check current nodegroup size: %v", err)
 	}
-	if size+delta > ng.MaxSize() {
-		return fmt.Errorf("size increase too large, desired:%d max:%d", size+delta, ng.MaxSize())
+	if size+delta > ng.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large, desired:%d max:%d", size+delta, ng.MaxSize(context.TODO()))
 	}
 
 	klog.V(0).Infof("Increasing size by %d, %d->%d", delta, ng.targetSize, ng.targetSize+delta)
@@ -114,12 +115,12 @@ func (ng *cherryNodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ng *cherryNodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *cherryNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes a set of nodes chosen by the autoscaler.
-func (ng *cherryNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *cherryNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	// Batch simultaneous deletes on individual nodes
 	if err := ng.addNodesToDelete(nodes); err != nil {
 		return err
@@ -150,8 +151,8 @@ func (ng *cherryNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	}
 
 	// Double check that the total number of batched nodes for deletion will not take the node group below its minimum size
-	if cachedSize-len(nodes) < ng.MinSize() {
-		return fmt.Errorf("size decrease too large, desired:%d min:%d", cachedSize-len(nodes), ng.MinSize())
+	if cachedSize-len(nodes) < ng.MinSize(context.TODO()) {
+		return fmt.Errorf("size decrease too large, desired:%d min:%d", cachedSize-len(nodes), ng.MinSize(context.TODO()))
 	}
 	klog.V(0).Infof("Deleting nodes: %v", nodeNames)
 
@@ -190,7 +191,7 @@ func (ng *cherryNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ng *cherryNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ng *cherryNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -231,7 +232,7 @@ func (ng *cherryNodeGroup) addNodesToDelete(nodes []*v1.Node) error {
 	}
 
 	// Check that these nodes would not make the batch delete more nodes than the minimum would allow
-	if cachedSize-len(ng.nodesToDelete)-len(nodes) < ng.MinSize() {
+	if cachedSize-len(ng.nodesToDelete)-len(nodes) < ng.MinSize(context.TODO()) {
 		return fmt.Errorf("deleting nodes would take nodegroup below minimum size %d", ng.minSize)
 	}
 	// otherwise, add the nodes to the batch and release the lock
@@ -241,7 +242,7 @@ func (ng *cherryNodeGroup) addNodesToDelete(nodes []*v1.Node) error {
 }
 
 // DecreaseTargetSize decreases the cluster node_count in Cherry Servers.
-func (ng *cherryNodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *cherryNodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
@@ -256,12 +257,12 @@ func (ng *cherryNodeGroup) Id() string {
 }
 
 // Debug returns a string formatted with the node group's min, max and target sizes.
-func (ng *cherryNodeGroup) Debug() string {
+func (ng *cherryNodeGroup) Debug(ctx context.Context) string {
 	return fmt.Sprintf("%s min=%d max=%d target=%d", ng.id, ng.minSize, ng.maxSize, ng.targetSize)
 }
 
 // Nodes returns a list of nodes that belong to this node group.
-func (ng *cherryNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *cherryNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	nodes, err := ng.cherryManager.getNodes(ng.id)
 	if err != nil {
 		return nil, fmt.Errorf("could not get nodes: %v", err)
@@ -274,48 +275,48 @@ func (ng *cherryNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (ng *cherryNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *cherryNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return ng.cherryManager.templateNodeInfo(ng.id)
 }
 
 // Exist returns if this node group exists.
 // Currently always returns true.
-func (ng *cherryNodeGroup) Exist() bool {
+func (ng *cherryNodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (ng *cherryNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *cherryNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.
-func (ng *cherryNodeGroup) Delete() error {
+func (ng *cherryNodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns if the nodegroup is autoprovisioned.
-func (ng *cherryNodeGroup) Autoprovisioned() bool {
+func (ng *cherryNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // MaxSize returns the maximum allowed size of the node group.
-func (ng *cherryNodeGroup) MaxSize() int {
+func (ng *cherryNodeGroup) MaxSize(ctx context.Context) int {
 	return ng.maxSize
 }
 
 // MinSize returns the minimum allowed size of the node group.
-func (ng *cherryNodeGroup) MinSize() int {
+func (ng *cherryNodeGroup) MinSize(ctx context.Context) int {
 	return ng.minSize
 }
 
 // TargetSize returns the target size of the node group.
-func (ng *cherryNodeGroup) TargetSize() (int, error) {
+func (ng *cherryNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return ng.targetSize, nil
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (ng *cherryNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *cherryNodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cherryservers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -181,12 +182,12 @@ func TestIncreaseDecreaseSize(t *testing.T) {
 
 	// Try to increase pool3 with negative size, this should return an error
 	// calls: (should error before any calls)
-	err = ngPool3.IncreaseSize(-1)
+	err = ngPool3.IncreaseSize(context.Background(), -1)
 	assert.Error(t, err)
 
 	// Now try to increase the pool3 size by 1, that should work
 	// calls: listServers, createServer
-	err = ngPool3.IncreaseSize(1)
+	err = ngPool3.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	if useRealEndpoint {
@@ -207,7 +208,7 @@ func TestIncreaseDecreaseSize(t *testing.T) {
 
 	// Now try to increase the pool2 size by 1, that should work
 	// calls: listServers, createServer
-	err = ngPool2.IncreaseSize(1)
+	err = ngPool2.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	if useRealEndpoint {
@@ -244,10 +245,10 @@ func TestIncreaseDecreaseSize(t *testing.T) {
 		}
 	}
 
-	err = ngPool2.DeleteNodes(nodesPool2)
+	err = ngPool2.DeleteNodes(context.Background(), nodesPool2)
 	assert.NoError(t, err)
 
-	err = ngPool3.DeleteNodes(nodesPool3)
+	err = ngPool3.DeleteNodes(context.Background(), nodesPool3)
 	assert.NoError(t, err)
 
 	// Wait a few seconds if talking to the actual Cherry API

--- a/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package civo
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -75,7 +76,7 @@ func (d *civoCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (d *civoCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (d *civoCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodeGroups := make([]cloudprovider.NodeGroup, len(d.manager.nodeGroups))
 	for i, ng := range d.manager.nodeGroups {
 		nodeGroups[i] = ng
@@ -86,14 +87,14 @@ func (d *civoCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (d *civoCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (d *civoCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	providerID := node.Spec.ProviderID
 	nodeID := toNodeID(providerID)
 
 	klog.V(5).Infof("checking nodegroup for node ID: %q", nodeID)
 	for _, group := range d.manager.nodeGroups {
 		klog.V(5).Infof("iterating over node group %q", group.Id())
-		nodes, err := group.Nodes()
+		nodes, err := group.Nodes(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -116,19 +117,19 @@ func (d *civoCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.No
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (d *civoCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (d *civoCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
-func (d *civoCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (d *civoCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from
 // the cloud provider. Implementation optional.
-func (d *civoCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (d *civoCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
@@ -136,7 +137,7 @@ func (d *civoCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // provided. The node group is not automatically created on the cloud provider
 // side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (d *civoCloudProvider) NewNodeGroup(
+func (d *civoCloudProvider) NewNodeGroup(ctx context.Context,
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
@@ -148,36 +149,36 @@ func (d *civoCloudProvider) NewNodeGroup(
 
 // GetResourceLimiter returns struct containing limits (max, min) for
 // resources (cores, memory etc.).
-func (d *civoCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (d *civoCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return d.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (d *civoCloudProvider) GPULabel() string {
+func (d *civoCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (d *civoCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (d *civoCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (d *civoCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(d, node)
+func (d *civoCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), d, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed,
 // i.e. go routines etc.
-func (d *civoCloudProvider) Cleanup() error {
+func (d *civoCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically
 // update cloud provider state. In particular the list of node groups returned
 // by NodeGroups() can change as a result of CloudProvider.Refresh().
-func (d *civoCloudProvider) Refresh() error {
+func (d *civoCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Info("Refreshing node group cache")
 	return d.manager.Refresh()
 }

--- a/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider_test.go
@@ -18,6 +18,7 @@ package civo
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,16 +142,16 @@ func TestCivoCloudProvider_NodeGroups(t *testing.T) {
 	provider := testCloudProvider(t, nil)
 
 	t.Run("success", func(t *testing.T) {
-		nodegroups := provider.NodeGroups()
+		nodegroups := provider.NodeGroups(context.Background())
 		assert.Equal(t, len(nodegroups), 2, "number of node groups does not match")
-		nodes, _ := nodegroups[0].Nodes()
+		nodes, _ := nodegroups[0].Nodes(context.Background())
 		assert.Equal(t, len(nodes), 2, "number of nodes in workers node group does not match")
 
 	})
 
 	t.Run("zero groups", func(t *testing.T) {
 		provider.manager.nodeGroups = []*NodeGroup{}
-		nodes := provider.NodeGroups()
+		nodes := provider.NodeGroups(context.Background())
 		assert.Equal(t, len(nodes), 0, "number of nodes do not match")
 	})
 }
@@ -219,7 +220,7 @@ func TestCivoCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		nodeGroup, err := provider.NodeGroupForNode(node)
+		nodeGroup, err := provider.NodeGroupForNode(context.Background(), node)
 		require.NoError(t, err)
 		require.NotNil(t, nodeGroup)
 		require.Equal(t, nodeGroup.Id(), "1", "node group ID does not match")
@@ -280,7 +281,7 @@ func TestCivoCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		nodeGroup, err := provider.NodeGroupForNode(node)
+		nodeGroup, err := provider.NodeGroupForNode(context.Background(), node)
 		require.NoError(t, err)
 		require.Nil(t, nodeGroup)
 	})

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
@@ -17,6 +17,7 @@ limitations under the License.
 package civo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -61,17 +62,17 @@ type CivoNodeTemplate struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *NodeGroup) MaxSize() int {
+func (n *NodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *NodeGroup) MinSize() int {
+func (n *NodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
 // GetOptions returns the options used to create this node group.
-func (n *NodeGroup) GetOptions(autoscaler.NodeGroupAutoscalingOptions) (*autoscaler.NodeGroupAutoscalingOptions, error) {
+func (n *NodeGroup) GetOptions(context.Context, autoscaler.NodeGroupAutoscalingOptions) (*autoscaler.NodeGroupAutoscalingOptions, error) {
 	return n.getOptions, nil
 }
 
@@ -80,23 +81,23 @@ func (n *NodeGroup) GetOptions(autoscaler.NodeGroupAutoscalingOptions) (*autosca
 // be equal to Size() once everything stabilizes (new nodes finish startup and
 // registration or removed nodes are deleted completely). Implementation
 // required.
-func (n *NodeGroup) TargetSize() (int, error) {
+func (n *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return n.nodePool.Count, nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *NodeGroup) IncreaseSize(delta int) error {
+func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
 
 	targetSize := n.nodePool.Count + delta
 
-	if targetSize > n.MaxSize() {
+	if targetSize > n.MaxSize(context.TODO()) {
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			n.nodePool.Count, targetSize, n.MaxSize())
+			n.nodePool.Count, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	req := &civocloud.KubernetesClusterPoolUpdateConfig{
@@ -108,9 +109,9 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 		return err
 	}
 
-	if targetSize > n.MaxSize() {
+	if targetSize > n.MaxSize(context.TODO()) {
 		return fmt.Errorf("size increase too large. current: %d, desired: %d, max: %d",
-			updatedNodePool.Count, targetSize, n.MaxSize())
+			updatedNodePool.Count, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	// update internal cache
@@ -119,7 +120,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -127,7 +128,7 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	for _, node := range nodes {
 		instanceID := toNodeID(node.Spec.ProviderID)
 		klog.V(4).Infof("deleteing node: %q", instanceID)
@@ -145,7 +146,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -154,15 +155,15 @@ func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *NodeGroup) DecreaseTargetSize(delta int) error {
+func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("delta must be negative, have: %d", delta)
 	}
 
 	targetSize := n.nodePool.Count + delta
-	if targetSize < n.MinSize() {
+	if targetSize < n.MinSize(context.TODO()) {
 		return fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
-			n.nodePool.Count, targetSize, n.MinSize())
+			n.nodePool.Count, targetSize, n.MinSize(context.TODO()))
 	}
 
 	req := &civocloud.KubernetesClusterPoolUpdateConfig{
@@ -191,14 +192,14 @@ func (n *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroup) Debug() string {
-	return fmt.Sprintf("id: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *NodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("id: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.  It is
 // required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
-func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	if n.nodePool == nil {
 		return nil, errors.New("node pool instance is not created")
 	}
@@ -213,7 +214,7 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // all of the labels, capacity and allocatable information as well as all pods
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
-func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	node, err := n.buildNodeFromTemplate(n.Id(), n.nodeTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build node from template")
@@ -226,26 +227,26 @@ func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 // Exist checks if the node group really exists on the cloud provider side.
 // Allows to tell the theoretical node group from the real one. Implementation
 // required.
-func (n *NodeGroup) Exist() bool {
+func (n *NodeGroup) Exist(ctx context.Context) bool {
 	return n.nodePool != nil
 }
 
 // Create creates the node group on the cloud provider side. Implementation
 // optional.
-func (n *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.  This will be
 // executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroup) Delete() error {
+func (n *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroup) Autoprovisioned() bool {
+func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package civo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -43,7 +44,7 @@ func TestNodeGroup_TargetSize(t *testing.T) {
 			Count: numberOfNodes,
 		}, 1, 10)
 
-		size, err := ng.TargetSize()
+		size, err := ng.TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, numberOfNodes, size, "target size is not correct")
 	})
@@ -79,7 +80,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -115,7 +116,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -134,7 +135,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		}, 1, 10)
 
 		delta := -1
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
 	})
@@ -154,7 +155,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		}, 1, 10)
 
 		delta := 0
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
 	})
@@ -176,8 +177,8 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		}, 1, maxNodes)
 
 		exp := fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			numberOfNodes, numberOfNodes+delta, ng.MaxSize())
-		err := ng.IncreaseSize(delta)
+			numberOfNodes, numberOfNodes+delta, ng.MaxSize(context.Background()))
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase is too large")
 	})
 }
@@ -213,7 +214,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -232,7 +233,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		}, 1, 10)
 
 		delta := 1
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be negative, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease must be negative")
@@ -255,7 +256,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		delta := 0
 		exp := fmt.Errorf("delta must be negative, have: %d", delta)
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease must be negative")
 	})
 
@@ -275,8 +276,8 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		}, 1, 5)
 
 		exp := fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
-			numberOfNodes, numberOfNodes+delta, ng.MinSize())
-		err := ng.DecreaseTargetSize(delta)
+			numberOfNodes, numberOfNodes+delta, ng.MinSize(context.Background()))
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease is too small")
 	})
 }
@@ -327,7 +328,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.NoError(t, err)
 	})
 
@@ -370,7 +371,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			errors.New("random error"),
 		).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.Error(t, err)
 	})
 }
@@ -449,7 +450,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 			},
 		}
 
-		nodes, err := ng.Nodes()
+		nodes, err := ng.Nodes(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, exp, nodes, "nodes do not match")
 	})
@@ -458,7 +459,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 		client := &civoClientMock{}
 		ng := testNodeGroup(client, nil, 1, 10)
 
-		_, err := ng.Nodes()
+		_, err := ng.Nodes(context.Background())
 		assert.Error(t, err, "Nodes() should return an error")
 	})
 }
@@ -474,7 +475,7 @@ func TestNodeGroup_Debug(t *testing.T) {
 		).Once()
 
 		ng := testNodeGroup(client, &civocloud.KubernetesPool{Count: 2}, 1, 200)
-		d := ng.Debug()
+		d := ng.Debug(context.Background())
 		exp := "id: 1 (min:1 max:200)"
 		assert.Equal(t, exp, d, "debug string do not match")
 	})
@@ -491,7 +492,7 @@ func TestNodeGroup_Exist(t *testing.T) {
 		).Once()
 
 		ng := testNodeGroup(client, &civocloud.KubernetesPool{Count: 3}, 1, 200)
-		exist := ng.Exist()
+		exist := ng.Exist(context.Background())
 		assert.Equal(t, true, exist, "node group should exist")
 	})
 
@@ -505,7 +506,7 @@ func TestNodeGroup_Exist(t *testing.T) {
 		).Once()
 
 		ng := testNodeGroup(client, nil, 1, 200)
-		exist := ng.Exist()
+		exist := ng.Exist(context.Background())
 		assert.Equal(t, false, exist, "node group should not exist")
 	})
 }
@@ -538,7 +539,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 			Region: "test",
 		}, 1, 10)
 
-		nodeInfo, err := ng.TemplateNodeInfo()
+		nodeInfo, err := ng.TemplateNodeInfo(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, len(nodeInfo.Pods()), 1, "should have one template pod")
 		assert.Equal(t, nodeInfo.Node().Status.Capacity.Cpu().ToDec().Value(), int64(1000), "should match cpu capacity ")

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstack
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -70,7 +71,7 @@ func (provider *cloudStackCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (provider *cloudStackCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (provider *cloudStackCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	asg := provider.manager.asg
 	return []cloudprovider.NodeGroup{asg}
 }
@@ -78,7 +79,7 @@ func (provider *cloudStackCloudProvider) NodeGroups() []cloudprovider.NodeGroup 
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred.
-func (provider *cloudStackCloudProvider) NodeGroupForNode(node *v1.Node) (cloudprovider.NodeGroup, error) {
+func (provider *cloudStackCloudProvider) NodeGroupForNode(ctx context.Context, node *v1.Node) (cloudprovider.NodeGroup, error) {
 	ng, err := provider.manager.clusterForNode(node)
 	if err != nil {
 		return nil, err
@@ -90,54 +91,54 @@ func (provider *cloudStackCloudProvider) NodeGroupForNode(node *v1.Node) (cloudp
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (provider *cloudStackCloudProvider) HasInstance(node *v1.Node) (bool, error) {
+func (provider *cloudStackCloudProvider) HasInstance(ctx context.Context, node *v1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (provider *cloudStackCloudProvider) Cleanup() error {
+func (provider *cloudStackCloudProvider) Cleanup(ctx context.Context) error {
 	return provider.manager.cleanup()
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
-func (provider *cloudStackCloudProvider) Refresh() error {
+func (provider *cloudStackCloudProvider) Refresh(ctx context.Context) error {
 	return provider.manager.refresh()
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
-func (provider *cloudStackCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (provider *cloudStackCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return availableMachineTypes, nil
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (provider *cloudStackCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (provider *cloudStackCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return provider.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (provider *cloudStackCloudProvider) GPULabel() string {
+func (provider *cloudStackCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (provider *cloudStackCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (provider *cloudStackCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (provider *cloudStackCloudProvider) GetNodeGpuConfig(node *v1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(provider, node)
+func (provider *cloudStackCloudProvider) GetNodeGpuConfig(ctx context.Context, node *v1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), provider, node)
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (provider *cloudStackCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (provider *cloudStackCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (provider *cloudStackCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []v1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (provider *cloudStackCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string, taints []v1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstack
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -81,11 +82,11 @@ func TestName(t *testing.T) {
 }
 
 func TestNodeGroups(t *testing.T) {
-	asgs := provider.NodeGroups()
+	asgs := provider.NodeGroups(context.Background())
 	assert.Equal(t, 1, len(asgs))
 	assert.Equal(t, testConfig.clusterID, asgs[0].Id())
-	assert.Equal(t, testConfig.maxSize, asgs[0].MaxSize())
-	assert.Equal(t, testConfig.minSize, asgs[0].MinSize())
+	assert.Equal(t, testConfig.maxSize, asgs[0].MaxSize(context.Background()))
+	assert.Equal(t, testConfig.minSize, asgs[0].MinSize(context.Background()))
 }
 
 func testNodeExistsWithName(t *testing.T) {
@@ -94,11 +95,11 @@ func testNodeExistsWithName(t *testing.T) {
 			Name: "vm1",
 		},
 	}
-	asg, err := provider.NodeGroupForNode(node)
+	asg, err := provider.NodeGroupForNode(context.Background(), node)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, testConfig.clusterID, asg.Id())
-	assert.Equal(t, testConfig.maxSize, asg.MaxSize())
-	assert.Equal(t, testConfig.minSize, asg.MinSize())
+	assert.Equal(t, testConfig.maxSize, asg.MaxSize(context.Background()))
+	assert.Equal(t, testConfig.minSize, asg.MinSize(context.Background()))
 }
 
 func testNodeExistsWithoutName(t *testing.T) {
@@ -107,11 +108,11 @@ func testNodeExistsWithoutName(t *testing.T) {
 			Name: "vm1",
 		},
 	}
-	asg, err := provider.NodeGroupForNode(node)
+	asg, err := provider.NodeGroupForNode(context.Background(), node)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, testConfig.clusterID, asg.Id())
-	assert.Equal(t, testConfig.maxSize, asg.MaxSize())
-	assert.Equal(t, testConfig.minSize, asg.MinSize())
+	assert.Equal(t, testConfig.maxSize, asg.MaxSize(context.Background()))
+	assert.Equal(t, testConfig.minSize, asg.MinSize(context.Background()))
 }
 
 func testNodeNotExistWithName(t *testing.T) {
@@ -120,7 +121,7 @@ func testNodeNotExistWithName(t *testing.T) {
 			Name: "vm5",
 		},
 	}
-	_, err := provider.NodeGroupForNode(node)
+	_, err := provider.NodeGroupForNode(context.Background(), node)
 	fmt.Println(provider.manager.asg.cluster)
 	fmt.Println(err)
 	assert.NotEqual(t, nil, err)
@@ -134,7 +135,7 @@ func testNodeNotExistWithoutName(t *testing.T) {
 			},
 		},
 	}
-	_, err := provider.NodeGroupForNode(node)
+	_, err := provider.NodeGroupForNode(context.Background(), node)
 	fmt.Println(provider.manager.asg.cluster)
 	fmt.Println(err)
 	assert.NotEqual(t, nil, err)
@@ -148,35 +149,35 @@ func TestNodeGroupForNode(t *testing.T) {
 }
 
 func TestGetAvailableMachineTypes(t *testing.T) {
-	types, err := provider.GetAvailableMachineTypes()
+	types, err := provider.GetAvailableMachineTypes(context.Background())
 	assert.Equal(t, availableMachineTypes, types)
 	assert.Equal(t, nil, err)
 }
 
 func TestGPULabel(t *testing.T) {
-	assert.Equal(t, GPULabel, provider.GPULabel())
+	assert.Equal(t, GPULabel, provider.GPULabel(context.Background()))
 }
 
 func TestGetAvailableGPUTypes(t *testing.T) {
-	assert.Equal(t, availableGPUTypes, provider.GetAvailableGPUTypes())
+	assert.Equal(t, availableGPUTypes, provider.GetAvailableGPUTypes(context.Background()))
 }
 
 func TestPricing(t *testing.T) {
-	_, err := provider.Pricing()
+	_, err := provider.Pricing(context.Background())
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
 func TestNewNodeGroup(t *testing.T) {
-	_, err := provider.NewNodeGroup("machineType", map[string]string{}, map[string]string{}, []v1.Taint{}, map[string]resource.Quantity{})
+	_, err := provider.NewNodeGroup(context.Background(), "machineType", map[string]string{}, map[string]string{}, []v1.Taint{}, map[string]resource.Quantity{})
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
 func TestCleanup(t *testing.T) {
-	assert.Equal(t, nil, provider.Cleanup())
+	assert.Equal(t, nil, provider.Cleanup(context.Background()))
 }
 
 func TestGetResourceLimiter(t *testing.T) {
-	rl, err := provider.GetResourceLimiter()
+	rl, err := provider.GetResourceLimiter(context.Background())
 	assert.Equal(t, &cloudprovider.ResourceLimiter{}, rl)
 	assert.Equal(t, nil, err)
 }
@@ -184,6 +185,6 @@ func TestGetResourceLimiter(t *testing.T) {
 func TestRefresh(t *testing.T) {
 	asg := provider.manager.asg
 	asg.cluster = createScaleUpClusterDetails()
-	assert.Equal(t, nil, provider.Refresh())
+	assert.Equal(t, nil, provider.Refresh(context.Background()))
 	assert.Equal(t, createClusterDetails(), asg.cluster)
 }

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstack
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -178,8 +179,8 @@ func TestFetchCluster(t *testing.T) {
 	assert.GreaterOrEqual(t, int64(time.Since(start)), int64(200*time.Millisecond))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, testConfig.clusterID, asg.Id())
-	assert.Equal(t, testConfig.maxSize, asg.MaxSize())
-	assert.Equal(t, testConfig.minSize, asg.MinSize())
+	assert.Equal(t, testConfig.maxSize, asg.MaxSize(context.Background()))
+	assert.Equal(t, testConfig.minSize, asg.MinSize(context.Background()))
 	assert.Nil(t, asg.cluster.VirtualMachineMap[""])
 	s.AssertExpectations(t)
 }

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -37,30 +38,30 @@ type asg struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (asg *asg) MaxSize() int {
+func (asg *asg) MaxSize(ctx context.Context) int {
 	return asg.cluster.Maxsize
 }
 
 // MinSize returns minimum size of the node group.
-func (asg *asg) MinSize() int {
+func (asg *asg) MinSize(ctx context.Context) int {
 	return asg.cluster.Minsize
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (asg *asg) TargetSize() (int, error) {
+func (asg *asg) TargetSize(ctx context.Context) (int, error) {
 	return asg.cluster.WorkerCount, nil
 }
 
 // IncreaseSize increases cluster size
-func (asg *asg) IncreaseSize(delta int) error {
+func (asg *asg) IncreaseSize(ctx context.Context, delta int) error {
 	klog.Infof("Increase Cluster : %s by %d", asg.cluster.ID, delta)
 	if delta <= 0 {
 		return fmt.Errorf("Delta must be positive")
 	}
 	newSize := asg.cluster.WorkerCount + delta
-	if newSize > asg.MaxSize() {
-		return fmt.Errorf("Delta too large - Wanted : %d Max : %d Have : %d", newSize, asg.MaxSize(), asg.cluster.WorkerCount)
+	if newSize > asg.MaxSize(context.TODO()) {
+		return fmt.Errorf("Delta too large - Wanted : %d Max : %d Have : %d", newSize, asg.MaxSize(context.TODO()), asg.cluster.WorkerCount)
 	}
 
 	cluster, err := asg.manager.scaleCluster(asg.cluster.ID, asg.cluster.WorkerCount+delta)
@@ -72,7 +73,7 @@ func (asg *asg) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (asg *asg) AtomicIncreaseSize(delta int) error {
+func (asg *asg) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -81,7 +82,7 @@ func (asg *asg) AtomicIncreaseSize(delta int) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes if the size
 // when there is an option to just decrease the target.
-func (asg *asg) DecreaseTargetSize(delta int) error {
+func (asg *asg) DecreaseTargetSize(ctx context.Context, delta int) error {
 	return errors.NewAutoscalerError(errors.CloudProviderError, "CloudProvider does not support DecreaseTargetSize")
 }
 
@@ -99,8 +100,8 @@ func (asg *asg) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (asg *asg) DeleteNodes(nodes []*apiv1.Node) error {
-	if asg.cluster.WorkerCount-len(nodes) < asg.MinSize() {
+func (asg *asg) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
+	if asg.cluster.WorkerCount-len(nodes) < asg.MinSize(context.TODO()) {
 		return fmt.Errorf("Goes below minsize. Can not delete %v nodes", len(nodes))
 	}
 
@@ -124,7 +125,7 @@ func (asg *asg) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (asg *asg) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (asg *asg) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -134,13 +135,13 @@ func (asg *asg) Id() string {
 }
 
 // Debug returns cluster id.
-func (asg *asg) Debug() string {
+func (asg *asg) Debug(ctx context.Context) string {
 	js, _ := json.Marshal(asg.cluster)
 	return fmt.Sprintf("Debug : %s", js)
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (asg *asg) Nodes() ([]cloudprovider.Instance, error) {
+func (asg *asg) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	instances := make([]cloudprovider.Instance, len(asg.cluster.VirtualMachines))
 	for i := 0; i < len(asg.cluster.VirtualMachines); i++ {
 		instances[i] = cloudprovider.Instance{
@@ -152,34 +153,34 @@ func (asg *asg) Nodes() ([]cloudprovider.Instance, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (asg *asg) Exist() bool {
+func (asg *asg) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (asg *asg) Autoprovisioned() bool {
+func (asg *asg) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // Create creates the node group on the cloud provider side.
-func (asg *asg) Create() (cloudprovider.NodeGroup, error) {
+func (asg *asg) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (asg *asg) Delete() error {
+func (asg *asg) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (asg *asg) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (asg *asg) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (asg *asg) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (asg *asg) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstack
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -43,18 +44,18 @@ func createASG() *asg {
 
 func TestMaxSize(t *testing.T) {
 	asg := createASG()
-	assert.Equal(t, testConfig.maxSize, asg.MaxSize())
+	assert.Equal(t, testConfig.maxSize, asg.MaxSize(context.Background()))
 }
 
 func TestMinSize(t *testing.T) {
 	asg := createASG()
-	assert.Equal(t, testConfig.minSize, asg.MinSize())
+	assert.Equal(t, testConfig.minSize, asg.MinSize(context.Background()))
 }
 
 func TestTargetSize(t *testing.T) {
 	clusterDetails := createClusterDetails()
 	asg := createASG()
-	targetSize, err := asg.TargetSize()
+	targetSize, err := asg.TargetSize(context.Background())
 	assert.Equal(t, clusterDetails.WorkerCount, targetSize)
 	assert.Equal(t, nil, err)
 }
@@ -67,7 +68,7 @@ func TestId(t *testing.T) {
 func TestNodes(t *testing.T) {
 	clusterDetails := createClusterDetails()
 	asg := createASG()
-	nodes, err := asg.Nodes()
+	nodes, err := asg.Nodes(context.Background())
 	assert.Equal(t, len(clusterDetails.VirtualMachines), len(nodes))
 	for i, node := range nodes {
 		assert.Equal(t, clusterDetails.VirtualMachines[i].ID, node.Id)
@@ -77,28 +78,28 @@ func TestNodes(t *testing.T) {
 
 func TestExist(t *testing.T) {
 	asg := createASG()
-	assert.Equal(t, true, asg.Exist())
+	assert.Equal(t, true, asg.Exist(context.Background()))
 }
 
 func TestAutoprovisioned(t *testing.T) {
 	asg := createASG()
-	assert.Equal(t, false, asg.Autoprovisioned())
+	assert.Equal(t, false, asg.Autoprovisioned(context.Background()))
 }
 
 func TestCreate(t *testing.T) {
 	asg := createASG()
-	_, err := asg.Create()
+	_, err := asg.Create(context.Background())
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
 func TestDelete(t *testing.T) {
 	asg := createASG()
-	assert.Equal(t, cloudprovider.ErrNotImplemented, asg.Delete())
+	assert.Equal(t, cloudprovider.ErrNotImplemented, asg.Delete(context.Background()))
 }
 
 func TestTemplateNodeInfo(t *testing.T) {
 	asg := createASG()
-	_, err := asg.TemplateNodeInfo()
+	_, err := asg.TemplateNodeInfo(context.Background())
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
@@ -107,12 +108,12 @@ func testIncreaseSizeError(t *testing.T) {
 
 	// Above the max size
 	asg := createASG()
-	err := asg.IncreaseSize(100)
+	err := asg.IncreaseSize(context.Background(), 100)
 	assert.Equal(t, clusterDetails, asg.cluster)
 	assert.NotEqual(t, nil, err)
 
 	// Delta must be positive
-	err = asg.IncreaseSize(-1)
+	err = asg.IncreaseSize(context.Background(), -1)
 	assert.Equal(t, clusterDetails, asg.cluster)
 	assert.NotEqual(t, nil, err)
 }
@@ -124,7 +125,7 @@ func testIncreaseSizeSuccess(t *testing.T) {
 	delta := clusterDetails.WorkerCount - scaleDownClusterDetails.WorkerCount
 	asg := createASG()
 	fmt.Println(asg.cluster.WorkerCount)
-	err := asg.IncreaseSize(delta)
+	err := asg.IncreaseSize(context.Background(), delta)
 	assert.Equal(t, scaleUpClusterDetails, asg.cluster)
 	assert.Equal(t, nil, err)
 }
@@ -136,7 +137,7 @@ func TestIncreaseSize(t *testing.T) {
 
 func TestDecreaseTargetSize(t *testing.T) {
 	asg := createASG()
-	err := asg.DecreaseTargetSize(1)
+	err := asg.DecreaseTargetSize(context.Background(), 1)
 	assert.NotEqual(t, nil, err)
 }
 
@@ -170,7 +171,7 @@ func testDeleteNodesError(t *testing.T) {
 
 	// Can't go below minSize
 	asg := createASG()
-	err := asg.DeleteNodes(nodes)
+	err := asg.DeleteNodes(context.Background(), nodes)
 	clusterDetails := createClusterDetails()
 	assert.Equal(t, clusterDetails, asg.cluster)
 	assert.NotEqual(t, nil, err)
@@ -178,7 +179,7 @@ func testDeleteNodesError(t *testing.T) {
 
 func testDeleteNodesSuccess(t *testing.T) {
 	asg := createASG()
-	err := asg.DeleteNodes([]*apiv1.Node{
+	err := asg.DeleteNodes(context.Background(), []*apiv1.Node{
 		{
 			Status: v1.NodeStatus{
 				NodeInfo: v1.NodeSystemInfo{

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterapi
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -811,12 +812,12 @@ func (c *machineController) nodeGroups() ([]cloudprovider.NodeGroup, error) {
 			if isScalableResourceAndPaused(*r) {
 				// if the resource is paused from reconciling by cluster api controllers, we don't want to include it
 				// as an active node group.
-				klog.V(4).Infof("discovered a paused node group: %s", ng.Debug())
+				klog.V(4).Infof("discovered a paused node group: %s", ng.Debug(context.TODO()))
 				continue
 			}
 
 			nodegroups = append(nodegroups, ng)
-			klog.V(4).Infof("discovered node group: %s", ng.Debug())
+			klog.V(4).Infof("discovered node group: %s", ng.Debug(context.TODO()))
 		}
 	}
 	return nodegroups, nil

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -746,7 +746,7 @@ func TestControllerNodeGroupsNodeCount(t *testing.T) {
 		}
 
 		for i := range nodegroups {
-			nodes, err := nodegroups[i].Nodes()
+			nodes, err := nodegroups[i].Nodes(context.Background())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -873,7 +873,7 @@ func TestControllerMachineSetNodeNamesWithoutLinkage(t *testing.T) {
 	}
 
 	ng := nodegroups[0]
-	nodeNames, err := ng.Nodes()
+	nodeNames, err := ng.Nodes(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -915,7 +915,7 @@ func TestControllerMachineSetNodeNamesUsingProviderID(t *testing.T) {
 	}
 
 	ng := nodegroups[0]
-	nodeNames, err := ng.Nodes()
+	nodeNames, err := ng.Nodes(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -971,7 +971,7 @@ func TestControllerMachineSetNodeNamesUsingStatusNodeRefName(t *testing.T) {
 		t.Fatalf("expected 1 nodegroup, got %d", l)
 	}
 
-	nodeNames, err := nodegroups[0].Nodes()
+	nodeNames, err := nodegroups[0].Nodes(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterapi
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -52,11 +53,11 @@ type nodegroup struct {
 
 var _ cloudprovider.NodeGroup = (*nodegroup)(nil)
 
-func (ng *nodegroup) MinSize() int {
+func (ng *nodegroup) MinSize(ctx context.Context) int {
 	return ng.scalableResource.MinSize()
 }
 
-func (ng *nodegroup) MaxSize() int {
+func (ng *nodegroup) MaxSize(ctx context.Context) int {
 	return ng.scalableResource.MaxSize()
 }
 
@@ -65,7 +66,7 @@ func (ng *nodegroup) MaxSize() int {
 // moment but should be equal to Size() once everything stabilizes
 // (new nodes finish startup and registration or removed nodes are
 // deleted completely). Implementation required.
-func (ng *nodegroup) TargetSize() (int, error) {
+func (ng *nodegroup) TargetSize(ctx context.Context) (int, error) {
 	replicas, found, err := unstructured.NestedInt64(ng.scalableResource.unstructured.Object, "spec", "replicas")
 	if err != nil {
 		return 0, errors.Wrap(err, "error getting replica count")
@@ -80,7 +81,7 @@ func (ng *nodegroup) TargetSize() (int, error) {
 // you need to explicitly name it and use DeleteNode. This function
 // should wait until node group size is updated. Implementation
 // required.
-func (ng *nodegroup) IncreaseSize(delta int) error {
+func (ng *nodegroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -94,7 +95,7 @@ func (ng *nodegroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ng *nodegroup) AtomicIncreaseSize(delta int) error {
+func (ng *nodegroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -102,7 +103,7 @@ func (ng *nodegroup) AtomicIncreaseSize(delta int) error {
 // either on failure or if the given node doesn't belong to this node
 // group. This function should wait until node group size is updated.
 // Implementation required.
-func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
+func (ng *nodegroup) DeleteNodes(ctx context.Context, nodes []*corev1.Node) error {
 	ng.machineController.accessLock.Lock()
 	defer ng.machineController.accessLock.Unlock()
 
@@ -112,7 +113,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	}
 
 	// if we are at minSize already we fail early.
-	if replicas <= ng.MinSize() {
+	if replicas <= ng.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
@@ -138,8 +139,8 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	// Step 2: if deleting len(nodes) would make the replica count
 	// < minSize, then the request to delete that many nodes is bogus
 	// and we fail fast.
-	if replicas-len(nodes) < ng.MinSize() {
-		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d", len(nodes), ng.Id(), replicas, ng.MinSize())
+	if replicas-len(nodes) < ng.MinSize(context.TODO()) {
+		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d", len(nodes), ng.Id(), replicas, ng.MinSize(context.TODO()))
 	}
 
 	// Step 3: when a backing Machine exists, mark it as a deletion candidate
@@ -221,7 +222,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ng *nodegroup) ForceDeleteNodes(nodes []*corev1.Node) error {
+func (ng *nodegroup) ForceDeleteNodes(ctx context.Context, nodes []*corev1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -231,7 +232,7 @@ func (ng *nodegroup) ForceDeleteNodes(nodes []*corev1.Node) error {
 // yet fulfilled. Delta should be negative. It is assumed that cloud
 // nodegroup will not delete the existing nodes when there is an option
 // to just decrease the target. Implementation required.
-func (ng *nodegroup) DecreaseTargetSize(delta int) error {
+func (ng *nodegroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
@@ -241,7 +242,7 @@ func (ng *nodegroup) DecreaseTargetSize(delta int) error {
 		return err
 	}
 
-	nodes, err := ng.Nodes()
+	nodes, err := ng.Nodes(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -275,17 +276,17 @@ func (ng *nodegroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (ng *nodegroup) Debug() string {
+func (ng *nodegroup) Debug(ctx context.Context) string {
 	replicas, err := ng.scalableResource.Replicas()
 	if err != nil {
-		return fmt.Sprintf("%s (min: %d, max: %d, replicas: %v)", ng.Id(), ng.MinSize(), ng.MaxSize(), err)
+		return fmt.Sprintf("%s (min: %d, max: %d, replicas: %v)", ng.Id(), ng.MinSize(context.TODO()), ng.MaxSize(context.TODO()), err)
 	}
-	return fmt.Sprintf(debugFormat, ng.Id(), ng.MinSize(), ng.MaxSize(), replicas)
+	return fmt.Sprintf(debugFormat, ng.Id(), ng.MinSize(context.TODO()), ng.MaxSize(context.TODO()), replicas)
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
 // This includes instances that might have not become a kubernetes node yet.
-func (ng *nodegroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *nodegroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	providerIDs, err := ng.scalableResource.ProviderIDs()
 	if err != nil {
 		return nil, err
@@ -386,7 +387,7 @@ func (ng *nodegroup) Nodes() ([]cloudprovider.Instance, error) {
 // allocatable information as well as all pods that are started on the
 // node by default, using manifest (most likely only kube-proxy).
 // Implementation optional.
-func (ng *nodegroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *nodegroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	if !ng.scalableResource.CanScaleFromZero() {
 		return nil, cloudprovider.ErrNotImplemented
 	}
@@ -446,7 +447,7 @@ func (ng *nodegroup) buildTemplateLabels(nodeName string, nsi *corev1.NodeSystem
 	// - Generic/default labels set in the environment of the cluster autoscaler
 	labels := cloudprovider.JoinStringMaps(buildGenericLabels(nodeName), nsiLabels, ng.scalableResource.Labels())
 
-	nodes, err := ng.Nodes()
+	nodes, err := ng.Nodes(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -467,14 +468,14 @@ func (ng *nodegroup) buildTemplateLabels(nodeName string, nsi *corev1.NodeSystem
 // Exist checks if the node group really exists on the cloud nodegroup
 // side. Allows to tell the theoretical node group from the real one.
 // Implementation required.
-func (ng *nodegroup) Exist() bool {
+func (ng *nodegroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud nodegroup side.
 // Implementation optional.
-func (ng *nodegroup) Create() (cloudprovider.NodeGroup, error) {
-	if ng.Exist() {
+func (ng *nodegroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
+	if ng.Exist(context.TODO()) {
 		return nil, cloudprovider.ErrAlreadyExist
 	}
 	return nil, cloudprovider.ErrNotImplemented
@@ -483,20 +484,20 @@ func (ng *nodegroup) Create() (cloudprovider.NodeGroup, error) {
 // Delete deletes the node group on the cloud nodegroup side. This will
 // be executed only for autoprovisioned node groups, once their size
 // drops to 0. Implementation optional.
-func (ng *nodegroup) Delete() error {
+func (ng *nodegroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
 // An autoprovisioned group was created by CA and can be deleted when
 // scaled to 0.
-func (ng *nodegroup) Autoprovisioned() bool {
+func (ng *nodegroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (ng *nodegroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *nodegroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	options := ng.scalableResource.autoscalingOptions
 	if options == nil || len(options) == 0 {
 		return &defaults, nil

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -180,35 +180,35 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 			t.Errorf("expected %q, got %q", testConfig.spec.namespace, ng.scalableResource.Namespace())
 		}
 
-		if ng.MinSize() != tc.minSize {
-			t.Errorf("expected %v, got %v", tc.minSize, ng.MinSize())
+		if ng.MinSize(context.Background()) != tc.minSize {
+			t.Errorf("expected %v, got %v", tc.minSize, ng.MinSize(context.Background()))
 		}
 
-		if ng.MaxSize() != tc.maxSize {
-			t.Errorf("expected %v, got %v", tc.maxSize, ng.MaxSize())
+		if ng.MaxSize(context.Background()) != tc.maxSize {
+			t.Errorf("expected %v, got %v", tc.maxSize, ng.MaxSize(context.Background()))
 		}
 
 		if ng.Id() != expectedID {
 			t.Errorf("expected %q, got %q", expectedID, ng.Id())
 		}
 
-		if ng.Debug() != expectedDebug {
-			t.Errorf("expected %q, got %q", expectedDebug, ng.Debug())
+		if ng.Debug(context.Background()) != expectedDebug {
+			t.Errorf("expected %q, got %q", expectedDebug, ng.Debug(context.Background()))
 		}
 
-		if exists := ng.Exist(); !exists {
+		if exists := ng.Exist(context.Background()); !exists {
 			t.Errorf("expected %t, got %t", true, exists)
 		}
 
-		if _, err := ng.Create(); err != cloudprovider.ErrAlreadyExist {
+		if _, err := ng.Create(context.Background()); err != cloudprovider.ErrAlreadyExist {
 			t.Error("expected error")
 		}
 
-		if err := ng.Delete(); err != cloudprovider.ErrNotImplemented {
+		if err := ng.Delete(context.Background()); err != cloudprovider.ErrNotImplemented {
 			t.Error("expected error")
 		}
 
-		if result := ng.Autoprovisioned(); result {
+		if result := ng.Autoprovisioned(context.Background()); result {
 			t.Errorf("expected %t, got %t", false, result)
 		}
 
@@ -277,7 +277,7 @@ func TestNodeGroupIncreaseSizeErrors(t *testing.T) {
 		}
 
 		ng := nodegroups[0].(*nodegroup)
-		currReplicas, err := ng.TargetSize()
+		currReplicas, err := ng.TargetSize(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -288,7 +288,7 @@ func TestNodeGroupIncreaseSizeErrors(t *testing.T) {
 
 		errors := len(tc.errorMsg) > 0
 
-		err = ng.IncreaseSize(tc.delta)
+		err = ng.IncreaseSize(context.Background(), tc.delta)
 		if errors && err == nil {
 			t.Fatal("expected an error")
 		}
@@ -375,7 +375,7 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 		}
 
 		ng := nodegroups[0].(*nodegroup)
-		currReplicas, err := ng.TargetSize()
+		currReplicas, err := ng.TargetSize(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -384,7 +384,7 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 			t.Errorf("initially expected %v, got %v", tc.initial, currReplicas)
 		}
 
-		if err := ng.IncreaseSize(tc.delta); err != nil {
+		if err := ng.IncreaseSize(context.Background(), tc.delta); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -569,7 +569,7 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			if ng == nil {
 				return false, nil
 			}
-			currReplicas, err := ng.TargetSize()
+			currReplicas, err := ng.TargetSize(context.Background())
 			if err != nil {
 				return true, fmt.Errorf("unexpected error: %v", err)
 			}
@@ -578,7 +578,7 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 				return true, fmt.Errorf("expected %v, got %v", tc.initial+tc.targetSizeIncrement, currReplicas)
 			}
 
-			if err := ng.DecreaseTargetSize(tc.delta); (err != nil) != tc.expectedError {
+			if err := ng.DecreaseTargetSize(context.Background(), tc.delta); (err != nil) != tc.expectedError {
 				return true, fmt.Errorf("expected error: %v, got: %v", tc.expectedError, err)
 			}
 
@@ -783,7 +783,7 @@ func TestNodeGroupDecreaseSizeErrors(t *testing.T) {
 		}
 
 		ng := nodegroups[0].(*nodegroup)
-		currReplicas, err := ng.TargetSize()
+		currReplicas, err := ng.TargetSize(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -794,7 +794,7 @@ func TestNodeGroupDecreaseSizeErrors(t *testing.T) {
 
 		errors := len(tc.errorMsg) > 0
 
-		err = ng.DecreaseTargetSize(tc.delta)
+		err = ng.DecreaseTargetSize(context.Background(), tc.delta)
 		if errors && err == nil {
 			t.Fatal("expected an error")
 		}
@@ -871,7 +871,7 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 		}
 
 		ng := nodegroups[0].(*nodegroup)
-		nodeNames, err := ng.Nodes()
+		nodeNames, err := ng.Nodes(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -890,7 +890,7 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 			}
 		}
 
-		if err := ng.DeleteNodes(testConfig.nodes[5:]); err != nil {
+		if err := ng.DeleteNodes(context.Background(), testConfig.nodes[5:]); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 
@@ -977,7 +977,7 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 		}
 
 		// Deleting nodes that are not in ng0 should fail.
-		err0 := ng0.DeleteNodes(testConfig1.nodes)
+		err0 := ng0.DeleteNodes(context.Background(), testConfig1.nodes)
 		if err0 == nil {
 			t.Error("expected an error")
 		}
@@ -989,7 +989,7 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 		}
 
 		// Deleting nodes that are not in ng1 should fail.
-		err1 := ng1.DeleteNodes(testConfig0.nodes)
+		err1 := ng1.DeleteNodes(context.Background(), testConfig0.nodes)
 		if err1 == nil {
 			t.Error("expected an error")
 		}
@@ -1000,13 +1000,13 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 
 		// Deleting from correct node group should fail because
 		// replicas would become <= 0.
-		if err := ng0.DeleteNodes(testConfig0.nodes); err == nil {
+		if err := ng0.DeleteNodes(context.Background(), testConfig0.nodes); err == nil {
 			t.Error("expected error")
 		}
 
 		// Deleting from correct node group should fail because
 		// replicas would become <= 0.
-		if err := ng1.DeleteNodes(testConfig1.nodes); err == nil {
+		if err := ng1.DeleteNodes(context.Background(), testConfig1.nodes); err == nil {
 			t.Error("expected error")
 		}
 	}
@@ -1099,7 +1099,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		}
 
 		ng := nodegroups[0].(*nodegroup)
-		nodeNames, err := ng.Nodes()
+		nodeNames, err := ng.Nodes(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1111,8 +1111,8 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		if len(nodeNames) <= expectedSize {
 			t.Fatalf("expected more nodes than the expected size: %d <= %d", len(nodeNames), expectedSize)
 		}
-		if ng.MinSize() >= expectedSize {
-			t.Fatalf("expected min size to be less than expected size: %d >= %d", ng.MinSize(), expectedSize)
+		if ng.MinSize(context.Background()) >= expectedSize {
+			t.Fatalf("expected min size to be less than expected size: %d >= %d", ng.MinSize(context.Background()), expectedSize)
 		}
 
 		if len(nodeNames) != len(testConfig.nodes) {
@@ -1140,7 +1140,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		}
 
 		// Delete all nodes over the expectedSize
-		if err := ng.DeleteNodes(nodesToBeDeleted); err != nil {
+		if err := ng.DeleteNodes(context.Background(), nodesToBeDeleted); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -1158,7 +1158,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 			if err != nil {
 				return false, err
 			}
-			targetSize, err := nodegroups[0].TargetSize()
+			targetSize, err := nodegroups[0].TargetSize(context.Background())
 			if err != nil {
 				return false, err
 			}
@@ -1175,7 +1175,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		ng = nodegroups[0].(*nodegroup)
 
 		// Check the nodegroup is at the expected size
-		actualSize, err := ng.TargetSize()
+		actualSize, err := ng.TargetSize(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1204,7 +1204,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		// Attempt to delete the nodes again which verifies
 		// that nodegroup.DeleteNodes() skips over nodes that
 		// have a non-nil DeletionTimestamp value.
-		if err := ng.DeleteNodes(nodesToBeDeleted); err != nil {
+		if err := ng.DeleteNodes(context.Background(), nodesToBeDeleted); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -1270,7 +1270,7 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 		}
 
 		ng := nodegroups[0].(*nodegroup)
-		nodeNames, err := ng.Nodes()
+		nodeNames, err := ng.Nodes(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1282,8 +1282,8 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 		if len(nodeNames) <= expectedSize {
 			t.Fatalf("expected more nodes than the expected size: %d <= %d", len(nodeNames), expectedSize)
 		}
-		if ng.MinSize() >= expectedSize {
-			t.Fatalf("expected min size to be less than expected size: %d >= %d", ng.MinSize(), expectedSize)
+		if ng.MinSize(context.Background()) >= expectedSize {
+			t.Fatalf("expected min size to be less than expected size: %d >= %d", ng.MinSize(context.Background()), expectedSize)
 		}
 
 		if len(nodeNames) != len(testConfig.nodes) {
@@ -1325,7 +1325,7 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 		}
 
 		for node, nodeGroup := range nodeToNodeGroup {
-			if err := nodeGroup.DeleteNodes([]*corev1.Node{node}); err != nil {
+			if err := nodeGroup.DeleteNodes(context.Background(), []*corev1.Node{node}); err != nil {
 				t.Fatalf("unexpected error deleting node: %v", err)
 			}
 		}
@@ -1424,7 +1424,7 @@ func TestNodeGroupWithFailedMachine(t *testing.T) {
 		}
 
 		ng := nodegroups[0]
-		nodeNames, err := ng.Nodes()
+		nodeNames, err := ng.Nodes(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1780,7 +1780,7 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 		}
 
 		ng := nodegroups[0]
-		nodeInfo, err := ng.TemplateNodeInfo()
+		nodeInfo, err := ng.TemplateNodeInfo(context.Background())
 		if config.expectedErr != nil {
 			if err != config.expectedErr {
 				t.Fatalf("expected error: %v, but got: %v", config.expectedErr, err)
@@ -1971,7 +1971,7 @@ func TestNodeGroupGetOptions(t *testing.T) {
 		}
 
 		ng := nodegroups[0]
-		opts, err := ng.GetOptions(defaultOptions)
+		opts, err := ng.GetOptions(context.Background(), defaultOptions)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOptions, opts)
 	}
@@ -2131,7 +2131,7 @@ func TestNodeGroupNodesInstancesStatus(t *testing.T) {
 		}
 
 		ng := nodegroups[0]
-		instances, err := ng.Nodes()
+		instances, err := ng.Nodes(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2326,7 +2326,7 @@ func TestNodeGroupMachinePoolDeleteNodes(t *testing.T) {
 					}
 				}
 
-				err = ng.DeleteNodes(nodesToDelete)
+				err = ng.DeleteNodes(context.Background(), nodesToDelete)
 				if tc.expectedError {
 					if err == nil {
 						t.Fatal("expected an error but got none")
@@ -2446,7 +2446,7 @@ func TestNodeGroupMachinePoolProviderIDList(t *testing.T) {
 				},
 			}
 
-			err = ng.DeleteNodes([]*corev1.Node{node})
+			err = ng.DeleteNodes(context.Background(), []*corev1.Node{node})
 			if tc.expectAllowed {
 				if err != nil {
 					t.Fatalf("expected scale-down to be allowed, got error: %v", err)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_processors.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_processors.go
@@ -17,9 +17,11 @@ limitations under the License.
 package clusterapi
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
-	"sigs.k8s.io/cluster-autoscaler/pkg/context"
+	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
 )
 
@@ -36,13 +38,13 @@ func NewScaleDownNodeUpgradeProcessor(c *machineController) *ScaleDownNodeUpgrad
 }
 
 // GetPodDestinationCandidates returns nodes as is no processing is required here
-func (p *ScaleDownNodeUpgradeProcessor) GetPodDestinationCandidates(ctx *context.AutoscalingContext,
+func (p *ScaleDownNodeUpgradeProcessor) GetPodDestinationCandidates(ctx *ca_context.AutoscalingContext,
 	nodes []*corev1.Node) ([]*corev1.Node, errors.AutoscalerError) {
 	return nodes, nil
 }
 
 // GetScaleDownCandidates returns filter nodes based on if scale down is enabled or disabled per nodegroup.
-func (p *ScaleDownNodeUpgradeProcessor) GetScaleDownCandidates(ctx *context.AutoscalingContext,
+func (p *ScaleDownNodeUpgradeProcessor) GetScaleDownCandidates(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext,
 	nodes []*corev1.Node) ([]*corev1.Node, errors.AutoscalerError) {
 	result := []*corev1.Node{}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterapi
 
 import (
+	"context"
 	"fmt"
 	"path"
 
@@ -67,11 +68,11 @@ func (p *provider) Name() string {
 	return p.providerName
 }
 
-func (p *provider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (p *provider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return p.resourceLimiter, nil
 }
 
-func (p *provider) NodeGroups() []cloudprovider.NodeGroup {
+func (p *provider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodegroups, err := p.controller.nodeGroups()
 	if err != nil {
 		klog.Errorf("error getting node groups: %v", err)
@@ -80,7 +81,7 @@ func (p *provider) NodeGroups() []cloudprovider.NodeGroup {
 	return nodegroups
 }
 
-func (p *provider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup, error) {
+func (p *provider) NodeGroupForNode(ctx context.Context, node *corev1.Node) (cloudprovider.NodeGroup, error) {
 	ng, err := p.controller.nodeGroupForNode(node)
 	if err != nil {
 		return nil, err
@@ -92,7 +93,7 @@ func (p *provider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup,
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (p *provider) HasInstance(node *corev1.Node) (bool, error) {
+func (p *provider) HasInstance(ctx context.Context, node *corev1.Node) (bool, error) {
 	machineID := node.Annotations[machineAnnotationKey]
 	ns := node.Annotations[clusterNamespaceAnnotationKey]
 
@@ -104,15 +105,16 @@ func (p *provider) HasInstance(node *corev1.Node) (bool, error) {
 	return false, fmt.Errorf("machine not found for node %s: %v", node.Name, err)
 }
 
-func (*provider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (*provider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
-func (*provider) GetAvailableMachineTypes() ([]string, error) {
+func (*provider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 func (*provider) NewNodeGroup(
+	ctx context.Context,
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
@@ -122,11 +124,11 @@ func (*provider) NewNodeGroup(
 	return nil, cloudprovider.ErrNotImplemented
 }
 
-func (*provider) Cleanup() error {
+func (*provider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-func (p *provider) Refresh() error {
+func (p *provider) Refresh(ctx context.Context) error {
 	return nil
 }
 
@@ -136,20 +138,20 @@ func (p *provider) GetInstanceID(node *corev1.Node) string {
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (p *provider) GetAvailableGPUTypes() map[string]struct{} {
+func (p *provider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	// TODO: implement this
 	return nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (p *provider) GPULabel() string {
+func (p *provider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (p *provider) GetNodeGpuConfig(node *corev1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(p, node)
+func (p *provider) GetNodeGpuConfig(ctx context.Context, node *corev1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), p, node)
 }
 
 func newProvider(

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterapi
 
 import (
+	"context"
 	"reflect"
 	"slices"
 	"testing"
@@ -38,7 +39,7 @@ func TestProviderConstructorProperties(t *testing.T) {
 		t.Errorf("expected %q, got %q", ProviderName, actual)
 	}
 
-	rl, err := provider.GetResourceLimiter()
+	rl, err := provider.GetResourceLimiter(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -47,11 +48,11 @@ func TestProviderConstructorProperties(t *testing.T) {
 		t.Errorf("expected %+v, got %+v", resourceLimits, rl)
 	}
 
-	if _, err := provider.Pricing(); err != cloudprovider.ErrNotImplemented {
+	if _, err := provider.Pricing(context.Background()); err != cloudprovider.ErrNotImplemented {
 		t.Errorf("expected an error")
 	}
 
-	machineTypes, err := provider.GetAvailableMachineTypes()
+	machineTypes, err := provider.GetAvailableMachineTypes(context.Background())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -59,25 +60,25 @@ func TestProviderConstructorProperties(t *testing.T) {
 		t.Errorf("expected 0, got %v", len(machineTypes))
 	}
 
-	if _, err := provider.NewNodeGroup("foo", nil, nil, nil, nil); err == nil {
+	if _, err := provider.NewNodeGroup(context.Background(), "foo", nil, nil, nil, nil); err == nil {
 		t.Error("expected an error")
 	}
 
-	if err := provider.Cleanup(); err != nil {
+	if err := provider.Cleanup(context.Background()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if err := provider.Refresh(); err != nil {
+	if err := provider.Refresh(context.Background()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	nodegroups := provider.NodeGroups()
+	nodegroups := provider.NodeGroups(context.Background())
 
 	if len(nodegroups) != 0 {
 		t.Errorf("expected 0, got %v", len(nodegroups))
 	}
 
-	ng, err := provider.NodeGroupForNode(&corev1.Node{
+	ng, err := provider.NodeGroupForNode(context.Background(), &corev1.Node{
 		TypeMeta: v1.TypeMeta{
 			Kind: "Node",
 		},
@@ -94,11 +95,11 @@ func TestProviderConstructorProperties(t *testing.T) {
 		t.Fatalf("unexpected nodegroup: %v", ng.Id())
 	}
 
-	if got := provider.GPULabel(); got != GPULabel {
+	if got := provider.GPULabel(context.Background()); got != GPULabel {
 		t.Fatalf("expected %q, got %q", GPULabel, got)
 	}
 
-	if got := len(provider.GetAvailableGPUTypes()); got != 0 {
+	if got := len(provider.GetAvailableGPUTypes(context.Background())); got != 0 {
 		t.Fatalf("expected 0 GPU types, got %d", got)
 	}
 }
@@ -131,7 +132,7 @@ func BenchmarkNodeGroups(b *testing.B) {
 	b.ResetTimer()
 	b.Run("NodeGroups", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			provider.NodeGroups()
+			provider.NodeGroups(context.Background())
 		}
 	})
 }
@@ -265,7 +266,7 @@ func TestNodeGroups(t *testing.T) {
 			t.Errorf("expected %q, got %q", ProviderName, actual)
 		}
 
-		observed := provider.NodeGroups()
+		observed := provider.NodeGroups(context.Background())
 		if len(observed) != tc.expectedNodeGroupCount {
 			t.Fatalf("unexpected node group length, expected: %d, observed %d", tc.expectedNodeGroupCount, observed)
 		}

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodegroup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package coreweave
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -48,29 +49,29 @@ func NewCoreWeaveNodeGroup(nodepool *CoreWeaveNodePool) *CoreWeaveNodeGroup {
 }
 
 // MaxSize returns the maximum size of the node group.
-func (ng *CoreWeaveNodeGroup) MaxSize() int {
+func (ng *CoreWeaveNodeGroup) MaxSize(ctx context.Context) int {
 	return ng.nodepool.GetMaxSize()
 }
 
 // MinSize returns the minimum size of the node group.
-func (ng *CoreWeaveNodeGroup) MinSize() int {
+func (ng *CoreWeaveNodeGroup) MinSize(ctx context.Context) int {
 	return ng.nodepool.GetMinSize()
 }
 
 // TargetSize returns the current target size of the node group.
-func (ng *CoreWeaveNodeGroup) TargetSize() (int, error) {
+func (ng *CoreWeaveNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return ng.nodepool.GetTargetSize(), nil
 }
 
 // IncreaseSize increases the size of the node group by the specified delta.
-func (ng *CoreWeaveNodeGroup) IncreaseSize(delta int) error {
+func (ng *CoreWeaveNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("Increasing size of node group %s by %d", ng.Name, delta)
 	return ng.nodepool.SetSize(ng.nodepool.GetTargetSize() + delta)
 }
 
 // AtomicIncreaseSize atomically increases the size of the node group by the specified delta.
 // This method is not implemented for CoreWeaveNodeGroup.
-func (ng *CoreWeaveNodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *CoreWeaveNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -80,7 +81,7 @@ func (ng *CoreWeaveNodeGroup) AtomicIncreaseSize(delta int) error {
 // target size of the node group accordingly.
 // If any check fails, it returns an error with a descriptive message.
 // If the nodes are successfully marked for removal, it returns nil.
-func (ng *CoreWeaveNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *CoreWeaveNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	ng.mutex.Lock()
 	defer ng.mutex.Unlock()
 	// Validate that the nodes belong to this node group
@@ -97,12 +98,12 @@ func (ng *CoreWeaveNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 
 // ForceDeleteNodes is not implemented for CoreWeaveNodeGroup.
 // node groups in CoreWeave do not support force deletion of nodes.
-func (ng *CoreWeaveNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ng *CoreWeaveNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DecreaseTargetSize decreases the target size of the node group by the specified delta.
-func (ng *CoreWeaveNodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *CoreWeaveNodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("Decreasing target size of node group %s by %d", ng.Name, delta)
 	if delta < 0 {
 		delta = -delta
@@ -116,12 +117,12 @@ func (ng *CoreWeaveNodeGroup) Id() string {
 }
 
 // Debug returns a debug string for the node group.
-func (ng *CoreWeaveNodeGroup) Debug() string {
+func (ng *CoreWeaveNodeGroup) Debug(ctx context.Context) string {
 	return ""
 }
 
 // Nodes returns the list of nodes in the node group.
-func (ng *CoreWeaveNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *CoreWeaveNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	// Return empty slice to avoid "not registered" warnings
 	return []cloudprovider.Instance{}, nil
 }
@@ -129,7 +130,7 @@ func (ng *CoreWeaveNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // TemplateNodeInfo returns a template NodeInfo for the node group.
 // This is used by the autoscaler to simulate what a new node would look like
 // when scaling from zero or when no nodes currently exist in the node group.
-func (ng *CoreWeaveNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *CoreWeaveNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	instanceTypeName := ng.nodepool.GetInstanceType()
 	if instanceTypeName == "" {
 		return nil, fmt.Errorf("node pool %s has no instance type defined", ng.Name)
@@ -232,23 +233,23 @@ func (ng *CoreWeaveNodeGroup) buildNodeLabels(nodeName, instanceTypeName string,
 }
 
 // Exist checks if the node group exists.
-func (ng *CoreWeaveNodeGroup) Exist() bool { return true }
+func (ng *CoreWeaveNodeGroup) Exist(ctx context.Context) bool { return true }
 
 // Create is not implemented for CoreWeaveNodeGroup.
-func (ng *CoreWeaveNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *CoreWeaveNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete is not implemented for CoreWeaveNodeGroup.
-func (ng *CoreWeaveNodeGroup) Delete() error {
+func (ng *CoreWeaveNodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns whether the node group is autoprovisioned.
 // In CoreWeave, node groups are not autoprovisioned, so it returns false
-func (ng *CoreWeaveNodeGroup) Autoprovisioned() bool { return false }
+func (ng *CoreWeaveNodeGroup) Autoprovisioned(ctx context.Context) bool { return false }
 
 // GetOptions returns the autoscaling options for the node group.
-func (ng *CoreWeaveNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *CoreWeaveNodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodegroup_test.go
@@ -128,13 +128,13 @@ func TestId(t *testing.T) {
 
 func TestMinMaxTargetSize(t *testing.T) {
 	ng := makeTestNodeGroup("ng-1", "uid-1", 2, 10, 5)
-	if ng.MinSize() != 2 {
-		t.Errorf("expected min size 2, got %d", ng.MinSize())
+	if ng.MinSize(context.Background()) != 2 {
+		t.Errorf("expected min size 2, got %d", ng.MinSize(context.Background()))
 	}
-	if ng.MaxSize() != 10 {
-		t.Errorf("expected max size 10, got %d", ng.MaxSize())
+	if ng.MaxSize(context.Background()) != 10 {
+		t.Errorf("expected max size 10, got %d", ng.MaxSize(context.Background()))
 	}
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.Background())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestMinMaxTargetSize(t *testing.T) {
 
 func TestIncreaseSize(t *testing.T) {
 	ng := makeTestNodeGroup("ng-1", "uid-1", 1, 5, 3)
-	err := ng.IncreaseSize(2)
+	err := ng.IncreaseSize(context.Background(), 2)
 	if err != nil && err != cloudprovider.ErrNotImplemented {
 		t.Errorf("expected ErrNotImplemented or nil, got %v", err)
 	}
@@ -199,7 +199,7 @@ func TestDeleteNodes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ng := makeTestNodeGroup("ng-1", "uid-1", 0, 5, initialTargetSize)
 
-			err := ng.DeleteNodes(tc.nodesToDelete)
+			err := ng.DeleteNodes(context.Background(), tc.nodesToDelete)
 			if tc.expectedError != nil {
 				require.Equal(t, tc.expectedError, err)
 				return
@@ -230,7 +230,7 @@ func TestDecreaseTargetSize(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ng := makeTestNodeGroup("ng-1", "uid-1", 1, 5, 3)
 
-			err := ng.DecreaseTargetSize(tc.delta)
+			err := ng.DecreaseTargetSize(context.Background(), tc.delta)
 			if tc.expectedError != nil {
 				require.Error(t, err)
 				require.Equal(t, tc.expectedError, err)
@@ -584,7 +584,7 @@ func TestTemplateNodeInfo(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ng := NewCoreWeaveNodeGroup(tc.nodePool)
-			nodeInfo, err := ng.TemplateNodeInfo()
+			nodeInfo, err := ng.TemplateNodeInfo(context.Background())
 
 			if tc.expectedError != "" {
 				require.Error(t, err)

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package coreweave
 
 import (
+	"context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -81,7 +82,7 @@ func (c *CoreWeaveCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (c *CoreWeaveCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (c *CoreWeaveCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	// Check if the manager is nil
 	if c.manager == nil {
 		klog.Error("CoreWeave manager is nil, cannot retrieve node groups")
@@ -98,7 +99,7 @@ func (c *CoreWeaveCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (c *CoreWeaveCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (c *CoreWeaveCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	klog.V(4).Infof("Getting node group for node %s", node.Name)
 	// Check if the manager is nil before proceeding
 	if c.manager == nil {
@@ -115,7 +116,7 @@ func (c *CoreWeaveCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 }
 
 // HasInstance checks if a given node has a corresponding instance in this cloud provider.
-func (c *CoreWeaveCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (c *CoreWeaveCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	// Check if the manager is nil
 	if c.manager == nil {
 		return false, fmt.Errorf("CoreWeave manager is nil")
@@ -143,54 +144,54 @@ func (c *CoreWeaveCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 
 // Pricing returns the pricing model for this cloud provider.
 // This method is not implemented for CoreWeave.
-func (c *CoreWeaveCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (c *CoreWeaveCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes returns a list of available machine types for this cloud provider.
 // This method is not implemented for CoreWeave.
-func (c *CoreWeaveCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (c *CoreWeaveCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup creates a new node group with the specified machine type, labels, system labels, taints, and extra resources.
 // This method is not implemented for CoreWeave.
-func (c *CoreWeaveCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (c *CoreWeaveCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns the resource limiter for this cloud provider.
-func (c *CoreWeaveCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (c *CoreWeaveCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return c.resourceLimiter, nil
 }
 
 // GPULabel returns the label used to identify GPU nodes.
 // This method is not implemented for CoreWeave, so it returns an empty string.
-func (c *CoreWeaveCloudProvider) GPULabel() string {
+func (c *CoreWeaveCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes returns a map of available GPU types for this cloud provider.
 // This method is not implemented for CoreWeave, so it returns nil.
-func (c *CoreWeaveCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (c *CoreWeaveCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the GPU configuration for a given node.
 // This method is not implemented for CoreWeave, so it returns nil.
-func (c *CoreWeaveCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+func (c *CoreWeaveCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
 	return nil
 }
 
 // Cleanup performs any necessary cleanup for the cloud provider.
 // This method is not implemented for CoreWeave, so it returns nil.
-func (c *CoreWeaveCloudProvider) Cleanup() error {
+func (c *CoreWeaveCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh refreshes the state of the cloud provider.
-func (c *CoreWeaveCloudProvider) Refresh() error {
+func (c *CoreWeaveCloudProvider) Refresh(ctx context.Context) error {
 	return c.manager.Refresh()
 }
 

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package coreweave
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -105,14 +106,14 @@ func TestCoreWeaveCloudProvider_Name(t *testing.T) {
 
 func TestCoreWeaveCloudProvider_NodeGroups_ManagerNil(t *testing.T) {
 	cp := &CoreWeaveCloudProvider{manager: nil}
-	if got := cp.NodeGroups(); got != nil {
+	if got := cp.NodeGroups(context.Background()); got != nil {
 		t.Errorf("expected nil, got %v", got)
 	}
 }
 
 func TestCoreWeaveCloudProvider_NodeGroups_ListError(t *testing.T) {
 	cp := &CoreWeaveCloudProvider{manager: &fakeManager{nodegroups: nil}}
-	if got := cp.NodeGroups(); got != nil {
+	if got := cp.NodeGroups(context.Background()); got != nil {
 		t.Errorf("expected nil, got %v", got)
 	}
 }
@@ -122,7 +123,7 @@ func TestCoreWeaveCloudProvider_NodeGroups_Success(t *testing.T) {
 	// Create a test manager with the nodepool item
 	manager := makeTestManagerWithNodePools(nodes, item)
 	cp := &CoreWeaveCloudProvider{manager: manager}
-	groups := cp.NodeGroups()
+	groups := cp.NodeGroups(context.Background())
 	if len(groups) != 1 {
 		t.Errorf("expected 1 node group, got %d", len(groups))
 	}
@@ -131,7 +132,7 @@ func TestCoreWeaveCloudProvider_NodeGroups_Success(t *testing.T) {
 func TestCoreWeaveCloudProvider_NodeGroupForNode_ManagerNil(t *testing.T) {
 	cp := &CoreWeaveCloudProvider{manager: nil}
 	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
-	ng, err := cp.NodeGroupForNode(node)
+	ng, err := cp.NodeGroupForNode(context.Background(), node)
 	if ng != nil || err == nil {
 		t.Error("expected nil node group and error when manager is nil")
 	}
@@ -144,7 +145,7 @@ func TestCoreWeaveCloudProvider_NodeGroupForNode_GetNodePoolByNameError(t *testi
 	manager.UpdateNodeGroup()
 	cp := &CoreWeaveCloudProvider{manager: manager}
 	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{coreWeaveNodePoolUID: "missing"}}}
-	nodeGroup, err := cp.NodeGroupForNode(node)
+	nodeGroup, err := cp.NodeGroupForNode(context.Background(), node)
 	if err != nil {
 		t.Errorf("unexpected error from NodeGroupForNode: %v", err)
 	}
@@ -160,7 +161,7 @@ func TestCoreWeaveCloudProvider_NodeGroupForNode_GetNodePoolByUIDError(t *testin
 	manager.UpdateNodeGroup()
 	cp := &CoreWeaveCloudProvider{manager: manager}
 	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{coreWeaveNodePoolUID: "wrong-uid"}}}
-	nodeGroup, err := cp.NodeGroupForNode(node)
+	nodeGroup, err := cp.NodeGroupForNode(context.Background(), node)
 	if err != nil {
 		t.Errorf("unexpected error from NodeGroupForNode: %v", err)
 	}
@@ -177,7 +178,7 @@ func TestCoreWeaveCloudProvider_NodeGroupForNode_Success(t *testing.T) {
 	manager.UpdateNodeGroup()
 	cp := &CoreWeaveCloudProvider{manager: manager}
 
-	ng, err := cp.NodeGroupForNode(node)
+	ng, err := cp.NodeGroupForNode(context.Background(), node)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -188,28 +189,28 @@ func TestCoreWeaveCloudProvider_NodeGroupForNode_Success(t *testing.T) {
 
 func TestCoreWeaveCloudProvider_NotImplementedMethods(t *testing.T) {
 	cp := &CoreWeaveCloudProvider{}
-	_, err2 := cp.Pricing()
+	_, err2 := cp.Pricing(context.Background())
 	if !errors.Is(err2, cloudprovider.ErrNotImplemented) {
 		t.Error("expected ErrNotImplemented for Pricing")
 	}
-	_, err3 := cp.GetAvailableMachineTypes()
+	_, err3 := cp.GetAvailableMachineTypes(context.Background())
 	if !errors.Is(err3, cloudprovider.ErrNotImplemented) {
 		t.Error("expected ErrNotImplemented for GetAvailableMachineTypes")
 	}
-	_, err4 := cp.NewNodeGroup("", nil, nil, nil, nil)
+	_, err4 := cp.NewNodeGroup(context.Background(), "", nil, nil, nil, nil)
 	if !errors.Is(err4, cloudprovider.ErrNotImplemented) {
 		t.Error("expected ErrNotImplemented for NewNodeGroup")
 	}
-	if cp.GPULabel() != "" {
+	if cp.GPULabel(context.Background()) != "" {
 		t.Error("expected empty string for GPULabel")
 	}
-	if cp.GetAvailableGPUTypes() != nil {
+	if cp.GetAvailableGPUTypes(context.Background()) != nil {
 		t.Error("expected nil for GetAvailableGPUTypes")
 	}
-	if cp.GetNodeGpuConfig(&apiv1.Node{}) != nil {
+	if cp.GetNodeGpuConfig(context.Background(), &apiv1.Node{}) != nil {
 		t.Error("expected nil for GetNodeGpuConfig")
 	}
-	if cp.Cleanup() != nil {
+	if cp.Cleanup(context.Background()) != nil {
 		t.Error("expected nil for Cleanup")
 	}
 }
@@ -217,7 +218,7 @@ func TestCoreWeaveCloudProvider_NotImplementedMethods(t *testing.T) {
 func TestCoreWeaveCloudProvider_HasInstance_ManagerNil(t *testing.T) {
 	cp := &CoreWeaveCloudProvider{manager: nil}
 	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
-	ok, err := cp.HasInstance(node)
+	ok, err := cp.HasInstance(context.Background(), node)
 	if ok {
 		t.Error("expected false when manager is nil")
 	}
@@ -229,19 +230,19 @@ func TestCoreWeaveCloudProvider_HasInstance_ManagerNil(t *testing.T) {
 func TestCoreWeaveCloudProvider_HasInstance_NoLabels(t *testing.T) {
 	cp := &CoreWeaveCloudProvider{manager: &fakeManager{}}
 	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: nil}}
-	ok, err := cp.HasInstance(node)
+	ok, err := cp.HasInstance(context.Background(), node)
 	if ok || err != nil {
 		t.Error("expected false, nil for node with nil labels")
 	}
 
 	node2 := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n2", Labels: map[string]string{}}}
-	ok2, err2 := cp.HasInstance(node2)
+	ok2, err2 := cp.HasInstance(context.Background(), node2)
 	if ok2 || err2 != nil {
 		t.Error("expected false, nil for node with empty labels")
 	}
 
 	node3 := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n3", Labels: map[string]string{"other": "value"}}}
-	ok3, err3 := cp.HasInstance(node3)
+	ok3, err3 := cp.HasInstance(context.Background(), node3)
 	if ok3 || err3 != nil {
 		t.Error("expected false, nil for node with unrelated labels")
 	}
@@ -250,7 +251,7 @@ func TestCoreWeaveCloudProvider_HasInstance_NoLabels(t *testing.T) {
 func TestCoreWeaveCloudProvider_HasInstance_NodeGroupError(t *testing.T) {
 	cp := &CoreWeaveCloudProvider{manager: &fakeManager{getNodeGroupErr: true}}
 	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{coreWeaveNodePoolUID: "uid1"}}}
-	ok, err := cp.HasInstance(node)
+	ok, err := cp.HasInstance(context.Background(), node)
 	if ok || err != nil {
 		t.Error("expected false, nil when GetNodeGroup returns error")
 	}

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package digitalocean
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -71,7 +72,7 @@ func (d *digitaloceanCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (d *digitaloceanCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (d *digitaloceanCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodeGroups := make([]cloudprovider.NodeGroup, len(d.manager.nodeGroups))
 	for i, ng := range d.manager.nodeGroups {
 		nodeGroups[i] = ng
@@ -82,7 +83,7 @@ func (d *digitaloceanCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (d *digitaloceanCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (d *digitaloceanCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	providerID := node.Spec.ProviderID
 	nodeID := toNodeID(providerID)
 
@@ -93,7 +94,7 @@ func (d *digitaloceanCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 	// proceed with this.
 	for _, group := range d.manager.nodeGroups {
 		klog.V(5).Infof("iterating over node group %q", group.Id())
-		nodes, err := group.Nodes()
+		nodes, err := group.Nodes(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -118,19 +119,19 @@ func (d *digitaloceanCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (d *digitaloceanCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (d *digitaloceanCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
-func (d *digitaloceanCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (d *digitaloceanCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from
 // the cloud provider. Implementation optional.
-func (d *digitaloceanCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (d *digitaloceanCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
@@ -138,7 +139,7 @@ func (d *digitaloceanCloudProvider) GetAvailableMachineTypes() ([]string, error)
 // provided. The node group is not automatically created on the cloud provider
 // side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (d *digitaloceanCloudProvider) NewNodeGroup(
+func (d *digitaloceanCloudProvider) NewNodeGroup(ctx context.Context,
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
@@ -150,36 +151,36 @@ func (d *digitaloceanCloudProvider) NewNodeGroup(
 
 // GetResourceLimiter returns struct containing limits (max, min) for
 // resources (cores, memory etc.).
-func (d *digitaloceanCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (d *digitaloceanCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return d.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (d *digitaloceanCloudProvider) GPULabel() string {
+func (d *digitaloceanCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (d *digitaloceanCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (d *digitaloceanCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (d *digitaloceanCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(d, node)
+func (d *digitaloceanCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), d, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed,
 // i.e. go routines etc.
-func (d *digitaloceanCloudProvider) Cleanup() error {
+func (d *digitaloceanCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically
 // update cloud provider state. In particular the list of node groups returned
 // by NodeGroups() can change as a result of CloudProvider.Refresh().
-func (d *digitaloceanCloudProvider) Refresh() error {
+func (d *digitaloceanCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Info("Refreshing node group cache")
 	return d.manager.Refresh()
 }

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider_test.go
@@ -134,13 +134,13 @@ func TestDigitalOceanCloudProvider_NodeGroups(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
-		nodes := provider.NodeGroups()
+		nodes := provider.NodeGroups(context.Background())
 		assert.Equal(t, len(nodes), 3, "number of nodes do not match")
 	})
 
 	t.Run("zero groups", func(t *testing.T) {
 		provider.manager.nodeGroups = []*NodeGroup{}
-		nodes := provider.NodeGroups()
+		nodes := provider.NodeGroups(context.Background())
 		assert.Equal(t, len(nodes), 0, "number of nodes do not match")
 	})
 }
@@ -186,7 +186,7 @@ func TestDigitalOceanCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		nodeGroup, err := provider.NodeGroupForNode(node)
+		nodeGroup, err := provider.NodeGroupForNode(context.Background(), node)
 		require.NoError(t, err)
 		require.NotNil(t, nodeGroup)
 		require.Equal(t, nodeGroup.Id(), "2", "node group ID does not match")
@@ -227,7 +227,7 @@ func TestDigitalOceanCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		nodeGroup, err := provider.NodeGroupForNode(node)
+		nodeGroup, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.Nil(t, nodeGroup)
 	})

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -60,12 +60,12 @@ type NodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *NodeGroup) MaxSize() int {
+func (n *NodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *NodeGroup) MinSize() int {
+func (n *NodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
@@ -74,31 +74,31 @@ func (n *NodeGroup) MinSize() int {
 // be equal to Size() once everything stabilizes (new nodes finish startup and
 // registration or removed nodes are deleted completely). Implementation
 // required.
-func (n *NodeGroup) TargetSize() (int, error) {
+func (n *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return n.nodePool.Count, nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *NodeGroup) IncreaseSize(delta int) error {
+func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
 
 	targetSize := n.nodePool.Count + delta
 
-	if targetSize > n.MaxSize() {
+	if targetSize > n.MaxSize(context.TODO()) {
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			n.nodePool.Count, targetSize, n.MaxSize())
+			n.nodePool.Count, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	req := &godo.KubernetesNodePoolUpdateRequest{
 		Count: &targetSize,
 	}
 
-	ctx := context.Background()
-	updatedNodePool, _, err := n.client.UpdateNodePool(ctx, n.clusterID, n.id, req)
+	ctx2 := context.Background()
+	updatedNodePool, _, err := n.client.UpdateNodePool(ctx2, n.clusterID, n.id, req)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -122,8 +122,8 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
-	ctx := context.Background()
+func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
+	ctx2 := context.Background()
 	for _, node := range nodes {
 		nodeID, ok := node.Labels[nodeIDLabel]
 		if !ok {
@@ -133,7 +133,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 			return fmt.Errorf("cannot delete node %q with provider ID %q on node pool %q: node ID label %q is missing", node.Name, node.Spec.ProviderID, n.id, nodeIDLabel)
 		}
 
-		_, err := n.client.DeleteNode(ctx, n.clusterID, n.id, nodeID, nil)
+		_, err := n.client.DeleteNode(ctx2, n.clusterID, n.id, nodeID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting node failed for cluster: %q node pool: %q node: %q: %s",
 				n.clusterID, n.id, nodeID, err)
@@ -147,7 +147,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -156,23 +156,23 @@ func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *NodeGroup) DecreaseTargetSize(delta int) error {
+func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("delta must be negative, have: %d", delta)
 	}
 
 	targetSize := n.nodePool.Count + delta
-	if targetSize < n.MinSize() {
+	if targetSize < n.MinSize(context.TODO()) {
 		return fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
-			n.nodePool.Count, targetSize, n.MinSize())
+			n.nodePool.Count, targetSize, n.MinSize(context.TODO()))
 	}
 
 	req := &godo.KubernetesNodePoolUpdateRequest{
 		Count: &targetSize,
 	}
 
-	ctx := context.Background()
-	updatedNodePool, _, err := n.client.UpdateNodePool(ctx, n.clusterID, n.id, req)
+	ctx2 := context.Background()
+	updatedNodePool, _, err := n.client.UpdateNodePool(ctx2, n.clusterID, n.id, req)
 	if err != nil {
 		return err
 	}
@@ -193,14 +193,14 @@ func (n *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroup) Debug() string {
-	return fmt.Sprintf("cluster ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *NodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("cluster ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.  It is
 // required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
-func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	if n.nodePool == nil {
 		return nil, errors.New("node pool instance is not created")
 	}
@@ -219,7 +219,7 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // all of the labels, capacity and allocatable information as well as all pods
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
-func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	if n.nodePoolTemplate != nil {
 		// Template has already been populated from cache - convert to node info and return
 		tni, err := toNodeInfoTemplate(n.nodePoolTemplate)
@@ -240,32 +240,32 @@ func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 // Exist checks if the node group really exists on the cloud provider side.
 // Allows to tell the theoretical node group from the real one. Implementation
 // required.
-func (n *NodeGroup) Exist() bool {
+func (n *NodeGroup) Exist(ctx context.Context) bool {
 	return n.nodePool != nil
 }
 
 // Create creates the node group on the cloud provider side. Implementation
 // optional.
-func (n *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.  This will be
 // executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroup) Delete() error {
+func (n *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroup) Autoprovisioned() bool {
+func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -97,8 +97,11 @@ func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 		Count: &targetSize,
 	}
 
-	ctx2 := context.Background()
-	updatedNodePool, _, err := n.client.UpdateNodePool(ctx2, n.clusterID, n.id, req)
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
+	updatedNodePool, _, err := n.client.UpdateNodePool(emptyCtx, n.clusterID, n.id, req)
 	if err != nil {
 		return err
 	}
@@ -123,7 +126,10 @@ func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
 func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
-	ctx2 := context.Background()
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
 	for _, node := range nodes {
 		nodeID, ok := node.Labels[nodeIDLabel]
 		if !ok {
@@ -133,7 +139,7 @@ func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error 
 			return fmt.Errorf("cannot delete node %q with provider ID %q on node pool %q: node ID label %q is missing", node.Name, node.Spec.ProviderID, n.id, nodeIDLabel)
 		}
 
-		_, err := n.client.DeleteNode(ctx2, n.clusterID, n.id, nodeID, nil)
+		_, err := n.client.DeleteNode(emptyCtx, n.clusterID, n.id, nodeID, nil)
 		if err != nil {
 			return fmt.Errorf("deleting node failed for cluster: %q node pool: %q node: %q: %s",
 				n.clusterID, n.id, nodeID, err)
@@ -171,8 +177,11 @@ func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 		Count: &targetSize,
 	}
 
-	ctx2 := context.Background()
-	updatedNodePool, _, err := n.client.UpdateNodePool(ctx2, n.clusterID, n.id, req)
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
+	updatedNodePool, _, err := n.client.UpdateNodePool(emptyCtx, n.clusterID, n.id, req)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
@@ -41,7 +41,7 @@ func TestNodeGroup_TargetSize(t *testing.T) {
 			Count: numberOfNodes,
 		})
 
-		size, err := ng.TargetSize()
+		size, err := ng.TargetSize(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, numberOfNodes, size, "target size is not correct")
 	})
@@ -75,7 +75,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -105,7 +105,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -116,7 +116,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		ng := testNodeGroup(client, &godo.KubernetesNodePool{
 			Count: numberOfNodes,
 		})
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
@@ -132,7 +132,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
 	})
 
@@ -146,9 +146,9 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		})
 
 		exp := fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			numberOfNodes, numberOfNodes+delta, ng.MaxSize())
+			numberOfNodes, numberOfNodes+delta, ng.MaxSize(context.Background()))
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase is too large")
 	})
 }
@@ -179,7 +179,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -207,7 +207,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 			nil,
 		).Once()
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -219,7 +219,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		})
 
 		delta := 1
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be negative, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease must be negative")
@@ -235,7 +235,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		delta := 0
 		exp := fmt.Errorf("delta must be negative, have: %d", delta)
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease must be negative")
 	})
 
@@ -250,8 +250,8 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		})
 
 		exp := fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
-			numberOfNodes, numberOfNodes+delta, ng.MinSize())
-		err := ng.DecreaseTargetSize(delta)
+			numberOfNodes, numberOfNodes+delta, ng.MinSize(context.Background()))
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease is too small")
 	})
 }
@@ -276,7 +276,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		client.On("DeleteNode", ctx, ng.clusterID, ng.id, "2", nil).Return(&godo.Response{}, nil).Once()
 		client.On("DeleteNode", ctx, ng.clusterID, ng.id, "3", nil).Return(&godo.Response{}, nil).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.NoError(t, err)
 	})
 
@@ -298,7 +298,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 		client.On("DeleteNode", ctx, ng.clusterID, ng.id, "2", nil).
 			Return(&godo.Response{}, errors.New("random error")).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.Error(t, err)
 	})
 }
@@ -380,7 +380,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 			},
 		}
 
-		nodes, err := ng.Nodes()
+		nodes, err := ng.Nodes(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, exp, nodes, "nodes do not match")
 	})
@@ -389,7 +389,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 		client := &doClientMock{}
 		ng := testNodeGroup(client, nil)
 
-		_, err := ng.Nodes()
+		_, err := ng.Nodes(context.Background())
 		assert.Error(t, err, "Nodes() should return an error")
 	})
 }
@@ -403,7 +403,7 @@ func TestNodeGroup_Debug(t *testing.T) {
 			MaxNodes: 200,
 		})
 
-		d := ng.Debug()
+		d := ng.Debug(context.Background())
 		exp := "cluster ID: 1 (min:1 max:200)"
 		assert.Equal(t, exp, d, "debug string do not match")
 	})
@@ -414,7 +414,7 @@ func TestNodeGroup_Exist(t *testing.T) {
 		client := &doClientMock{}
 		ng := testNodeGroup(client, &godo.KubernetesNodePool{Count: 3})
 
-		exist := ng.Exist()
+		exist := ng.Exist(context.Background())
 		assert.Equal(t, true, exist, "node pool should exist")
 	})
 
@@ -422,7 +422,7 @@ func TestNodeGroup_Exist(t *testing.T) {
 		client := &doClientMock{}
 		ng := testNodeGroup(client, nil)
 
-		exist := ng.Exist()
+		exist := ng.Exist(context.Background())
 		assert.Equal(t, false, exist, "node pool should not exist")
 	})
 }

--- a/cluster-autoscaler/cloudprovider/equinixmetal/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package equinixmetal
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -95,23 +96,23 @@ func (pcp *equinixMetalCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (pcp *equinixMetalCloudProvider) GPULabel() string {
+func (pcp *equinixMetalCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (pcp *equinixMetalCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (pcp *equinixMetalCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (pcp *equinixMetalCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(pcp, node)
+func (pcp *equinixMetalCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), pcp, node)
 }
 
 // NodeGroups returns all node groups managed by this cloud provider.
-func (pcp *equinixMetalCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (pcp *equinixMetalCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	groups := make([]cloudprovider.NodeGroup, len(pcp.nodeGroups))
 	for i := range pcp.nodeGroups {
 		groups[i] = pcp.nodeGroups[i]
@@ -127,7 +128,7 @@ func (pcp *equinixMetalCloudProvider) AddNodeGroup(group *equinixMetalNodeGroup)
 // NodeGroupForNode returns the node group that a given node belongs to.
 //
 // Since only a single node group is currently supported, the first node group is always returned.
-func (pcp *equinixMetalCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (pcp *equinixMetalCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	controllerNodeLabel := DefaultControllerNodeLabelKey
 	value, present := os.LookupEnv(ControllerNodeIdentifierMetalEnv)
 	if present {
@@ -155,43 +156,43 @@ func (pcp *equinixMetalCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudp
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (pcp *equinixMetalCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (pcp *equinixMetalCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (pcp *equinixMetalCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (pcp *equinixMetalCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return &Price{}, nil
 }
 
 // GetAvailableMachineTypes is not implemented.
-func (pcp *equinixMetalCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (pcp *equinixMetalCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup is not implemented.
-func (pcp *equinixMetalCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (pcp *equinixMetalCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns resource constraints for the cloud provider
-func (pcp *equinixMetalCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (pcp *equinixMetalCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return pcp.resourceLimiter, nil
 }
 
 // Refresh is called before every autoscaler main loop.
 //
 // Currently only prints debug information.
-func (pcp *equinixMetalCloudProvider) Refresh() error {
+func (pcp *equinixMetalCloudProvider) Refresh(ctx context.Context) error {
 	for _, nodegroup := range pcp.nodeGroups {
-		klog.V(3).Info(nodegroup.Debug())
+		klog.V(3).Info(nodegroup.Debug(context.TODO()))
 	}
 	return nil
 }
 
 // Cleanup currently does nothing.
-func (pcp *equinixMetalCloudProvider) Cleanup() error {
+func (pcp *equinixMetalCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/equinixmetal/node_group.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/node_group.go
@@ -17,6 +17,7 @@ limitations under the License.
 package equinixmetal
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -70,7 +71,7 @@ const (
 //
 // Takes precautions so that the cluster is not modified while in an UPDATE_IN_PROGRESS state.
 // Blocks until the cluster has reached UPDATE_COMPLETE.
-func (ng *equinixMetalNodeGroup) IncreaseSize(delta int) error {
+func (ng *equinixMetalNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	ng.clusterUpdateMutex.Lock()
 	defer ng.clusterUpdateMutex.Unlock()
 
@@ -82,8 +83,8 @@ func (ng *equinixMetalNodeGroup) IncreaseSize(delta int) error {
 	if err != nil {
 		return fmt.Errorf("could not check current nodegroup size: %v", err)
 	}
-	if size+delta > ng.MaxSize() {
-		return fmt.Errorf("size increase too large, desired:%d max:%d", size+delta, ng.MaxSize())
+	if size+delta > ng.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large, desired:%d max:%d", size+delta, ng.MaxSize(context.TODO()))
 	}
 
 	klog.V(0).Infof("Increasing size by %d, %d->%d", delta, *ng.targetSize, *ng.targetSize+delta)
@@ -98,7 +99,7 @@ func (ng *equinixMetalNodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ng *equinixMetalNodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *equinixMetalNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -109,7 +110,7 @@ func (ng *equinixMetalNodeGroup) AtomicIncreaseSize(delta int) error {
 //   - simultaneous but separate calls from the autoscaler are batched together
 //   - does not allow scaling while the cluster is already in an UPDATE_IN_PROGRESS state
 //   - after scaling down, blocks until the cluster has reached UPDATE_COMPLETE
-func (ng *equinixMetalNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *equinixMetalNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	klog.V(1).Infof("Locking nodesToDeleteMutex")
 
 	// Batch simultaneous deletes on individual nodes
@@ -135,7 +136,7 @@ func (ng *equinixMetalNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	}
 
 	// Check that these nodes would not make the batch delete more nodes than the minimum would allow
-	if cachedSize-len(ng.nodesToDelete)-len(nodes) < ng.MinSize() {
+	if cachedSize-len(ng.nodesToDelete)-len(nodes) < ng.MinSize(context.TODO()) {
 		ng.nodesToDeleteMutex.Unlock()
 		klog.V(1).Infof("UnLocking nodesToDeleteMutex")
 		return fmt.Errorf("deleting nodes would take nodegroup below minimum size %d", ng.minSize)
@@ -187,8 +188,8 @@ func (ng *equinixMetalNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	klog.V(0).Infof("Deleting nodes: %v", nodeNames)
 
 	// Double check that the total number of batched nodes for deletion will not take the node group below its minimum size
-	if cachedSize-len(nodes) < ng.MinSize() {
-		return fmt.Errorf("size decrease too large, desired:%d min:%d", cachedSize-len(nodes), ng.MinSize())
+	if cachedSize-len(nodes) < ng.MinSize(context.TODO()) {
+		return fmt.Errorf("size decrease too large, desired:%d min:%d", cachedSize-len(nodes), ng.MinSize(context.TODO()))
 	}
 
 	var nodeRefs []NodeRef
@@ -227,12 +228,12 @@ func (ng *equinixMetalNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ng *equinixMetalNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ng *equinixMetalNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DecreaseTargetSize decreases the cluster node_count in Equinix Metal.
-func (ng *equinixMetalNodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *equinixMetalNodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
@@ -247,12 +248,12 @@ func (ng *equinixMetalNodeGroup) Id() string {
 }
 
 // Debug returns a string formatted with the node group's min, max and target sizes.
-func (ng *equinixMetalNodeGroup) Debug() string {
+func (ng *equinixMetalNodeGroup) Debug(ctx context.Context) string {
 	return fmt.Sprintf("%s min=%d max=%d target=%d", ng.id, ng.minSize, ng.maxSize, *ng.targetSize)
 }
 
 // Nodes returns a list of nodes that belong to this node group.
-func (ng *equinixMetalNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *equinixMetalNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	nodes, err := ng.equinixMetalManager.getNodes(ng.id)
 	if err != nil {
 		return nil, fmt.Errorf("could not get nodes: %v", err)
@@ -265,48 +266,48 @@ func (ng *equinixMetalNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (ng *equinixMetalNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *equinixMetalNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return ng.equinixMetalManager.templateNodeInfo(ng.id)
 }
 
 // Exist returns if this node group exists.
 // Currently always returns true.
-func (ng *equinixMetalNodeGroup) Exist() bool {
+func (ng *equinixMetalNodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (ng *equinixMetalNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *equinixMetalNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.
-func (ng *equinixMetalNodeGroup) Delete() error {
+func (ng *equinixMetalNodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns if the nodegroup is autoprovisioned.
-func (ng *equinixMetalNodeGroup) Autoprovisioned() bool {
+func (ng *equinixMetalNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // MaxSize returns the maximum allowed size of the node group.
-func (ng *equinixMetalNodeGroup) MaxSize() int {
+func (ng *equinixMetalNodeGroup) MaxSize(ctx context.Context) int {
 	return ng.maxSize
 }
 
 // MinSize returns the minimum allowed size of the node group.
-func (ng *equinixMetalNodeGroup) MinSize() int {
+func (ng *equinixMetalNodeGroup) MinSize(ctx context.Context) int {
 	return ng.minSize
 }
 
 // TargetSize returns the target size of the node group.
-func (ng *equinixMetalNodeGroup) TargetSize() (int, error) {
+func (ng *equinixMetalNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return *ng.targetSize, nil
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (ng *equinixMetalNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *equinixMetalNodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/equinixmetal/node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/node_group_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package equinixmetal
 
 import (
+	"context"
 	"os"
 	"sync"
 	"testing"
@@ -99,11 +100,11 @@ func TestIncreaseDecreaseSize(t *testing.T) {
 	}
 
 	// Try to increase pool3 with negative size, this should return an error
-	err = ngPool3.IncreaseSize(-1)
+	err = ngPool3.IncreaseSize(context.Background(), -1)
 	assert.Error(t, err)
 
 	// Now try to increase the pool3 size by 1, that should work
-	err = ngPool3.IncreaseSize(1)
+	err = ngPool3.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	if len(os.Getenv("PACKET_AUTH_TOKEN")) > 0 || len(os.Getenv(metalAuthTokenEnv)) > 0 {
@@ -117,7 +118,7 @@ func TestIncreaseDecreaseSize(t *testing.T) {
 	assert.Equal(t, int(2), len(n2Pool3))
 
 	// Now try to increase the pool2 size by 1, that should work
-	err = ngPool2.IncreaseSize(1)
+	err = ngPool2.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	if len(os.Getenv("PACKET_AUTH_TOKEN")) > 0 || len(os.Getenv(metalAuthTokenEnv)) > 0 {
@@ -144,10 +145,10 @@ func TestIncreaseDecreaseSize(t *testing.T) {
 		}
 	}
 
-	err = ngPool2.DeleteNodes(nodesPool2)
+	err = ngPool2.DeleteNodes(context.Background(), nodesPool2)
 	assert.NoError(t, err)
 
-	err = ngPool3.DeleteNodes(nodesPool3)
+	err = ngPool3.DeleteNodes(context.Background(), nodesPool3)
 	assert.NoError(t, err)
 
 	// Wait a few seconds if talking to the actual Packet API

--- a/cluster-autoscaler/cloudprovider/equinixmetal/price_model.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/price_model.go
@@ -17,6 +17,7 @@ limitations under the License.
 package equinixmetal
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -53,7 +54,7 @@ var instancePrices = map[string]float64{
 
 // NodePrice returns a price of running the given node for a given period of time.
 // All prices are in USD.
-func (model *Price) NodePrice(node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
+func (model *Price) NodePrice(ctx context.Context, node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
 	price := 0.0
 	if node.Labels != nil {
 		if machineType, found := node.Labels[apiv1.LabelInstanceType]; found {
@@ -73,7 +74,7 @@ func getHours(startTime time.Time, endTime time.Time) float64 {
 
 // PodPrice returns a theoretical minimum price of running a pod for a given
 // period of time on a perfectly matching machine.
-func (model *Price) PodPrice(pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
+func (model *Price) PodPrice(ctx context.Context, pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
 	podRequests := podutils.PodRequests(pod)
 	return getBasePrice(podRequests, startTime, endTime), nil
 }

--- a/cluster-autoscaler/cloudprovider/equinixmetal/price_model_test.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/price_model_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package equinixmetal
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -39,12 +40,12 @@ func TestGetNodePrice(t *testing.T) {
 
 	node1 := BuildTestNode("node1", plan1.CPU*1000, plan1.MemoryMb*1024*1024)
 	node1.Labels = labelsPool1
-	price1, err := model.NodePrice(node1, now, now.Add(time.Hour))
+	price1, err := model.NodePrice(context.Background(), node1, now, now.Add(time.Hour))
 	assert.NoError(t, err)
 
 	node2 := BuildTestNode("node2", plan2.CPU*1000, plan2.MemoryMb*1024*1024)
 	node2.Labels = labelsPool2
-	price2, err := model.NodePrice(node2, now, now.Add(time.Hour))
+	price2, err := model.NodePrice(context.Background(), node2, now, now.Add(time.Hour))
 	assert.NoError(t, err)
 
 	assert.True(t, price1 == 1.05)
@@ -58,9 +59,9 @@ func TestGetPodPrice(t *testing.T) {
 	model := &Price{}
 	now := time.Now()
 
-	price1, err := model.PodPrice(pod1, now, now.Add(time.Hour))
+	price1, err := model.PodPrice(context.Background(), pod1, now, now.Add(time.Hour))
 	assert.NoError(t, err)
-	price2, err := model.PodPrice(pod2, now, now.Add(time.Hour))
+	price2, err := model.PodPrice(context.Background(), pod2, now, now.Add(time.Hour))
 	assert.NoError(t, err)
 	// 2 times bigger pod should cost twice as much.
 	assert.True(t, math.Abs(price1*2-price2) < 0.001)

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package exoscale
 
 import (
+	"context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -63,14 +64,14 @@ func (e *exoscaleCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (e *exoscaleCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (e *exoscaleCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	return e.manager.nodeGroups
 }
 
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (e *exoscaleCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (e *exoscaleCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	instancePool, err := e.instancePoolFromNode(node)
 	if err != nil {
 		if err == errNoInstancePool {
@@ -204,26 +205,26 @@ func (e *exoscaleCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (e *exoscaleCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (e *exoscaleCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (e *exoscaleCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (e *exoscaleCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (e *exoscaleCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (e *exoscaleCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (e *exoscaleCloudProvider) NewNodeGroup(
+func (e *exoscaleCloudProvider) NewNodeGroup(ctx context.Context,
 	_ string,
 	_,
 	_ map[string]string,
@@ -234,34 +235,34 @@ func (e *exoscaleCloudProvider) NewNodeGroup(
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (e *exoscaleCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (e *exoscaleCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return e.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (e *exoscaleCloudProvider) GPULabel() string {
+func (e *exoscaleCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (e *exoscaleCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (e *exoscaleCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (e *exoscaleCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(e, node)
+func (e *exoscaleCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), e, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (e *exoscaleCloudProvider) Cleanup() error {
+func (e *exoscaleCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (e *exoscaleCloudProvider) Refresh() error {
+func (e *exoscaleCloudProvider) Refresh(ctx context.Context) error {
 	debugf("refreshing node groups cache")
 	return e.manager.Refresh()
 }

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider_test.go
@@ -205,7 +205,7 @@ func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_NodeGroupForNode_Ins
 			nil,
 		)
 
-	nodeGroup, err := ts.p.NodeGroupForNode(&apiv1.Node{
+	nodeGroup, err := ts.p.NodeGroupForNode(context.Background(), &apiv1.Node{
 		Spec: apiv1.NodeSpec{
 			ProviderID: toProviderID(testInstanceID),
 		},
@@ -276,7 +276,7 @@ func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_NodeGroupForNode_SKS
 			nil,
 		)
 
-	nodeGroup, err := ts.p.NodeGroupForNode(&apiv1.Node{
+	nodeGroup, err := ts.p.NodeGroupForNode(context.Background(), &apiv1.Node{
 		Spec: apiv1.NodeSpec{
 			ProviderID: toProviderID(testInstanceID),
 		},
@@ -303,7 +303,7 @@ func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_NodeGroupForNode_Sta
 			nil,
 		)
 
-	nodeGroup, err := ts.p.NodeGroupForNode(&apiv1.Node{
+	nodeGroup, err := ts.p.NodeGroupForNode(context.Background(), &apiv1.Node{
 		Spec: apiv1.NodeSpec{
 			ProviderID: toProviderID(testInstanceID),
 		},
@@ -367,7 +367,7 @@ func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_NodeGroups() {
 			nil,
 		)
 
-	instancePoolNodeGroup, err := ts.p.NodeGroupForNode(&apiv1.Node{
+	instancePoolNodeGroup, err := ts.p.NodeGroupForNode(context.Background(), &apiv1.Node{
 		Spec: apiv1.NodeSpec{
 			ProviderID: toProviderID(instancePoolInstanceID),
 		},
@@ -425,7 +425,7 @@ func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_NodeGroups() {
 			nil,
 		)
 
-	sksNodepoolNodeGroup, err := ts.p.NodeGroupForNode(&apiv1.Node{
+	sksNodepoolNodeGroup, err := ts.p.NodeGroupForNode(context.Background(), &apiv1.Node{
 		Spec: apiv1.NodeSpec{
 			ProviderID: toProviderID(sksNodepoolInstanceID),
 		},
@@ -440,7 +440,7 @@ func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_NodeGroups() {
 
 	// ---------------------------------------------------------------
 
-	ts.Require().Len(ts.p.NodeGroups(), 2)
+	ts.Require().Len(ts.p.NodeGroups(context.Background()), 2)
 }
 
 func TestSuiteExoscaleCloudProvider(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -44,7 +44,7 @@ type instancePoolNodeGroup struct {
 var errNoInstancePool = errors.New("not an Instance Pool member")
 
 // MaxSize returns maximum size of the node group.
-func (n *instancePoolNodeGroup) MaxSize() int {
+func (n *instancePoolNodeGroup) MaxSize(ctx context.Context) int {
 	if n.maxSize > 0 {
 		return n.maxSize
 	}
@@ -57,7 +57,7 @@ func (n *instancePoolNodeGroup) MaxSize() int {
 }
 
 // MinSize returns minimum size of the node group.
-func (n *instancePoolNodeGroup) MinSize() int {
+func (n *instancePoolNodeGroup) MinSize(ctx context.Context) int {
 
 	// NOTE: minSize is expected to be >= 1.
 	// Update this check to allow 0 if scale-from-zero support is added.
@@ -72,23 +72,23 @@ func (n *instancePoolNodeGroup) MinSize() int {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (n *instancePoolNodeGroup) TargetSize() (int, error) {
+func (n *instancePoolNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return int(*n.instancePool.Size), nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *instancePoolNodeGroup) IncreaseSize(delta int) error {
+func (n *instancePoolNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
 
 	targetSize := *n.instancePool.Size + int64(delta)
 
-	if targetSize > int64(n.MaxSize()) {
+	if targetSize > int64(n.MaxSize(context.TODO())) {
 		return fmt.Errorf("size increase is too large (current: %d desired: %d max: %d)",
-			*n.instancePool.Size, targetSize, n.MaxSize())
+			*n.instancePool.Size, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	infof("scaling Instance Pool %s to size %d", *n.instancePool.ID, targetSize)
@@ -107,14 +107,14 @@ func (n *instancePoolNodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *instancePoolNodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *instancePoolNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (n *instancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *instancePoolNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	n.Lock()
 	defer n.Unlock()
 
@@ -145,7 +145,7 @@ func (n *instancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *instancePoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *instancePoolNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -154,7 +154,7 @@ func (n *instancePoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *instancePoolNodeGroup) DecreaseTargetSize(_ int) error {
+func (n *instancePoolNodeGroup) DecreaseTargetSize(ctx context.Context, _ int) error {
 	// Exoscale Instance Pools don't support down-sizing without deleting members,
 	// so it is not possible to implement it according to the documented behavior.
 	return nil
@@ -166,15 +166,15 @@ func (n *instancePoolNodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *instancePoolNodeGroup) Debug() string {
-	return fmt.Sprintf("Node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *instancePoolNodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("Node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (n *instancePoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *instancePoolNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	nodes := make([]cloudprovider.Instance, len(*n.instancePool.InstanceIDs))
 	for i, id := range *n.instancePool.InstanceIDs {
 		instance, err := n.m.client.GetInstance(n.m.ctx, n.m.zone, id)
@@ -194,37 +194,37 @@ func (n *instancePoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (n *instancePoolNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *instancePoolNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (n *instancePoolNodeGroup) Exist() bool {
+func (n *instancePoolNodeGroup) Exist(ctx context.Context) bool {
 	return n.instancePool != nil
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (n *instancePoolNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *instancePoolNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *instancePoolNodeGroup) Delete() error {
+func (n *instancePoolNodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (n *instancePoolNodeGroup) Autoprovisioned() bool {
+func (n *instancePoolNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // instancePoolNodeGroup. Returning a nil will result in using default options.
-func (n *instancePoolNodeGroup) GetOptions(_ config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *instancePoolNodeGroup) GetOptions(ctx context.Context, _ config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package exoscale
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 	apiv1 "k8s.io/api/core/v1"
 	egoscale "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2"
@@ -43,7 +45,7 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_MaxSize() {
 		m: ts.p.manager,
 	}
 
-	ts.Require().Equal(int(testComputeInstanceQuotaLimit), nodeGroup.MaxSize())
+	ts.Require().Equal(int(testComputeInstanceQuotaLimit), nodeGroup.MaxSize(context.Background()))
 }
 
 func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_MinSize() {
@@ -56,7 +58,7 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_MinSize() {
 		minSize: 1,
 	}
 
-	ts.Require().Equal(1, nodeGroup.MinSize())
+	ts.Require().Equal(1, nodeGroup.MinSize(context.Background()))
 }
 
 func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_TargetSize() {
@@ -69,7 +71,7 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_TargetSize() {
 		m: ts.p.manager,
 	}
 
-	actual, err := nodeGroup.TargetSize()
+	actual, err := nodeGroup.TargetSize(context.Background())
 	ts.Require().NoError(err)
 	ts.Require().Equal(int(testInstancePoolSize), actual)
 }
@@ -108,10 +110,10 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_IncreaseSize() {
 		m: ts.p.manager,
 	}
 
-	ts.Require().NoError(nodeGroup.IncreaseSize(int(testInstancePoolSize + 1)))
+	ts.Require().NoError(nodeGroup.IncreaseSize(context.Background(), int(testInstancePoolSize+1)))
 
 	// Test size increase failure if beyond current limits:
-	ts.Require().Error(nodeGroup.IncreaseSize(1000))
+	ts.Require().Error(nodeGroup.IncreaseSize(context.Background(), 1000))
 }
 
 func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_DeleteNodes() {
@@ -150,7 +152,7 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_DeleteNodes() {
 		m: ts.p.manager,
 	}
 
-	ts.Require().NoError(nodeGroup.DeleteNodes([]*apiv1.Node{node}))
+	ts.Require().NoError(nodeGroup.DeleteNodes(context.Background(), []*apiv1.Node{node}))
 }
 
 func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_Id() {
@@ -184,7 +186,7 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_Nodes() {
 		m: ts.p.manager,
 	}
 
-	instances, err := nodeGroup.Nodes()
+	instances, err := nodeGroup.Nodes(context.Background())
 	ts.Require().NoError(err)
 	ts.Require().Len(instances, 1)
 	ts.Require().Equal(testInstanceID, toNodeID(instances[0].Id))
@@ -199,7 +201,7 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_Exist() {
 		m: ts.p.manager,
 	}
 
-	ts.Require().True(nodeGroup.Exist())
+	ts.Require().True(nodeGroup.Exist(context.Background()))
 }
 
 func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_MinSize_Custom() {
@@ -212,5 +214,5 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_MinSize_Custom() {
 		minSize: 3,
 	}
 
-	ts.Require().Equal(3, nodeGroup.MinSize())
+	ts.Require().Equal(3, nodeGroup.MinSize(context.Background()))
 }

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
@@ -46,12 +46,12 @@ type sksNodepoolNodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *sksNodepoolNodeGroup) MaxSize() int {
+func (n *sksNodepoolNodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *sksNodepoolNodeGroup) MinSize() int {
+func (n *sksNodepoolNodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
@@ -59,23 +59,23 @@ func (n *sksNodepoolNodeGroup) MinSize() int {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (n *sksNodepoolNodeGroup) TargetSize() (int, error) {
+func (n *sksNodepoolNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return int(*n.sksNodepool.Size), nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *sksNodepoolNodeGroup) IncreaseSize(delta int) error {
+func (n *sksNodepoolNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
 
 	targetSize := *n.sksNodepool.Size + int64(delta)
 
-	if targetSize > int64(n.MaxSize()) {
+	if targetSize > int64(n.MaxSize(context.TODO())) {
 		return fmt.Errorf("size increase is too large (current: %d desired: %d max: %d)",
-			*n.sksNodepool.Size, targetSize, n.MaxSize())
+			*n.sksNodepool.Size, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	infof("scaling SKS Nodepool %s to size %d", *n.sksNodepool.ID, targetSize)
@@ -95,14 +95,14 @@ func (n *sksNodepoolNodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *sksNodepoolNodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *sksNodepoolNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (n *sksNodepoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *sksNodepoolNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	n.Lock()
 	defer n.Unlock()
 
@@ -139,7 +139,7 @@ func (n *sksNodepoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *sksNodepoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *sksNodepoolNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -148,7 +148,7 @@ func (n *sksNodepoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *sksNodepoolNodeGroup) DecreaseTargetSize(_ int) error {
+func (n *sksNodepoolNodeGroup) DecreaseTargetSize(ctx context.Context, _ int) error {
 	// Exoscale Instance Pools don't support down-sizing without deleting members,
 	// so it is not possible to implement it according to the documented behavior.
 	return nil
@@ -160,15 +160,15 @@ func (n *sksNodepoolNodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *sksNodepoolNodeGroup) Debug() string {
-	return fmt.Sprintf("Node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *sksNodepoolNodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("Node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (n *sksNodepoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *sksNodepoolNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	instancePool, err := n.m.client.GetInstancePool(n.m.ctx, n.m.zone, *n.sksNodepool.InstancePoolID)
 	if err != nil {
 		errorf(
@@ -198,37 +198,37 @@ func (n *sksNodepoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (n *sksNodepoolNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *sksNodepoolNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (n *sksNodepoolNodeGroup) Exist() bool {
+func (n *sksNodepoolNodeGroup) Exist(ctx context.Context) bool {
 	return n.sksNodepool != nil
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (n *sksNodepoolNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *sksNodepoolNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *sksNodepoolNodeGroup) Delete() error {
+func (n *sksNodepoolNodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (n *sksNodepoolNodeGroup) Autoprovisioned() bool {
+func (n *sksNodepoolNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // sksNodepoolNodeGroup. Returning a nil will result in using default options.
-func (n *sksNodepoolNodeGroup) GetOptions(_ config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *sksNodepoolNodeGroup) GetOptions(ctx context.Context, _ config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package exoscale
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 	apiv1 "k8s.io/api/core/v1"
 	egoscale "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2"
@@ -49,7 +51,7 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_MaxSize() {
 		maxSize: int(testComputeInstanceQuotaLimit),
 	}
 
-	ts.Require().Equal(int(testComputeInstanceQuotaLimit), nodeGroup.MaxSize())
+	ts.Require().Equal(int(testComputeInstanceQuotaLimit), nodeGroup.MaxSize(context.Background()))
 }
 
 func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_MinSize() {
@@ -67,7 +69,7 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_MinSize() {
 		maxSize: int(testComputeInstanceQuotaLimit),
 	}
 
-	ts.Require().Equal(int(testSKSNodepoolSize), nodeGroup.MinSize())
+	ts.Require().Equal(int(testSKSNodepoolSize), nodeGroup.MinSize(context.Background()))
 }
 
 func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_TargetSize() {
@@ -84,7 +86,7 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_TargetSize() {
 		m: ts.p.manager,
 	}
 
-	actual, err := nodeGroup.TargetSize()
+	actual, err := nodeGroup.TargetSize(context.Background())
 	ts.Require().NoError(err)
 	ts.Require().Equal(int(testInstancePoolSize), actual)
 }
@@ -137,10 +139,10 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_IncreaseSize() {
 		maxSize: int(testComputeInstanceQuotaLimit),
 	}
 
-	ts.Require().NoError(nodeGroup.IncreaseSize(int(testInstancePoolSize + 1)))
+	ts.Require().NoError(nodeGroup.IncreaseSize(context.Background(), int(testInstancePoolSize+1)))
 
 	// Test size increase failure if beyond current limits:
-	ts.Require().Error(nodeGroup.IncreaseSize(1000))
+	ts.Require().Error(nodeGroup.IncreaseSize(context.Background(), 1000))
 }
 
 func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_DeleteNodes() {
@@ -187,7 +189,7 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_DeleteNodes() {
 		maxSize: int(testComputeInstanceQuotaLimit),
 	}
 
-	ts.Require().NoError(nodeGroup.DeleteNodes([]*apiv1.Node{node}))
+	ts.Require().NoError(nodeGroup.DeleteNodes(context.Background(), []*apiv1.Node{node}))
 }
 
 func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_Id() {
@@ -242,7 +244,7 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_Nodes() {
 		maxSize: int(testComputeInstanceQuotaLimit),
 	}
 
-	instances, err := nodeGroup.Nodes()
+	instances, err := nodeGroup.Nodes(context.Background())
 	ts.Require().NoError(err)
 	ts.Require().Len(instances, 1)
 	ts.Require().Equal(testInstanceID, toNodeID(instances[0].Id))
@@ -264,5 +266,5 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_Exist() {
 		maxSize: int(testComputeInstanceQuotaLimit),
 	}
 
-	ts.Require().True(nodeGroup.Exist())
+	ts.Require().True(nodeGroup.Exist(context.Background()))
 }

--- a/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/wrapper/wrapper.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/wrapper/wrapper.go
@@ -67,9 +67,9 @@ func apiv1Node(pbNode *protos.ExternalGrpcNode) *apiv1.Node {
 func pbNodeGroup(ng cloudprovider.NodeGroup) *protos.NodeGroup {
 	return &protos.NodeGroup{
 		Id:      ng.Id(),
-		MaxSize: int32(ng.MaxSize()),
-		MinSize: int32(ng.MinSize()),
-		Debug:   ng.Debug(),
+		MaxSize: int32(ng.MaxSize(context.TODO())),
+		MinSize: int32(ng.MinSize(context.TODO())),
+		Debug:   ng.Debug(context.TODO()),
 	}
 }
 
@@ -82,7 +82,7 @@ func (w *Wrapper) NodeGroups(_ context.Context, req *protos.NodeGroupsRequest) (
 	debug(req)
 
 	pbNgs := make([]*protos.NodeGroup, 0)
-	for _, ng := range w.provider.NodeGroups() {
+	for _, ng := range w.provider.NodeGroups(context.TODO()) {
 		pbNgs = append(pbNgs, pbNodeGroup(ng))
 	}
 	return &protos.NodeGroupsResponse{
@@ -99,7 +99,7 @@ func (w *Wrapper) NodeGroupForNode(_ context.Context, req *protos.NodeGroupForNo
 		return nil, fmt.Errorf("request fields were nil")
 	}
 	node := apiv1Node(pbNode)
-	ng, err := w.provider.NodeGroupForNode(node)
+	ng, err := w.provider.NodeGroupForNode(context.TODO(), node)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (w *Wrapper) NodeGroupForNode(_ context.Context, req *protos.NodeGroupForNo
 func (w *Wrapper) PricingNodePrice(_ context.Context, req *protos.PricingNodePriceRequest) (*protos.PricingNodePriceResponse, error) {
 	debug(req)
 
-	model, err := w.provider.Pricing()
+	model, err := w.provider.Pricing(context.TODO())
 	if err != nil {
 		if err == cloudprovider.ErrNotImplemented {
 			return nil, status.Error(codes.Unimplemented, err.Error())
@@ -141,7 +141,7 @@ func (w *Wrapper) PricingNodePrice(_ context.Context, req *protos.PricingNodePri
 	if reqNode == nil || reqStartTime == nil || reqEndTime == nil {
 		return nil, fmt.Errorf("request fields were nil")
 	}
-	price, nodePriceErr := model.NodePrice(apiv1Node(reqNode), reqStartTime.Time, reqEndTime.Time)
+	price, nodePriceErr := model.NodePrice(context.TODO(), apiv1Node(reqNode), reqStartTime.Time, reqEndTime.Time)
 	if nodePriceErr != nil {
 		return nil, nodePriceErr
 	}
@@ -154,7 +154,7 @@ func (w *Wrapper) PricingNodePrice(_ context.Context, req *protos.PricingNodePri
 func (w *Wrapper) PricingPodPrice(_ context.Context, req *protos.PricingPodPriceRequest) (*protos.PricingPodPriceResponse, error) {
 	debug(req)
 
-	model, err := w.provider.Pricing()
+	model, err := w.provider.Pricing(context.TODO())
 	if err != nil {
 		if err == cloudprovider.ErrNotImplemented {
 			return nil, status.Error(codes.Unimplemented, err.Error())
@@ -187,7 +187,7 @@ func (w *Wrapper) PricingPodPrice(_ context.Context, req *protos.PricingPodPrice
 	if reqPod == nil || reqStartTime == nil || reqEndTime == nil {
 		return nil, fmt.Errorf("request fields were nil")
 	}
-	price, podPriceErr := model.PodPrice(reqPod, reqStartTime.Time, reqEndTime.Time)
+	price, podPriceErr := model.PodPrice(context.TODO(), reqPod, reqStartTime.Time, reqEndTime.Time)
 	if podPriceErr != nil {
 		return nil, podPriceErr
 	}
@@ -200,7 +200,7 @@ func (w *Wrapper) PricingPodPrice(_ context.Context, req *protos.PricingPodPrice
 func (w *Wrapper) GPULabel(_ context.Context, req *protos.GPULabelRequest) (*protos.GPULabelResponse, error) {
 	debug(req)
 
-	label := w.provider.GPULabel()
+	label := w.provider.GPULabel(context.TODO())
 	return &protos.GPULabelResponse{
 		Label: label,
 	}, nil
@@ -210,7 +210,7 @@ func (w *Wrapper) GPULabel(_ context.Context, req *protos.GPULabelRequest) (*pro
 func (w *Wrapper) GetAvailableGPUTypes(_ context.Context, req *protos.GetAvailableGPUTypesRequest) (*protos.GetAvailableGPUTypesResponse, error) {
 	debug(req)
 
-	types := w.provider.GetAvailableGPUTypes()
+	types := w.provider.GetAvailableGPUTypes(context.TODO())
 	pbGpuTypes := make(map[string]*anypb.Any)
 	for t := range types {
 		pbGpuTypes[t] = nil
@@ -224,7 +224,7 @@ func (w *Wrapper) GetAvailableGPUTypes(_ context.Context, req *protos.GetAvailab
 func (w *Wrapper) Cleanup(_ context.Context, req *protos.CleanupRequest) (*protos.CleanupResponse, error) {
 	debug(req)
 
-	err := w.provider.Cleanup()
+	err := w.provider.Cleanup(context.TODO())
 	return &protos.CleanupResponse{}, err
 }
 
@@ -232,13 +232,13 @@ func (w *Wrapper) Cleanup(_ context.Context, req *protos.CleanupRequest) (*proto
 func (w *Wrapper) Refresh(_ context.Context, req *protos.RefreshRequest) (*protos.RefreshResponse, error) {
 	debug(req)
 
-	err := w.provider.Refresh()
+	err := w.provider.Refresh(context.TODO())
 	return &protos.RefreshResponse{}, err
 }
 
 // getNodeGroup retrieves the NodeGroup giving its id.
 func (w *Wrapper) getNodeGroup(id string) cloudprovider.NodeGroup {
-	for _, n := range w.provider.NodeGroups() {
+	for _, n := range w.provider.NodeGroups(context.TODO()) {
 		if n.Id() == id {
 			return n
 		}
@@ -255,7 +255,7 @@ func (w *Wrapper) NodeGroupTargetSize(_ context.Context, req *protos.NodeGroupTa
 	if ng == nil {
 		return nil, fmt.Errorf("NodeGroup %q, not found", id)
 	}
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (w *Wrapper) NodeGroupIncreaseSize(_ context.Context, req *protos.NodeGroup
 	if ng == nil {
 		return nil, fmt.Errorf("NodeGroup %q, not found", id)
 	}
-	err := ng.IncreaseSize(int(req.GetDelta()))
+	err := ng.IncreaseSize(context.TODO(), int(req.GetDelta()))
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func (w *Wrapper) NodeGroupDeleteNodes(_ context.Context, req *protos.NodeGroupD
 	for _, n := range req.GetNodes() {
 		nodes = append(nodes, apiv1Node(n))
 	}
-	err := ng.DeleteNodes(nodes)
+	err := ng.DeleteNodes(context.TODO(), nodes)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func (w *Wrapper) NodeGroupDecreaseTargetSize(_ context.Context, req *protos.Nod
 	if ng == nil {
 		return nil, fmt.Errorf("NodeGroup %q, not found", id)
 	}
-	err := ng.DecreaseTargetSize(int(req.GetDelta()))
+	err := ng.DecreaseTargetSize(context.TODO(), int(req.GetDelta()))
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +325,7 @@ func (w *Wrapper) NodeGroupNodes(_ context.Context, req *protos.NodeGroupNodesRe
 	if ng == nil {
 		return nil, fmt.Errorf("NodeGroup %q, not found", id)
 	}
-	instances, err := ng.Nodes()
+	instances, err := ng.Nodes(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +367,7 @@ func (w *Wrapper) NodeGroupTemplateNodeInfo(_ context.Context, req *protos.NodeG
 	if ng == nil {
 		return nil, fmt.Errorf("NodeGroup %q, not found", id)
 	}
-	info, err := ng.TemplateNodeInfo()
+	info, err := ng.TemplateNodeInfo(context.TODO())
 	if err != nil {
 		if err == cloudprovider.ErrNotImplemented {
 			return nil, status.Error(codes.Unimplemented, err.Error())
@@ -421,7 +421,7 @@ func (w *Wrapper) NodeGroupGetOptions(_ context.Context, req *protos.NodeGroupAu
 		ZeroOrMaxNodeScaling:             pbDefaults.GetZeroOrMaxNodeScaling(),
 		IgnoreDaemonSetsUtilization:      pbDefaults.GetIgnoreDaemonSetsUtilization(),
 	}
-	opts, err := ng.GetOptions(defaults)
+	opts, err := ng.GetOptions(context.TODO(), defaults)
 	if err != nil {
 		if err == cloudprovider.ErrNotImplemented {
 			return nil, status.Error(codes.Unimplemented, err.Error())

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
@@ -79,7 +79,7 @@ func (e *externalGrpcCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (e *externalGrpcCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (e *externalGrpcCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
@@ -114,7 +114,7 @@ func (e *externalGrpcCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (e *externalGrpcCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (e *externalGrpcCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
@@ -158,7 +158,7 @@ func (e *externalGrpcCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpro
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (e *externalGrpcCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (e *externalGrpcCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
@@ -169,7 +169,7 @@ type pricingModel struct {
 }
 
 // NodePrice returns a price of running the given node for a given period of time.
-func (m *pricingModel) NodePrice(node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
+func (m *pricingModel) NodePrice(ctx context.Context, node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), m.grpcTimeout)
 	defer cancel()
 	klog.V(5).Infof("Performing gRPC call PricingNodePrice for node %v", node.Name)
@@ -192,7 +192,7 @@ func (m *pricingModel) NodePrice(node *apiv1.Node, startTime time.Time, endTime 
 
 // PodPrice returns a theoretical minimum price of running a pod for a given
 // period of time on a perfectly matching machine.
-func (m *pricingModel) PodPrice(pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
+func (m *pricingModel) PodPrice(ctx context.Context, pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), m.grpcTimeout)
 	defer cancel()
 	klog.V(5).Infof("Performing gRPC call PricingPodPrice for pod %v", pod.Name)
@@ -224,7 +224,7 @@ func (m *pricingModel) PodPrice(pod *apiv1.Pod, startTime time.Time, endTime tim
 // The external gRPC provider will always return a pricing model without errors,
 // even if a cloud provider does not actually support this feature, errors will be returned
 // by subsequent calls to the pricing model if this is the case.
-func (e *externalGrpcCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (e *externalGrpcCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return &pricingModel{
 		client:      e.client,
 		grpcTimeout: e.grpcTimeout,
@@ -233,25 +233,25 @@ func (e *externalGrpcCloudProvider) Pricing() (cloudprovider.PricingModel, error
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (e *externalGrpcCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (e *externalGrpcCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (e *externalGrpcCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (e *externalGrpcCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (e *externalGrpcCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (e *externalGrpcCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return e.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (e *externalGrpcCloudProvider) GPULabel() string {
+func (e *externalGrpcCloudProvider) GPULabel(ctx context.Context) string {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
@@ -273,7 +273,7 @@ func (e *externalGrpcCloudProvider) GPULabel() string {
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (e *externalGrpcCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (e *externalGrpcCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
@@ -300,12 +300,12 @@ func (e *externalGrpcCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (e *externalGrpcCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(e, node)
+func (e *externalGrpcCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), e, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (e *externalGrpcCloudProvider) Cleanup() error {
+func (e *externalGrpcCloudProvider) Cleanup(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(context.Background(), e.grpcTimeout)
 	defer cancel()
 	klog.V(5).Info("Performing gRPC call Cleanup")
@@ -319,7 +319,7 @@ func (e *externalGrpcCloudProvider) Cleanup() error {
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (e *externalGrpcCloudProvider) Refresh() error {
+func (e *externalGrpcCloudProvider) Refresh(ctx context.Context) error {
 	// invalidate cache
 	e.mutex.Lock()
 	e.nodeGroupForNodeCache = make(map[string]cloudprovider.NodeGroup)

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package externalgrpc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -51,17 +52,17 @@ func TestCloudProvider_NodeGroups(t *testing.T) {
 		}, nil,
 	).Times(2)
 
-	ngs := c.NodeGroups()
+	ngs := c.NodeGroups(context.Background())
 	assert.Equal(t, 2, len(ngs))
 	for _, ng := range ngs {
 		if ng.Id() == "1" {
-			assert.Equal(t, 10, ng.MinSize())
-			assert.Equal(t, 20, ng.MaxSize())
-			assert.Equal(t, "test1", ng.Debug())
+			assert.Equal(t, 10, ng.MinSize(context.Background()))
+			assert.Equal(t, 20, ng.MaxSize(context.Background()))
+			assert.Equal(t, "test1", ng.Debug(context.Background()))
 		} else if ng.Id() == "2" {
-			assert.Equal(t, 30, ng.MinSize())
-			assert.Equal(t, 40, ng.MaxSize())
-			assert.Equal(t, "test2", ng.Debug())
+			assert.Equal(t, 30, ng.MinSize(context.Background()))
+			assert.Equal(t, 40, ng.MaxSize(context.Background()))
+			assert.Equal(t, "test2", ng.Debug(context.Background()))
 		} else {
 			assert.Fail(t, "node group id not recognized")
 		}
@@ -69,19 +70,19 @@ func TestCloudProvider_NodeGroups(t *testing.T) {
 
 	// test cached answer
 	m.AssertNumberOfCalls(t, "NodeGroups", 1)
-	ngs = c.NodeGroups()
+	ngs = c.NodeGroups(context.Background())
 	assert.Equal(t, 2, len(ngs))
 	m.AssertNumberOfCalls(t, "NodeGroups", 1)
 
 	// test answer after refresh to clear cached answer
-	err := c.Refresh()
+	err := c.Refresh(context.Background())
 	assert.NoError(t, err)
-	ngs = c.NodeGroups()
+	ngs = c.NodeGroups(context.Background())
 	assert.Equal(t, 2, len(ngs))
 	m.AssertNumberOfCalls(t, "NodeGroups", 2)
 
 	// test empty answer
-	err = c.Refresh()
+	err = c.Refresh(context.Background())
 	assert.NoError(t, err)
 
 	m.On(
@@ -92,12 +93,12 @@ func TestCloudProvider_NodeGroups(t *testing.T) {
 		}, nil,
 	).Once()
 
-	ngs = c.NodeGroups()
+	ngs = c.NodeGroups(context.Background())
 	assert.NotNil(t, ngs)
 	assert.Equal(t, 0, len(ngs))
 
 	// test grpc error
-	err = c.Refresh()
+	err = c.Refresh(context.Background())
 	assert.NoError(t, err)
 
 	m.On(
@@ -109,7 +110,7 @@ func TestCloudProvider_NodeGroups(t *testing.T) {
 		fmt.Errorf("mock error"),
 	).Once()
 
-	ngs = c.NodeGroups()
+	ngs = c.NodeGroups(context.Background())
 	assert.NotNil(t, ngs)
 	assert.Equal(t, 0, len(ngs))
 
@@ -146,41 +147,41 @@ func TestCloudProvider_NodeGroupForNode(t *testing.T) {
 	apiv1Node1.Name = "node1"
 	apiv1Node1.Spec.ProviderID = "providerId://node1"
 
-	ng1, err := c.NodeGroupForNode(apiv1Node1)
+	ng1, err := c.NodeGroupForNode(context.Background(), apiv1Node1)
 	assert.NoError(t, err)
 	assert.Equal(t, "1", ng1.Id())
-	assert.Equal(t, 10, ng1.MinSize())
-	assert.Equal(t, 20, ng1.MaxSize())
-	assert.Equal(t, "test1", ng1.Debug())
+	assert.Equal(t, 10, ng1.MinSize(context.Background()))
+	assert.Equal(t, 20, ng1.MaxSize(context.Background()))
+	assert.Equal(t, "test1", ng1.Debug(context.Background()))
 
 	apiv1Node2 := &apiv1.Node{}
 	apiv1Node2.Name = "node2"
 	apiv1Node2.Spec.ProviderID = "providerId://node2"
 
-	ng2, err := c.NodeGroupForNode(apiv1Node2)
+	ng2, err := c.NodeGroupForNode(context.Background(), apiv1Node2)
 	assert.NoError(t, err)
 	assert.Equal(t, "2", ng2.Id())
-	assert.Equal(t, 30, ng2.MinSize())
-	assert.Equal(t, 40, ng2.MaxSize())
-	assert.Equal(t, "test2", ng2.Debug())
+	assert.Equal(t, 30, ng2.MinSize(context.Background()))
+	assert.Equal(t, 40, ng2.MaxSize(context.Background()))
+	assert.Equal(t, "test2", ng2.Debug(context.Background()))
 
 	// test cached answer
-	ng1, err = c.NodeGroupForNode(apiv1Node1)
+	ng1, err = c.NodeGroupForNode(context.Background(), apiv1Node1)
 	assert.NoError(t, err)
 	assert.Equal(t, "1", ng1.Id())
 	m.AssertNumberOfCalls(t, "NodeGroupForNode", 2)
 
 	// test clear cache
-	err = c.Refresh()
+	err = c.Refresh(context.Background())
 	assert.NoError(t, err)
 
-	ng1, err = c.NodeGroupForNode(apiv1Node1)
+	ng1, err = c.NodeGroupForNode(context.Background(), apiv1Node1)
 	assert.NoError(t, err)
 	assert.Equal(t, "1", ng1.Id())
 	m.AssertNumberOfCalls(t, "NodeGroupForNode", 3)
 
 	//test no node group for node
-	err = c.Refresh()
+	err = c.Refresh(context.Background())
 	assert.NoError(t, err)
 
 	m.On(
@@ -197,12 +198,12 @@ func TestCloudProvider_NodeGroupForNode(t *testing.T) {
 	apiv1Node3.Name = "node3"
 	apiv1Node3.Spec.ProviderID = "providerId://node3"
 
-	ng3, err := c.NodeGroupForNode(apiv1Node3)
+	ng3, err := c.NodeGroupForNode(context.Background(), apiv1Node3)
 	assert.NoError(t, err)
 	assert.Equal(t, nil, ng3)
 
 	//test grpc error
-	err = c.Refresh()
+	err = c.Refresh(context.Background())
 	assert.NoError(t, err)
 
 	m.On(
@@ -220,16 +221,16 @@ func TestCloudProvider_NodeGroupForNode(t *testing.T) {
 	apiv1Node4.Name = "node4"
 	apiv1Node4.Spec.ProviderID = "providerId://node4"
 
-	_, err = c.NodeGroupForNode(apiv1Node4)
+	_, err = c.NodeGroupForNode(context.Background(), apiv1Node4)
 	assert.Error(t, err)
 
 	//test error is not cached
-	_, err = c.NodeGroupForNode(apiv1Node4)
+	_, err = c.NodeGroupForNode(context.Background(), apiv1Node4)
 	assert.Error(t, err)
 	m.AssertNumberOfCalls(t, "NodeGroupForNode", 6)
 
 	//test nil node param
-	_, err = c.NodeGroupForNode(nil)
+	_, err = c.NodeGroupForNode(context.Background(), nil)
 	assert.Error(t, err)
 }
 
@@ -238,7 +239,7 @@ func TestCloudProvider_Pricing(t *testing.T) {
 	defer teardown()
 	c := newExternalGrpcCloudProvider(client, defaultGRPCTimeout, nil)
 
-	model, errPricing := c.Pricing()
+	model, errPricing := c.Pricing(context.Background())
 	assert.NoError(t, errPricing)
 	assert.NotNil(t, model)
 
@@ -263,14 +264,14 @@ func TestCloudProvider_Pricing(t *testing.T) {
 	apiv1Node1 := &apiv1.Node{}
 	apiv1Node1.Name = "node1"
 
-	price, err := model.NodePrice(apiv1Node1, time.Time{}, time.Time{})
+	price, err := model.NodePrice(context.Background(), apiv1Node1, time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.Equal(t, float64(100), price)
 
 	apiv1Node2 := &apiv1.Node{}
 	apiv1Node2.Name = "node2"
 
-	price, err = model.NodePrice(apiv1Node2, time.Time{}, time.Time{})
+	price, err = model.NodePrice(context.Background(), apiv1Node2, time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.Equal(t, float64(200), price)
 
@@ -287,7 +288,7 @@ func TestCloudProvider_Pricing(t *testing.T) {
 	apiv1Node3 := &apiv1.Node{}
 	apiv1Node3.Name = "node3"
 
-	_, err = model.NodePrice(apiv1Node3, time.Time{}, time.Time{})
+	_, err = model.NodePrice(context.Background(), apiv1Node3, time.Time{}, time.Time{})
 	assert.Error(t, err)
 
 	// test notImplemented for NodePrice
@@ -303,7 +304,7 @@ func TestCloudProvider_Pricing(t *testing.T) {
 	apiv1Node4 := &apiv1.Node{}
 	apiv1Node4.Name = "node4"
 
-	_, err = model.NodePrice(apiv1Node4, time.Time{}, time.Time{})
+	_, err = model.NodePrice(context.Background(), apiv1Node4, time.Time{}, time.Time{})
 	assert.Error(t, err)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 
@@ -330,14 +331,14 @@ func TestCloudProvider_Pricing(t *testing.T) {
 	apiv1Pod1 := &apiv1.Pod{}
 	apiv1Pod1.Name = "pod1"
 
-	price, err = model.PodPrice(apiv1Pod1, time.Time{}, time.Time{})
+	price, err = model.PodPrice(context.Background(), apiv1Pod1, time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.Equal(t, float64(100), price)
 
 	apiv1Pod2 := &apiv1.Pod{}
 	apiv1Pod2.Name = "pod2"
 
-	price, err = model.PodPrice(apiv1Pod2, time.Time{}, time.Time{})
+	price, err = model.PodPrice(context.Background(), apiv1Pod2, time.Time{}, time.Time{})
 	assert.NoError(t, err)
 	assert.Equal(t, float64(200), price)
 
@@ -355,7 +356,7 @@ func TestCloudProvider_Pricing(t *testing.T) {
 	apiv1Pod3 := &apiv1.Pod{}
 	apiv1Pod3.Name = "pod3"
 
-	_, err = model.PodPrice(apiv1Pod3, time.Time{}, time.Time{})
+	_, err = model.PodPrice(context.Background(), apiv1Pod3, time.Time{}, time.Time{})
 	assert.Error(t, err)
 
 	// test notImplemented for PodPrice
@@ -372,7 +373,7 @@ func TestCloudProvider_Pricing(t *testing.T) {
 	apiv1Pod4 := &apiv1.Pod{}
 	apiv1Pod4.Name = "pod4"
 
-	_, err = model.PodPrice(apiv1Pod4, time.Time{}, time.Time{})
+	_, err = model.PodPrice(context.Background(), apiv1Pod4, time.Time{}, time.Time{})
 	assert.Error(t, err)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 
@@ -393,11 +394,11 @@ func TestCloudProvider_GPULabel(t *testing.T) {
 		nil,
 	)
 
-	label := c.GPULabel()
+	label := c.GPULabel(context.Background())
 	assert.Equal(t, "gpu_label", label)
 
 	// test cache
-	label = c.GPULabel()
+	label = c.GPULabel(context.Background())
 	assert.Equal(t, "gpu_label", label)
 	m.AssertNumberOfCalls(t, "GPULabel", 1)
 
@@ -414,11 +415,11 @@ func TestCloudProvider_GPULabel(t *testing.T) {
 		&protos.GPULabelResponse{Label: "gpu_label"},
 		fmt.Errorf("mock error"),
 	)
-	label = c2.GPULabel()
+	label = c2.GPULabel(context.Background())
 	assert.Equal(t, "", label)
 
 	//test error is not cached
-	label = c2.GPULabel()
+	label = c2.GPULabel(context.Background())
 	assert.Equal(t, "", label)
 	m2.AssertNumberOfCalls(t, "GPULabel", 2)
 
@@ -443,13 +444,13 @@ func TestCloudProvider_GetAvailableGPUTypes(t *testing.T) {
 		nil,
 	)
 
-	gpuTypes := c.GetAvailableGPUTypes()
+	gpuTypes := c.GetAvailableGPUTypes(context.Background())
 	assert.NotNil(t, gpuTypes)
 	assert.NotNil(t, gpuTypes["type1"])
 	assert.NotNil(t, gpuTypes["type2"])
 
 	// test cache
-	gpuTypes = c.GetAvailableGPUTypes()
+	gpuTypes = c.GetAvailableGPUTypes(context.Background())
 	assert.NotNil(t, gpuTypes)
 	assert.NotNil(t, gpuTypes["type1"])
 	assert.NotNil(t, gpuTypes["type2"])
@@ -467,7 +468,7 @@ func TestCloudProvider_GetAvailableGPUTypes(t *testing.T) {
 		nil,
 	)
 
-	gpuTypes = c2.GetAvailableGPUTypes()
+	gpuTypes = c2.GetAvailableGPUTypes(context.Background())
 	assert.NotNil(t, gpuTypes)
 	assert.Equal(t, 0, len(gpuTypes))
 
@@ -483,11 +484,11 @@ func TestCloudProvider_GetAvailableGPUTypes(t *testing.T) {
 		fmt.Errorf("mock error"),
 	)
 
-	gpuTypes = c3.GetAvailableGPUTypes()
+	gpuTypes = c3.GetAvailableGPUTypes(context.Background())
 	assert.Nil(t, gpuTypes)
 
 	// test error is not cahced
-	gpuTypes = c3.GetAvailableGPUTypes()
+	gpuTypes = c3.GetAvailableGPUTypes(context.Background())
 	assert.Nil(t, gpuTypes)
 	m3.AssertNumberOfCalls(t, "GetAvailableGPUTypes", 2)
 
@@ -506,7 +507,7 @@ func TestCloudProvider_Cleanup(t *testing.T) {
 		nil,
 	).Once()
 
-	err := c.Cleanup()
+	err := c.Cleanup(context.Background())
 	assert.NoError(t, err)
 
 	// test grpc error
@@ -517,7 +518,7 @@ func TestCloudProvider_Cleanup(t *testing.T) {
 		fmt.Errorf("mock error"),
 	).Once()
 
-	err = c.Cleanup()
+	err = c.Cleanup(context.Background())
 	assert.Error(t, err)
 }
 
@@ -534,7 +535,7 @@ func TestCloudProvider_Refresh(t *testing.T) {
 		nil,
 	).Once()
 
-	err := c.Refresh()
+	err := c.Refresh(context.Background())
 	assert.NoError(t, err)
 
 	// test grpc error
@@ -545,6 +546,6 @@ func TestCloudProvider_Refresh(t *testing.T) {
 		fmt.Errorf("mock error"),
 	).Once()
 
-	err = c.Refresh()
+	err = c.Refresh(context.Background())
 	assert.Error(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
@@ -49,12 +49,12 @@ type NodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *NodeGroup) MaxSize() int {
+func (n *NodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *NodeGroup) MinSize() int {
+func (n *NodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
@@ -63,7 +63,7 @@ func (n *NodeGroup) MinSize() int {
 // be equal to Size() once everything stabilizes (new nodes finish startup and
 // registration or removed nodes are deleted completely). Implementation
 // required.
-func (n *NodeGroup) TargetSize() (int, error) {
+func (n *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), n.grpcTimeout)
 	defer cancel()
 	klog.V(5).Infof("Performing gRPC call NodeGroupTargetSize for node group %v", n.id)
@@ -80,7 +80,7 @@ func (n *NodeGroup) TargetSize() (int, error) {
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *NodeGroup) IncreaseSize(delta int) error {
+func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	ctx, cancel := context.WithTimeout(context.Background(), n.grpcTimeout)
 	defer cancel()
 	klog.V(5).Infof("Performing gRPC call NodeGroupIncreaseSize for node group %v", n.id)
@@ -96,7 +96,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -104,7 +104,7 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	pbNodes := make([]*protos.ExternalGrpcNode, 0)
 	for _, n := range nodes {
 		pbNodes = append(pbNodes, externalGrpcNode(n))
@@ -124,7 +124,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -133,7 +133,7 @@ func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *NodeGroup) DecreaseTargetSize(delta int) error {
+func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	ctx, cancel := context.WithTimeout(context.Background(), n.grpcTimeout)
 	defer cancel()
 	klog.V(5).Infof("Performing gRPC call NodeGroupDecreaseTargetSize for node group %v", n.id)
@@ -154,14 +154,14 @@ func (n *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroup) Debug() string {
+func (n *NodeGroup) Debug(ctx context.Context) string {
 	return n.debug
 }
 
 // Nodes returns a list of all nodes that belong to this node group. It is
 // required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
-func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), n.grpcTimeout)
 	defer cancel()
 	klog.V(5).Infof("Performing gRPC call NodeGroupNodes for node group %v", n.id)
@@ -206,7 +206,7 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // complex approach and does not cover all the scenarios. For the sake of simplicity,
 // the `nodeInfo` is defined as a Kubernetes `k8s.io.api.core.v1.Node` type
 // where the system could still extract certain info about the node.
-func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
@@ -247,32 +247,32 @@ func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 // Exist checks if the node group really exists on the cloud provider side.
 // Allows to tell the theoretical node group from the real one. Implementation
 // required.
-func (n *NodeGroup) Exist() bool {
+func (n *NodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation
 // optional.
-func (n *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.  This will be
 // executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroup) Delete() error {
+func (n *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroup) Autoprovisioned() bool {
+func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), n.grpcTimeout)
 	defer cancel()
 	klog.V(5).Infof("Performing gRPC call NodeGroupGetOptions for node group %v", n.id)

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package externalgrpc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -76,7 +77,7 @@ func TestCloudProvider_Nodes(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	instances, err := ng1.Nodes()
+	instances, err := ng1.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(instances))
 	for _, i := range instances {
@@ -113,7 +114,7 @@ func TestCloudProvider_Nodes(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	_, err = ng2.Nodes()
+	_, err = ng2.Nodes(context.Background())
 	assert.Error(t, err)
 
 }
@@ -163,16 +164,16 @@ func TestCloudProvider_TemplateNodeInfo(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	nodeInfo1, err := ng1.TemplateNodeInfo()
+	nodeInfo1, err := ng1.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, apiv1Node1.Name, nodeInfo1.Node().Name)
 
-	nodeInfo2, err := ng2.TemplateNodeInfo()
+	nodeInfo2, err := ng2.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, apiv1Node2.Name, nodeInfo2.Node().Name)
 
 	// test cached answer
-	nodeInfo1, err = ng1.TemplateNodeInfo()
+	nodeInfo1, err = ng1.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, apiv1Node1.Name, nodeInfo1.Node().Name)
 	m.AssertNumberOfCalls(t, "NodeGroupTemplateNodeInfo", 2)
@@ -194,7 +195,7 @@ func TestCloudProvider_TemplateNodeInfo(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	nodeInfo3, err := ng3.TemplateNodeInfo()
+	nodeInfo3, err := ng3.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Nil(t, nodeInfo3)
 
@@ -216,7 +217,7 @@ func TestCloudProvider_TemplateNodeInfo(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	_, err = ng4.TemplateNodeInfo()
+	_, err = ng4.TemplateNodeInfo(context.Background())
 	assert.Error(t, err)
 
 	// test notImplemented
@@ -237,7 +238,7 @@ func TestCloudProvider_TemplateNodeInfo(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	_, err = ng5.TemplateNodeInfo()
+	_, err = ng5.TemplateNodeInfo(context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 
@@ -283,7 +284,7 @@ func TestCloudProvider_GetOptions(t *testing.T) {
 		IgnoreDaemonSetsUtilization:      false,
 	}
 
-	opts, err := ng1.GetOptions(defaultsOpts)
+	opts, err := ng1.GetOptions(context.Background(), defaultsOpts)
 	assert.NoError(t, err)
 	assert.Equal(t, 0.6, opts.ScaleDownUtilizationThreshold)
 	assert.Equal(t, 0.7, opts.ScaleDownGpuUtilizationThreshold)
@@ -311,7 +312,7 @@ func TestCloudProvider_GetOptions(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	opts, err = ng2.GetOptions(defaultsOpts)
+	opts, err = ng2.GetOptions(context.Background(), defaultsOpts)
 	assert.Error(t, err)
 	assert.Nil(t, opts)
 
@@ -331,7 +332,7 @@ func TestCloudProvider_GetOptions(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	opts, err = ng3.GetOptions(defaultsOpts)
+	opts, err = ng3.GetOptions(context.Background(), defaultsOpts)
 	assert.NoError(t, err)
 	assert.Nil(t, opts)
 
@@ -351,7 +352,7 @@ func TestCloudProvider_GetOptions(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	_, err = ng4.GetOptions(defaultsOpts)
+	_, err = ng4.GetOptions(context.Background(), defaultsOpts)
 	assert.Error(t, err)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 
@@ -379,7 +380,7 @@ func TestCloudProvider_GetOptions(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	opts, err = ng5.GetOptions(defaultsOpts)
+	opts, err = ng5.GetOptions(context.Background(), defaultsOpts)
 	assert.NoError(t, err)
 	assert.Equal(t, 0.6, opts.ScaleDownUtilizationThreshold)
 	assert.Equal(t, 0.7, opts.ScaleDownGpuUtilizationThreshold)
@@ -412,7 +413,7 @@ func TestCloudProvider_TargetSize(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	size, err := ng1.TargetSize()
+	size, err := ng1.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, size)
 
@@ -432,7 +433,7 @@ func TestCloudProvider_TargetSize(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	_, err = ng2.TargetSize()
+	_, err = ng2.TargetSize(context.Background())
 	assert.Error(t, err)
 
 }
@@ -456,7 +457,7 @@ func TestCloudProvider_IncreaseSize(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	err := ng1.IncreaseSize(1)
+	err := ng1.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	// test grpc error
@@ -475,7 +476,7 @@ func TestCloudProvider_IncreaseSize(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	err = ng2.IncreaseSize(1)
+	err = ng2.IncreaseSize(context.Background(), 1)
 	assert.Error(t, err)
 
 }
@@ -499,7 +500,7 @@ func TestCloudProvider_DecreaseSize(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	err := ng1.DecreaseTargetSize(1)
+	err := ng1.DecreaseTargetSize(context.Background(), 1)
 	assert.NoError(t, err)
 
 	// test grpc error
@@ -518,7 +519,7 @@ func TestCloudProvider_DecreaseSize(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	err = ng2.DecreaseTargetSize(1)
+	err = ng2.DecreaseTargetSize(context.Background(), 1)
 	assert.Error(t, err)
 
 }
@@ -550,7 +551,7 @@ func TestCloudProvider_DeleteNodes(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	err := ng1.DeleteNodes(nodes)
+	err := ng1.DeleteNodes(context.Background(), nodes)
 	assert.NoError(t, err)
 
 	// test grpc error
@@ -569,7 +570,7 @@ func TestCloudProvider_DeleteNodes(t *testing.T) {
 		grpcTimeout: defaultGRPCTimeout,
 	}
 
-	err = ng2.DeleteNodes(nodes)
+	err = ng2.DeleteNodes(context.Background(), nodes)
 	assert.Error(t, err)
 
 }

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -134,33 +134,33 @@ type GceInstance struct {
 // AutoscalingGceClient is used for communicating with GCE API.
 type AutoscalingGceClient interface {
 	// reading resources
-	FetchMachineType(zone, machineType string) (*gce.MachineType, error)
+	FetchMachineType(ctx context.Context, zone, machineType string) (*gce.MachineType, error)
 	FetchMachineTypes(zone string) ([]*gce.MachineType, error)
 	FetchAllMigs(zone string) ([]*gce.InstanceGroupManager, error)
-	FetchAllInstances(project, zone string, filter string) ([]GceInstance, error)
-	FetchMig(migRef GceRef) (*gce.InstanceGroupManager, error)
-	FetchMigTargetSize(GceRef) (int64, error)
-	FetchMigBasename(GceRef) (string, error)
-	FetchMigInstances(GceRef) ([]GceInstance, error)
-	FetchMigTemplateName(migRef GceRef) (InstanceTemplateName, error)
-	FetchMigTemplate(migRef GceRef, templateName string, regional bool) (*gce.InstanceTemplate, error)
-	FetchMigsWithName(zone string, filter *regexp.Regexp) ([]string, error)
-	FetchZones(region string) ([]string, error)
+	FetchAllInstances(ctx context.Context, project, zone string, filter string) ([]GceInstance, error)
+	FetchMig(ctx context.Context, migRef GceRef) (*gce.InstanceGroupManager, error)
+	FetchMigTargetSize(context.Context, GceRef) (int64, error)
+	FetchMigBasename(context.Context, GceRef) (string, error)
+	FetchMigInstances(context.Context, GceRef) ([]GceInstance, error)
+	FetchMigTemplateName(ctx context.Context, migRef GceRef) (InstanceTemplateName, error)
+	FetchMigTemplate(ctx context.Context, migRef GceRef, templateName string, regional bool) (*gce.InstanceTemplate, error)
+	FetchMigsWithName(ctx context.Context, zone string, filter *regexp.Regexp) ([]string, error)
+	FetchZones(ctx context.Context, region string) ([]string, error)
 	FetchAvailableCpuPlatforms() (map[string][]string, error)
 	FetchAvailableDiskTypes(zone string) ([]string, error)
 	FetchReservations() ([]*gce.Reservation, error)
 	FetchReservationsInProject(projectId string) ([]*gce.Reservation, error)
-	FetchListManagedInstancesResults(migRef GceRef) (string, error)
+	FetchListManagedInstancesResults(ctx context.Context, migRef GceRef) (string, error)
 
 	// modifying resources
-	ResizeMig(GceRef, int64) error
-	DeleteInstances(migRef GceRef, instances []GceRef) error
-	CreateInstances(GceRef, string, int64, []string) ([]string, error)
+	ResizeMig(context.Context, GceRef, int64) error
+	DeleteInstances(ctx context.Context, migRef GceRef, instances []GceRef) error
+	CreateInstances(context.Context, GceRef, string, int64, []string) ([]string, error)
 
 	// WaitForOperation can be used to poll GCE operations until completion/timeout using WAIT calls.
 	// Calling this is normally not needed when interacting with the client, other methods should call it internally.
 	// Can be used to extend the interface with more methods outside of this package.
-	WaitForOperation(operationName, operationType, project, zone string) error
+	WaitForOperation(ctx context.Context, operationName, operationType, project, zone string) error
 }
 
 type autoscalingGceClientV1 struct {
@@ -219,9 +219,9 @@ func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl, 
 	}, nil
 }
 
-func (client *autoscalingGceClientV1) FetchMachineType(zone, machineType string) (*gce.MachineType, error) {
+func (client *autoscalingGceClientV1) FetchMachineType(ctx context.Context, zone, machineType string) (*gce.MachineType, error) {
 	registerRequest("machine_types", "get")
-	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
+	ctx, cancel := context.WithTimeout(ctx, client.operationPerCallTimeout)
 	defer cancel()
 	return client.gceService.MachineTypes.Get(client.projectId, zone, machineType).Context(ctx).Do()
 }
@@ -256,9 +256,9 @@ func (client *autoscalingGceClientV1) FetchAllMigs(zone string) ([]*gce.Instance
 	return migs, nil
 }
 
-func (client *autoscalingGceClientV1) FetchMig(migRef GceRef) (*gce.InstanceGroupManager, error) {
+func (client *autoscalingGceClientV1) FetchMig(ctx context.Context, migRef GceRef) (*gce.InstanceGroupManager, error) {
 	registerRequest("instance_group_managers", "get")
-	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
+	ctx, cancel := context.WithTimeout(ctx, client.operationPerCallTimeout)
 	defer cancel()
 	igm, err := client.gceService.InstanceGroupManagers.Get(migRef.Project, migRef.Zone, migRef.Name).Context(ctx).Do()
 	if err != nil {
@@ -272,51 +272,51 @@ func (client *autoscalingGceClientV1) FetchMig(migRef GceRef) (*gce.InstanceGrou
 	return igm, nil
 }
 
-func (client *autoscalingGceClientV1) FetchMigTargetSize(migRef GceRef) (int64, error) {
-	igm, err := client.FetchMig(migRef)
+func (client *autoscalingGceClientV1) FetchMigTargetSize(ctx context.Context, migRef GceRef) (int64, error) {
+	igm, err := client.FetchMig(ctx, migRef)
 	if err != nil {
 		return 0, err
 	}
 	return igm.TargetSize + igm.TargetSuspendedSize, nil
 }
 
-func (client *autoscalingGceClientV1) FetchMigBasename(migRef GceRef) (string, error) {
-	igm, err := client.FetchMig(migRef)
+func (client *autoscalingGceClientV1) FetchMigBasename(ctx context.Context, migRef GceRef) (string, error) {
+	igm, err := client.FetchMig(ctx, migRef)
 	if err != nil {
 		return "", err
 	}
 	return igm.BaseInstanceName, nil
 }
 
-func (client *autoscalingGceClientV1) FetchListManagedInstancesResults(migRef GceRef) (string, error) {
-	igm, err := client.FetchMig(migRef)
+func (client *autoscalingGceClientV1) FetchListManagedInstancesResults(ctx context.Context, migRef GceRef) (string, error) {
+	igm, err := client.FetchMig(ctx, migRef)
 	if err != nil {
 		return "", err
 	}
 	return igm.ListManagedInstancesResults, nil
 }
 
-func (client *autoscalingGceClientV1) ResizeMig(migRef GceRef, size int64) error {
+func (client *autoscalingGceClientV1) ResizeMig(ctx context.Context, migRef GceRef, size int64) error {
 	registerRequest("instance_group_managers", "resize")
-	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
+	ctx, cancel := context.WithTimeout(ctx, client.operationPerCallTimeout)
 	defer cancel()
 	op, err := client.gceService.InstanceGroupManagers.Resize(migRef.Project, migRef.Zone, migRef.Name, size).Context(ctx).Do()
 	if err != nil {
 		return err
 	}
-	return client.WaitForOperation(op.Name, op.OperationType, migRef.Project, migRef.Zone)
+	return client.WaitForOperation(ctx, op.Name, op.OperationType, migRef.Project, migRef.Zone)
 }
 
-func (client *autoscalingGceClientV1) CreateInstances(migRef GceRef, baseName string, delta int64, existingInstanceProviderIds []string) ([]string, error) {
+func (client *autoscalingGceClientV1) CreateInstances(ctx context.Context, migRef GceRef, baseName string, delta int64, existingInstanceProviderIds []string) ([]string, error) {
 	registerRequest("instance_group_managers", "create_instances")
-	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
+	ctx, cancel := context.WithTimeout(ctx, client.operationPerCallTimeout)
 	defer cancel()
 	req := gce.InstanceGroupManagersCreateInstancesRequest{}
-	instanceNames := instanceIdsToNamesMap(existingInstanceProviderIds)
+	instanceNames := instanceIdsToNamesMap(ctx, existingInstanceProviderIds)
 	req.Instances = make([]*gce.PerInstanceConfig, 0, delta)
 	createdIds := make([]string, delta)
 	for i := range delta {
-		newInstanceName := generateInstanceName(baseName, instanceNames)
+		newInstanceName := generateInstanceName(ctx, baseName, instanceNames)
 		instanceNames[newInstanceName] = true
 		req.Instances = append(req.Instances, &gce.PerInstanceConfig{Name: newInstanceName})
 		ref := GceRef{migRef.Project, migRef.Zone, newInstanceName}
@@ -327,15 +327,16 @@ func (client *autoscalingGceClientV1) CreateInstances(migRef GceRef, baseName st
 	if err != nil {
 		return nil, err
 	}
-	return createdIds, client.WaitForOperation(op.Name, op.OperationType, migRef.Project, migRef.Zone)
+	return createdIds, client.WaitForOperation(ctx, op.Name, op.OperationType, migRef.Project, migRef.Zone)
 }
 
-func instanceIdsToNamesMap(instanceProviderIds []string) map[string]bool {
+func instanceIdsToNamesMap(ctx context.Context, instanceProviderIds []string) map[string]bool {
+	logger := klog.FromContext(ctx)
 	instanceNames := make(map[string]bool, len(instanceProviderIds))
 	for _, inst := range instanceProviderIds {
 		ref, err := GceRefFromProviderId(inst)
 		if err != nil {
-			klog.Warningf("Failed to extract instance name from %q: %v", inst, err)
+			logger.Info("Failed to extract instance name from id", "instanceId", inst, "err", err)
 		} else {
 			inst = ref.Name
 		}
@@ -347,19 +348,19 @@ func instanceIdsToNamesMap(instanceProviderIds []string) map[string]bool {
 // WaitForOperation can be used to poll GCE operations until completion/timeout using WAIT calls.
 // Calling this is normally not needed when interacting with the client, other methods should call it internally.
 // Can be used to extend the interface with more methods outside of this package.
-func (client *autoscalingGceClientV1) WaitForOperation(operationName, operationType, project, zone string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), client.operationWaitTimeout)
+func (client *autoscalingGceClientV1) WaitForOperation(ctx context.Context, operationName, operationType, project, zone string) error {
+	logger := klog.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, client.operationWaitTimeout)
 	defer cancel()
 
 	for {
-		klog.V(4).Infof("Waiting for operation %s/%s (%s/%s)", operationType, operationName, project, zone)
+		logger.V(4).Info("Waiting for operation", "operationType", operationType, "operationName", operationName, "project", project, "zone", zone)
 		registerRequest("zone_operations", "wait")
 		op, err := client.gceService.ZoneOperations.Wait(project, zone, operationName).Context(ctx).Do()
 		if err != nil {
 			return fmt.Errorf("error while waiting for operation %s/%s: %w", operationType, operationName, err)
 		}
-
-		klog.V(4).Infof("Operation %s/%s (%s/%s) status: %s", operationType, operationName, project, zone, op.Status)
+		logger.V(4).Info("Operation status", "operationType", operationType, "operationName", operationName, "project", project, "zone", zone, "status", op.Status)
 		if op.Status == "DONE" {
 			if op.Error != nil {
 				errBytes, err := op.Error.MarshalJSON()
@@ -377,9 +378,9 @@ func (client *autoscalingGceClientV1) WaitForOperation(operationName, operationT
 	}
 }
 
-func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances []GceRef) error {
+func (client *autoscalingGceClientV1) DeleteInstances(ctx context.Context, migRef GceRef, instances []GceRef) error {
 	registerRequest("instance_group_managers", "delete_instances")
-	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
+	ctx, cancel := context.WithTimeout(ctx, client.operationPerCallTimeout)
 	defer cancel()
 	req := gce.InstanceGroupManagersDeleteInstancesRequest{
 		Instances:                      []string{},
@@ -392,18 +393,19 @@ func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances [
 	if err != nil {
 		return err
 	}
-	return client.WaitForOperation(op.Name, op.OperationType, migRef.Project, migRef.Zone)
+	return client.WaitForOperation(ctx, op.Name, op.OperationType, migRef.Project, migRef.Zone)
 }
 
-func (client *autoscalingGceClientV1) FetchAllInstances(project, zone, filter string) ([]GceInstance, error) {
+func (client *autoscalingGceClientV1) FetchAllInstances(ctx context.Context, project, zone, filter string) ([]GceInstance, error) {
+	logger := klog.FromContext(ctx)
 	registerRequest("instances", "list")
 	instances := make([]GceInstance, 0)
 	loggingQuota := klogx.NewLoggingQuota(MaxInstancesLogged)
-	err := client.gceService.Instances.List(project, zone).Filter(filter).Pages(context.Background(), func(page *gce.InstanceList) error {
+	err := client.gceService.Instances.List(project, zone).Filter(filter).Pages(ctx, func(page *gce.InstanceList) error {
 		for _, gceInstance := range page.Items {
 			instance, err := externalToInternalInstance(gceInstance, loggingQuota)
 			if err != nil {
-				klog.Errorf("Error converting instance to GceInstance: %v", err)
+				logger.Error(err, "Error converting instance to GceInstance")
 				continue
 			}
 			instances = append(instances, instance)
@@ -411,7 +413,7 @@ func (client *autoscalingGceClientV1) FetchAllInstances(project, zone, filter st
 		return nil
 	})
 	if err != nil {
-		klog.Errorf("Failed listing Instances in zone %s, project %s: %v", zone, project, err)
+		logger.Error(err, "Failed listing Instances", "zone", zone, "project", project)
 		return nil, err
 	}
 	klogx.V(5).Over(loggingQuota).Infof("Unable to parse IGM for %v other instances", -loggingQuota.Left())
@@ -461,15 +463,16 @@ func createIgmRef(gceInstance *gce.Instance, project string, loggingQuota *klogx
 	return igmRef
 }
 
-func (client *autoscalingGceClientV1) FetchMigInstances(migRef GceRef) ([]GceInstance, error) {
+func (client *autoscalingGceClientV1) FetchMigInstances(ctx context.Context, migRef GceRef) ([]GceInstance, error) {
+	logger := klog.FromContext(ctx)
 	registerRequest("instance_group_managers", "list_managed_instances")
 	b := newInstanceListBuilder(migRef)
-	err := client.gceService.InstanceGroupManagers.ListManagedInstances(migRef.Project, migRef.Zone, migRef.Name).Pages(context.Background(), b.loadPage)
+	err := client.gceService.InstanceGroupManagers.ListManagedInstances(migRef.Project, migRef.Zone, migRef.Name).Pages(ctx, b.loadPage)
 	if err != nil {
-		klog.V(4).Infof("Failed MIG info request for %s %s %s: %v", migRef.Project, migRef.Zone, migRef.Name, err)
+		logger.V(4).Info("Failed MIG info request", "mig", migRef, "err", err)
 		return nil, err
 	}
-	return b.build(), nil
+	return b.build(ctx), nil
 }
 
 type instanceListBuilder struct {
@@ -561,10 +564,11 @@ func (i *instanceListBuilder) gceInstanceToInstance(ref GceRef, gceInstance *gce
 	return instance
 }
 
-func (i *instanceListBuilder) build() []GceInstance {
+func (i *instanceListBuilder) build(ctx context.Context) []GceInstance {
+	logger := klog.FromContext(ctx)
 	klogx.V(4).Over(i.errorLoggingQuota).Infof("Got %v other GCE instances being created with lastAttemptErrors", -i.errorLoggingQuota.Left())
 	if len(i.errorCodeCounts) > 0 {
-		klog.Warningf("Spotted following instance creation error codes: %#v", i.errorCodeCounts)
+		logger.Info("Spotted following instance creation error codes", "errorCodeCounts", i.errorCodeCounts)
 	}
 	return i.infos
 }
@@ -753,21 +757,22 @@ func isInvalidReservationError(errorMessage string) bool {
 	return false
 }
 
-func generateInstanceName(baseName string, existingNames map[string]bool) string {
+func generateInstanceName(ctx context.Context, baseName string, existingNames map[string]bool) string {
+	logger := klog.FromContext(ctx)
 	for i := 0; i < 100; i++ {
 		name := fmt.Sprintf("%v-%v", baseName, rand.String(4))
 		if ok, _ := existingNames[name]; !ok {
 			return name
 		}
 	}
-	klog.Warning("Unable to create unique name for a new instance, duplicate name might occur")
+	logger.Info("Unable to create unique name for a new instance, duplicate name might occur")
 	name := fmt.Sprintf("%v-%v", baseName, rand.String(4))
 	return name
 }
 
-func (client *autoscalingGceClientV1) FetchZones(region string) ([]string, error) {
+func (client *autoscalingGceClientV1) FetchZones(ctx context.Context, region string) ([]string, error) {
 	registerRequest("regions", "get")
-	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
+	ctx, cancel := context.WithTimeout(ctx, client.operationPerCallTimeout)
 	defer cancel()
 	r, err := client.gceService.Regions.Get(client.projectId, region).Context(ctx).Do()
 	if err != nil {
@@ -812,16 +817,16 @@ func (client *autoscalingGceClientV1) FetchAvailableDiskTypes(zone string) ([]st
 	return availableDiskTypes, nil
 }
 
-func (client *autoscalingGceClientV1) FetchMigTemplateName(migRef GceRef) (InstanceTemplateName, error) {
-	igm, err := client.FetchMig(migRef)
+func (client *autoscalingGceClientV1) FetchMigTemplateName(ctx context.Context, migRef GceRef) (InstanceTemplateName, error) {
+	igm, err := client.FetchMig(ctx, migRef)
 	if err != nil {
 		return InstanceTemplateName{}, err
 	}
 	return InstanceTemplateNameFromUrl(igm.InstanceTemplate)
 }
 
-func (client *autoscalingGceClientV1) FetchMigTemplate(migRef GceRef, templateName string, regional bool) (*gce.InstanceTemplate, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
+func (client *autoscalingGceClientV1) FetchMigTemplate(ctx context.Context, migRef GceRef, templateName string, regional bool) (*gce.InstanceTemplate, error) {
+	ctx, cancel := context.WithTimeout(ctx, client.operationPerCallTimeout)
 	defer cancel()
 	if regional {
 		zoneHyphenIndex := strings.LastIndex(migRef.Zone, "-")
@@ -833,15 +838,16 @@ func (client *autoscalingGceClientV1) FetchMigTemplate(migRef GceRef, templateNa
 	return client.gceService.InstanceTemplates.Get(migRef.Project, templateName).Context(ctx).Do()
 }
 
-func (client *autoscalingGceClientV1) FetchMigsWithName(zone string, name *regexp.Regexp) ([]string, error) {
+func (client *autoscalingGceClientV1) FetchMigsWithName(ctx context.Context, zone string, name *regexp.Regexp) ([]string, error) {
+	logger := klog.FromContext(ctx)
 	filter := fmt.Sprintf("name eq %s", name)
 	links := make([]string, 0)
 	registerRequest("instance_groups", "list")
 	req := client.gceService.InstanceGroups.List(client.projectId, zone).Filter(filter)
-	if err := req.Pages(context.TODO(), func(page *gce.InstanceGroupList) error {
+	if err := req.Pages(ctx, func(page *gce.InstanceGroupList) error {
 		for _, ig := range page.Items {
 			links = append(links, ig.SelfLink)
-			klog.V(3).Infof("found managed instance group %s matching regexp %s", ig.Name, name)
+			logger.V(3).Info("Found managed instance group matching regexp", "migName", ig.Name, "regexp", name)
 		}
 		return nil
 	}); err != nil {

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -109,7 +109,7 @@ func TestWaitForOp(t *testing.T) {
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197/wait").Return(operationRunningResponse).Times(3)
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197/wait").Return(operationDoneResponse).Once()
 
-	err := g.WaitForOperation("operation-1505728466148-d16f5197", "TestWaitForOp", projectId, zoneB)
+	err := g.WaitForOperation(context.Background(), "operation-1505728466148-d16f5197", "TestWaitForOp", projectId, zoneB)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
 }
@@ -121,7 +121,7 @@ func TestWaitForOpError(t *testing.T) {
 
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197/wait").Return(operationDoneResponseError).Once()
 
-	err := g.WaitForOperation("operation-1505728466148-d16f5197", "TestWaitForOpError", projectId, zoneB)
+	err := g.WaitForOperation(context.Background(), "operation-1505728466148-d16f5197", "TestWaitForOpError", projectId, zoneB)
 	assert.Error(t, err)
 	mock.AssertExpectationsForObjects(t, server)
 }
@@ -137,7 +137,7 @@ func TestWaitForOpTimeout(t *testing.T) {
 
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197/wait").Return(operationRunningResponse).Once()
 
-	err := g.WaitForOperation("operation-1505728466148-d16f5197", "TestWaitForOpTimeout", projectId, zoneB)
+	err := g.WaitForOperation(context.Background(), "operation-1505728466148-d16f5197", "TestWaitForOpTimeout", projectId, zoneB)
 	assert.Error(t, err)
 	mock.AssertExpectationsForObjects(t, server)
 }
@@ -151,7 +151,7 @@ func TestWaitForOpContextTimeout(t *testing.T) {
 
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197/wait").After(time.Minute).Return(operationDoneResponse).Once()
 
-	err := g.WaitForOperation("operation-1505728466148-d16f5197", "TestWaitForOpContextTimeout", projectId, zoneB)
+	err := g.WaitForOperation(context.Background(), "operation-1505728466148-d16f5197", "TestWaitForOpContextTimeout", projectId, zoneB)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	mock.AssertExpectationsForObjects(t, server)
 }
@@ -282,7 +282,7 @@ func TestErrors(t *testing.T) {
 			b, err := json.Marshal(lmiResponse)
 			assert.NoError(t, err)
 			server.On("handle", "/projects/zones/instanceGroupManagers/listManagedInstances").Return(string(b)).Times(1)
-			instances, err := g.FetchMigInstances(GceRef{})
+			instances, err := g.FetchMigInstances(context.Background(), GceRef{})
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedErrorCode, instances[0].Status.ErrorInfo.ErrorCode)
 			assert.Equal(t, tc.expectedErrorClass, instances[0].Status.ErrorInfo.ErrorClass)
@@ -662,7 +662,7 @@ func TestFetchMigInstancesInstanceUrlHandling(t *testing.T) {
 				assert.NoError(t, err)
 				server.On("handle", "/projects/zones/instanceGroupManagers/listManagedInstances", token).Return(string(b)).Times(1)
 			}
-			gotInstances, err := g.FetchMigInstances(GceRef{})
+			gotInstances, err := g.FetchMigInstances(context.Background(), GceRef{})
 			assert.NoError(t, err)
 			if diff := cmp.Diff(tc.wantInstances, gotInstances, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("FetchMigInstances(...): err diff (-want +got):\n%s", diff)
@@ -698,7 +698,7 @@ func TestUserAgent(t *testing.T) {
 
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505728466148-d16f5197/wait").Return("testuseragent", operationDoneResponse).Maybe()
 
-	err := g.WaitForOperation("operation-1505728466148-d16f5197", "TestUserAgent", projectId, zoneB)
+	err := g.WaitForOperation(context.Background(), "operation-1505728466148-d16f5197", "TestUserAgent", projectId, zoneB)
 
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
@@ -716,136 +716,136 @@ func TestAutoscalingClientTimeouts(t *testing.T) {
 	}{
 		"CreateInstances_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.CreateInstances(GceRef{}, "", 0, nil)
+				_, err := client.CreateInstances(context.Background(), GceRef{}, "", 0, nil)
 				return err
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"DeleteInstances_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				return client.DeleteInstances(GceRef{}, nil)
+				return client.DeleteInstances(context.Background(), GceRef{}, nil)
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"ResizeMig_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				return client.ResizeMig(GceRef{}, 0)
+				return client.ResizeMig(context.Background(), GceRef{}, 0)
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"FetchMachineType_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMachineType("", "")
+				_, err := client.FetchMachineType(context.Background(), "", "")
 				return err
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"FetchMigBasename_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigBasename(GceRef{})
+				_, err := client.FetchMigBasename(context.Background(), GceRef{})
 				return err
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"FetchMigTargetSize_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigTargetSize(GceRef{})
+				_, err := client.FetchMigTargetSize(context.Background(), GceRef{})
 				return err
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"FetchMigTemplate_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigTemplate(GceRef{}, "", false)
+				_, err := client.FetchMigTemplate(context.Background(), GceRef{}, "", false)
 				return err
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"FetchMigTemplateName_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigTemplateName(GceRef{})
+				_, err := client.FetchMigTemplateName(context.Background(), GceRef{})
 				return err
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"FetchListManagedInstancesResults_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchListManagedInstancesResults(GceRef{})
+				_, err := client.FetchListManagedInstancesResults(context.Background(), GceRef{})
 				return err
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"FetchZones_ContextTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchZones("")
+				_, err := client.FetchZones(context.Background(), "")
 				return err
 			},
 			operationPerCallTimeout: &instantTimeout,
 		},
 		"CreateInstances_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.CreateInstances(GceRef{}, "", 0, nil)
+				_, err := client.CreateInstances(context.Background(), GceRef{}, "", 0, nil)
 				return err
 			},
 			httpTimeout: instantTimeout,
 		},
 		"DeleteInstances_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				return client.DeleteInstances(GceRef{}, nil)
+				return client.DeleteInstances(context.Background(), GceRef{}, nil)
 			},
 			httpTimeout: instantTimeout,
 		},
 		"ResizeMig_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				return client.ResizeMig(GceRef{}, 0)
+				return client.ResizeMig(context.Background(), GceRef{}, 0)
 			},
 			httpTimeout: instantTimeout,
 		},
 		"FetchMachineType_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMachineType("", "")
+				_, err := client.FetchMachineType(context.Background(), "", "")
 				return err
 			},
 			httpTimeout: instantTimeout,
 		},
 		"FetchMigBasename_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigBasename(GceRef{})
+				_, err := client.FetchMigBasename(context.Background(), GceRef{})
 				return err
 			},
 			httpTimeout: instantTimeout,
 		},
 		"FetchMigTargetSize_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigTargetSize(GceRef{})
+				_, err := client.FetchMigTargetSize(context.Background(), GceRef{})
 				return err
 			},
 			httpTimeout: instantTimeout,
 		},
 		"FetchMigTemplate_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigTemplate(GceRef{}, "", false)
+				_, err := client.FetchMigTemplate(context.Background(), GceRef{}, "", false)
 				return err
 			},
 			httpTimeout: instantTimeout,
 		},
 		"FetchMigTemplateName_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigTemplateName(GceRef{})
+				_, err := client.FetchMigTemplateName(context.Background(), GceRef{})
 				return err
 			},
 			httpTimeout: instantTimeout,
 		},
 		"FetchListManagedInstancesResults_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchListManagedInstancesResults(GceRef{})
+				_, err := client.FetchListManagedInstancesResults(context.Background(), GceRef{})
 				return err
 			},
 			httpTimeout: instantTimeout,
 		},
 		"FetchZones_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchZones("")
+				_, err := client.FetchZones(context.Background(), "")
 				return err
 			},
 			httpTimeout: instantTimeout,
@@ -866,7 +866,7 @@ func TestAutoscalingClientTimeouts(t *testing.T) {
 		},
 		"FetchMigInstances_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigInstances(GceRef{})
+				_, err := client.FetchMigInstances(context.Background(), GceRef{})
 				return err
 			},
 			httpTimeout: instantTimeout,
@@ -887,7 +887,7 @@ func TestAutoscalingClientTimeouts(t *testing.T) {
 		},
 		"FetchMigsWithName_HttpClientTimeout": {
 			clientFunc: func(client *autoscalingGceClientV1) error {
-				_, err := client.FetchMigsWithName("", &regexp.Regexp{})
+				_, err := client.FetchMigsWithName(context.Background(), "", &regexp.Regexp{})
 				return err
 			},
 			httpTimeout: instantTimeout,
@@ -928,7 +928,7 @@ func TestCreateInstances(t *testing.T) {
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-2505728466148-216f5197/wait").Return(operationDoneResponse).Once()
 	client := newTestAutoscalingGceClientWithTimeout(t, "project", server.URL, "", time.Second)
 	migRef := GceRef{Project: "project1", Zone: "us-central1-b", Name: "igm1"}
-	createdIds, err := client.CreateInstances(migRef, migRef.Name, 10, nil)
+	createdIds, err := client.CreateInstances(context.Background(), migRef, migRef.Name, 10, nil)
 	assert.NoError(t, err)
 	assert.Len(t, createdIds, 10, "Expected 10 instance names in result")
 	for _, id := range createdIds {
@@ -1227,7 +1227,7 @@ func TestFetchAllInstances(t *testing.T) {
 				server.On("handle", "/projects/myprojid/zones/myzone/instances", token).Return(string(b)).Times(1)
 			}
 
-			got, err := gceInternalService.FetchAllInstances("myprojid", "myzone", "test-cluster")
+			got, err := gceInternalService.FetchAllInstances(context.Background(), "myprojid", "myzone", "test-cluster")
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("autoscalingInternalGceClient.FetchAllInstances() diff (-want +got): %s", diff)
 			}
@@ -1388,7 +1388,7 @@ func TestFetchMigTargetSize(t *testing.T) {
 			gceClient := newTestAutoscalingGceClient(t, "project1", server.URL, "")
 			b, _ := json.Marshal(tc.response)
 			server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers/mig-1").Return(string(b)).Once()
-			size, err := gceClient.FetchMigTargetSize(mig)
+			size, err := gceClient.FetchMigTargetSize(context.Background(), mig)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantSize, size)
 			mock.AssertExpectationsForObjects(t, server)

--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"reflect"
 	"sync"
 	"time"
@@ -103,7 +104,8 @@ func NewGceCache() *GceCache {
 }
 
 // RegisterMig returns true if the node group wasn't in cache before, or its config was updated.
-func (gc *GceCache) RegisterMig(newMig Mig) bool {
+func (gc *GceCache) RegisterMig(ctx context.Context, newMig Mig) bool {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
@@ -111,25 +113,25 @@ func (gc *GceCache) RegisterMig(newMig Mig) bool {
 	if found {
 		if !reflect.DeepEqual(oldMig, newMig) {
 			gc.migs[newMig.GceRef()] = newMig
-			klog.V(4).Infof("Updated Mig %s", newMig.GceRef().String())
+			logger.V(4).Info("Updated mig", "mig", newMig.GceRef())
 			return true
 		}
 		return false
 	}
-
-	klog.V(1).Infof("Registering %s", newMig.GceRef().String())
+	logger.V(1).Info("Registering mig", "mig", newMig.GceRef())
 	gc.migs[newMig.GceRef()] = newMig
 	return true
 }
 
 // UnregisterMig returns true if the node group has been removed, and false if it was already missing from cache.
-func (gc *GceCache) UnregisterMig(toBeRemoved Mig) bool {
+func (gc *GceCache) UnregisterMig(ctx context.Context, toBeRemoved Mig) bool {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	_, found := gc.migs[toBeRemoved.GceRef()]
 	if found {
-		klog.V(1).Infof("Unregistered Mig %s", toBeRemoved.GceRef().String())
+		logger.V(1).Info("Unregistered mig", "mig", toBeRemoved.GceRef())
 		delete(gc.migs, toBeRemoved.GceRef())
 		gc.removeMigInstances(toBeRemoved.GceRef())
 		return true
@@ -159,26 +161,28 @@ func (gc *GceCache) GetMigs() []Mig {
 }
 
 // GetMigInstances returns the cached instances for a given MIG GceRef
-func (gc *GceCache) GetMigInstances(migRef GceRef) ([]GceInstance, bool) {
+func (gc *GceCache) GetMigInstances(ctx context.Context, migRef GceRef) ([]GceInstance, bool) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	instances, found := gc.instances[migRef]
 	if found {
-		klog.V(5).Infof("Instances cache hit for %s", migRef)
+		logger.V(5).Info("Instances cache hit for mig", "mig", migRef)
 	}
 	return append([]GceInstance{}, instances...), found
 }
 
 // GetMigInstancesUpdateTime returns the timestamp when the cached instances
 // were updated for a given MIG GceRef
-func (gc *GceCache) GetMigInstancesUpdateTime(migRef GceRef) (time.Time, bool) {
+func (gc *GceCache) GetMigInstancesUpdateTime(ctx context.Context, migRef GceRef) (time.Time, bool) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	timestamp, found := gc.instancesUpdateTime[migRef]
 	if found {
-		klog.V(5).Infof("Instances update time cache hit for %s", migRef)
+		logger.V(5).Info("Instances update time cache hit for mig", "mig", migRef)
 	}
 	return timestamp, found
 }
@@ -193,26 +197,28 @@ func (gc *GceCache) IsMigInstancesCacheEmpty(migRef GceRef) bool {
 }
 
 // GetMigForInstance returns the cached MIG for instance GceRef
-func (gc *GceCache) GetMigForInstance(instanceRef GceRef) (GceRef, bool) {
+func (gc *GceCache) GetMigForInstance(ctx context.Context, instanceRef GceRef) (GceRef, bool) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	migRef, found := gc.instancesToMig[instanceRef]
 	if found {
-		klog.V(5).Infof("MIG cache hit for %s", instanceRef)
+		logger.V(5).Info("MIG cache hit for instance", "instance", instanceRef)
 	}
 	return migRef, found
 }
 
 // IsMigUnknownForInstance checks if MIG was marked as unknown for instance, meaning that
 // a Mig to which this instance should belong does not list it as one of its instances.
-func (gc *GceCache) IsMigUnknownForInstance(instanceRef GceRef) bool {
+func (gc *GceCache) IsMigUnknownForInstance(ctx context.Context, instanceRef GceRef) bool {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	unknown, _ := gc.instancesFromUnknownMig[instanceRef]
 	if unknown {
-		klog.V(5).Infof("Unknown MIG cache hit for %s", instanceRef)
+		logger.V(5).Info("Unknown MIG cache hit for instance", "instance", instanceRef)
 	}
 	return unknown
 }
@@ -246,21 +252,21 @@ func (gc *GceCache) MarkInstanceMigUnknown(instanceRef GceRef) {
 }
 
 // InvalidateAllMigInstances clears the mig instances cache
-func (gc *GceCache) InvalidateAllMigInstances() {
+func (gc *GceCache) InvalidateAllMigInstances(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-
-	klog.V(5).Infof("Mig instances cache invalidated")
+	logger.V(5).Info("Mig instances cache invalidated")
 	gc.instances = make(map[GceRef][]GceInstance)
 	gc.instancesUpdateTime = make(map[GceRef]time.Time)
 }
 
 // InvalidateMigInstances clears the mig instances cache for a given Mig
-func (gc *GceCache) InvalidateMigInstances(migRef GceRef) {
+func (gc *GceCache) InvalidateMigInstances(ctx context.Context, migRef GceRef) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-
-	klog.V(5).Infof("Mig instances cache invalidated for %v", migRef.Name)
+	logger.V(5).Info("Mig instances cache invalidated for mig", "mig", migRef)
 	delete(gc.instances, migRef)
 	delete(gc.instancesUpdateTime, migRef)
 }
@@ -275,11 +281,11 @@ func (gc *GceCache) InvalidateInstancesToMig(migRef GceRef) {
 }
 
 // InvalidateAllInstancesToMig clears the instance to mig cache
-func (gc *GceCache) InvalidateAllInstancesToMig() {
+func (gc *GceCache) InvalidateAllInstancesToMig(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-
-	klog.V(5).Infof("Instances to migs cache invalidated")
+	logger.V(5).Info("Instances to migs cache invalidated")
 	gc.instancesToMig = make(map[GceRef]GceRef)
 	gc.instancesFromUnknownMig = make(map[GceRef]bool)
 }
@@ -324,13 +330,14 @@ func (gc *GceCache) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error)
 }
 
 // GetMigTargetSize returns the cached targetSize for a GceRef
-func (gc *GceCache) GetMigTargetSize(ref GceRef) (int64, bool) {
+func (gc *GceCache) GetMigTargetSize(ctx context.Context, ref GceRef) (int64, bool) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	size, found := gc.migTargetSizeCache[ref]
 	if found {
-		klog.V(5).Infof("Target size cache hit for %s", ref)
+		logger.V(5).Info("Target size cache hit for mig", "mig", ref)
 	}
 	return size, found
 }
@@ -356,22 +363,23 @@ func (gc *GceCache) IsMigTargetSizeCacheEmpty() bool {
 }
 
 // InvalidateMigTargetSize clears the target size cache
-func (gc *GceCache) InvalidateMigTargetSize(ref GceRef) {
+func (gc *GceCache) InvalidateMigTargetSize(ctx context.Context, ref GceRef) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	if _, found := gc.migTargetSizeCache[ref]; found {
-		klog.V(5).Infof("Target size cache invalidated for %s", ref)
+		logger.V(5).Info("Target size cache invalidated for mig", "mig", ref)
 		delete(gc.migTargetSizeCache, ref)
 	}
 }
 
 // InvalidateAllMigTargetSizes clears the target size cache
-func (gc *GceCache) InvalidateAllMigTargetSizes() {
+func (gc *GceCache) InvalidateAllMigTargetSizes(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-
-	klog.V(5).Infof("Target size cache invalidated")
+	logger.V(5).Info("Target size cache invalidated")
 	gc.migTargetSizeCache = map[GceRef]int64{}
 }
 
@@ -396,22 +404,23 @@ func (gc *GceCache) SetMigIsStable(ref GceRef, isStable bool) {
 }
 
 // InvalidateAllMigIsStable clears the isStable cache
-func (gc *GceCache) InvalidateAllMigIsStable() {
+func (gc *GceCache) InvalidateAllMigIsStable(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-
-	klog.V(5).Infof("IsStable cache invalidated")
+	logger.V(5).Info("IsStable cache invalidated")
 	gc.migIsStableCache = map[GceRef]bool{}
 }
 
 // GetMigInstanceTemplateName returns the cached instance template ref for a mig GceRef
-func (gc *GceCache) GetMigInstanceTemplateName(ref GceRef) (InstanceTemplateName, bool) {
+func (gc *GceCache) GetMigInstanceTemplateName(ctx context.Context, ref GceRef) (InstanceTemplateName, bool) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	instanceTemplateName, found := gc.instanceTemplateNameCache[ref]
 	if found {
-		klog.V(5).Infof("Instance template names cache hit for %s", ref)
+		logger.V(5).Info("Instance template names cache hit for mig", "mig", ref)
 	}
 	return instanceTemplateName, found
 }
@@ -436,22 +445,23 @@ func (gc *GceCache) InvalidateMigInstanceTemplateName(ref GceRef) {
 }
 
 // InvalidateAllMigInstanceTemplateNames clears the instance template ref cache
-func (gc *GceCache) InvalidateAllMigInstanceTemplateNames() {
+func (gc *GceCache) InvalidateAllMigInstanceTemplateNames(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
-
-	klog.V(5).Infof("Instance template names cache invalidated")
+	logger.V(5).Info("Instance template names cache invalidated")
 	gc.instanceTemplateNameCache = map[GceRef]InstanceTemplateName{}
 }
 
 // GetMigInstanceTemplate returns the cached gce.InstanceTemplate for a mig GceRef
-func (gc *GceCache) GetMigInstanceTemplate(ref GceRef) (*gce.InstanceTemplate, bool) {
+func (gc *GceCache) GetMigInstanceTemplate(ctx context.Context, ref GceRef) (*gce.InstanceTemplate, bool) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	instanceTemplate, found := gc.instanceTemplatesCache[ref]
 	if found {
-		klog.V(5).Infof("Instance template cache hit for %s", ref)
+		logger.V(5).Info("Instance template cache hit for mig", "mig", ref)
 	}
 	return instanceTemplate, found
 }
@@ -486,7 +496,8 @@ func (gc *GceCache) InvalidateAllMigInstanceTemplates() {
 
 // DropInstanceTemplatesForMissingMigs clears the instance template
 // cache intended MIGs which are no longer present in the cluster
-func (gc *GceCache) DropInstanceTemplatesForMissingMigs(currentMigs []Mig) {
+func (gc *GceCache) DropInstanceTemplatesForMissingMigs(ctx context.Context, currentMigs []Mig) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
@@ -494,8 +505,7 @@ func (gc *GceCache) DropInstanceTemplatesForMissingMigs(currentMigs []Mig) {
 	for _, mig := range currentMigs {
 		requiredKeys[mig.GceRef()] = struct{}{}
 	}
-
-	klog.V(5).Infof("Instance template cache partially invalidated")
+	logger.V(5).Info("Instance template cache partially invalidated")
 	for key := range gc.instanceTemplatesCache {
 		if _, exists := requiredKeys[key]; !exists {
 			delete(gc.instanceTemplatesCache, key)
@@ -504,13 +514,14 @@ func (gc *GceCache) DropInstanceTemplatesForMissingMigs(currentMigs []Mig) {
 }
 
 // GetMigKubeEnv returns the cached KubeEnv for a mig GceRef
-func (gc *GceCache) GetMigKubeEnv(ref GceRef) (KubeEnv, bool) {
+func (gc *GceCache) GetMigKubeEnv(ctx context.Context, ref GceRef) (KubeEnv, bool) {
+	logger := klog.FromContext(ctx)
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 
 	kubeEnv, found := gc.kubeEnvCache[ref]
 	if found {
-		klog.V(5).Infof("Kube-env cache hit for %s", ref)
+		logger.V(5).Info("Kube-env cache hit for mig", "mig", ref)
 	}
 	return kubeEnv, found
 }

--- a/cluster-autoscaler/cloudprovider/gce/cache_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -135,16 +136,16 @@ func TestMigInstancesCache(t *testing.T) {
 	c.SetMigInstances(migRef, instances, time.Now())
 
 	// Then: can retrieve instances from cache by MIG reference
-	gotInstances, found := c.GetMigInstances(migRef)
+	gotInstances, found := c.GetMigInstances(context.Background(), migRef)
 	assert.False(t, c.IsMigInstancesCacheEmpty(migRef), "Expected MIG instances cache to not be empty after SetMigInstances was called")
 	assert.True(t, found, "Expected MIG insatcnes cache to be populated")
 	assert.Equal(t, gotInstances, instances)
 
 	// When: Invalidate the cache
-	c.InvalidateAllMigInstances()
+	c.InvalidateAllMigInstances(context.Background())
 
 	// Then: Cache is empty
-	_, found = c.GetMigInstances(migRef)
+	_, found = c.GetMigInstances(context.Background(), migRef)
 	assert.False(t, found, "Expected MIG instances cache to be empty after InvalidateAllMigInstances was called")
 	assert.True(t, c.IsMigInstancesCacheEmpty(migRef))
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -76,7 +77,7 @@ func BuildGceCloudProvider(gceManager GceManager, resourceLimiter *cloudprovider
 }
 
 // Cleanup cleans up all resources before the cloud provider is removed
-func (gce *GceCloudProvider) Cleanup() error {
+func (gce *GceCloudProvider) Cleanup(ctx context.Context) error {
 	gce.gceManager.Cleanup()
 	return nil
 }
@@ -87,19 +88,19 @@ func (gce *GceCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (gce *GceCloudProvider) GPULabel() string {
+func (gce *GceCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (gce *GceCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (gce *GceCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil. If node has GPU attached using DRA - populates the according field in GpuConfig
-func (gce *GceCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	gpuConfig := gpu.GetNodeGPUFromCloudProvider(gce, node)
+func (gce *GceCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	gpuConfig := gpu.GetNodeGPUFromCloudProvider(ctx, gce, node)
 
 	// If GPU devices are exposed using DRA - extended resource
 	// won't be present in the node alloctable or capacity
@@ -114,7 +115,7 @@ func (gce *GceCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.G
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (gce *GceCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (gce *GceCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	migs := gce.gceManager.GetMigs()
 	result := make([]cloudprovider.NodeGroup, 0, len(migs))
 	for _, mig := range migs {
@@ -124,13 +125,14 @@ func (gce *GceCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (gce *GceCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	logger := klog.FromContext(ctx)
 	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
-		klog.Errorf("Error extracting node.Spec.ProviderID for node %v: %v", node.Name, err)
+		logger.Error(err, "Error extracting node.Spec.ProviderID for node", "node", klog.KObj(node))
 		return nil, err
 	}
-	mig, err := gce.gceManager.GetMigForInstance(ref)
+	mig, err := gce.gceManager.GetMigForInstance(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -141,29 +143,29 @@ func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (gce *GceCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (gce *GceCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (gce *GceCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (gce *GceCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return gce.pricingModel, nil
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
-func (gce *GceCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (gce *GceCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (gce *GceCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (gce *GceCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (gce *GceCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (gce *GceCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	resourceLimiter, err := gce.gceManager.GetResourceLimiter()
 	if err != nil {
 		return nil, err
@@ -176,8 +178,8 @@ func (gce *GceCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimite
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (gce *GceCloudProvider) Refresh() error {
-	return gce.gceManager.Refresh()
+func (gce *GceCloudProvider) Refresh(ctx context.Context) error {
+	return gce.gceManager.Refresh(ctx)
 }
 
 // GceRef contains s reference to some entity in GCE world.
@@ -245,54 +247,54 @@ func (mig *gceMig) IsStable() (bool, error) {
 }
 
 // MaxSize returns maximum size of the node group.
-func (mig *gceMig) MaxSize() int {
+func (mig *gceMig) MaxSize(ctx context.Context) int {
 	return mig.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (mig *gceMig) MinSize() int {
+func (mig *gceMig) MinSize(ctx context.Context) int {
 	return mig.minSize
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (mig *gceMig) TargetSize() (int, error) {
-	size, err := mig.gceManager.GetMigSize(mig)
+func (mig *gceMig) TargetSize(ctx context.Context) (int, error) {
+	size, err := mig.gceManager.GetMigSize(ctx, mig)
 	return int(size), err
 }
 
 // IncreaseSize increases Mig size
-func (mig *gceMig) IncreaseSize(delta int) error {
+func (mig *gceMig) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
-	size, err := mig.gceManager.GetMigSize(mig)
+	size, err := mig.gceManager.GetMigSize(ctx, mig)
 	if err != nil {
 		return err
 	}
-	if int(size)+delta > mig.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, mig.MaxSize())
+	if int(size)+delta > mig.MaxSize(ctx) {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, mig.MaxSize(ctx))
 	}
-	return mig.gceManager.CreateInstances(mig, int64(delta))
+	return mig.gceManager.CreateInstances(ctx, mig, int64(delta))
 }
 
 // AtomicIncreaseSize is not implemented.
-func (mig *gceMig) AtomicIncreaseSize(delta int) error {
+func (mig *gceMig) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
-func (mig *gceMig) DecreaseTargetSize(delta int) error {
+func (mig *gceMig) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
-	size, err := mig.gceManager.GetMigSize(mig)
+	size, err := mig.gceManager.GetMigSize(ctx, mig)
 	if err != nil {
 		return err
 	}
-	nodes, err := mig.gceManager.GetMigNodes(mig)
+	nodes, err := mig.gceManager.GetMigNodes(ctx, mig)
 	if err != nil {
 		return err
 	}
@@ -300,16 +302,16 @@ func (mig *gceMig) DecreaseTargetSize(delta int) error {
 		return fmt.Errorf("attempt to delete existing nodes targetSize:%d delta:%d existingNodes: %d",
 			size, delta, len(nodes))
 	}
-	return mig.gceManager.SetMigSize(mig, size+int64(delta))
+	return mig.gceManager.SetMigSize(ctx, mig, size+int64(delta))
 }
 
 // Belongs returns true if the given node belongs to the NodeGroup.
-func (mig *gceMig) Belongs(node *apiv1.Node) (bool, error) {
+func (mig *gceMig) Belongs(ctx context.Context, node *apiv1.Node) (bool, error) {
 	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		return false, err
 	}
-	targetMig, err := mig.gceManager.GetMigForInstance(ref)
+	targetMig, err := mig.gceManager.GetMigForInstance(ctx, ref)
 	if err != nil {
 		return false, err
 	}
@@ -323,23 +325,23 @@ func (mig *gceMig) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (mig *gceMig) DeleteNodes(nodes []*apiv1.Node) error {
-	size, err := mig.gceManager.GetMigSize(mig)
+func (mig *gceMig) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
+	size, err := mig.gceManager.GetMigSize(ctx, mig)
 	if err != nil {
 		return err
 	}
-	if int(size) <= mig.MinSize() {
+	if int(size) <= mig.MinSize(ctx) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
-	return mig.ForceDeleteNodes(nodes)
+	return mig.ForceDeleteNodes(ctx, nodes)
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (mig *gceMig) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (mig *gceMig) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	refs := make([]GceRef, 0, len(nodes))
 	for _, node := range nodes {
 
-		belongs, err := mig.Belongs(node)
+		belongs, err := mig.Belongs(ctx, node)
 		if err != nil {
 			return err
 		}
@@ -352,7 +354,7 @@ func (mig *gceMig) ForceDeleteNodes(nodes []*apiv1.Node) error {
 		}
 		refs = append(refs, gceref)
 	}
-	return mig.gceManager.DeleteInstances(refs)
+	return mig.gceManager.DeleteInstances(ctx, refs)
 }
 
 // Id returns mig url.
@@ -361,13 +363,13 @@ func (mig *gceMig) Id() string {
 }
 
 // Debug returns a debug string for the Mig.
-func (mig *gceMig) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", mig.Id(), mig.MinSize(), mig.MaxSize())
+func (mig *gceMig) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", mig.Id(), mig.MinSize(ctx), mig.MaxSize(ctx))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (mig *gceMig) Nodes() ([]cloudprovider.Instance, error) {
-	gceInstances, err := mig.gceManager.GetMigNodes(mig)
+func (mig *gceMig) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
+	gceInstances, err := mig.gceManager.GetMigNodes(ctx, mig)
 	if err != nil {
 		return nil, err
 	}
@@ -379,34 +381,34 @@ func (mig *gceMig) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // Exist checks if the node group really exists on the cloud provider side.
-func (mig *gceMig) Exist() bool {
+func (mig *gceMig) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (mig *gceMig) Create() (cloudprovider.NodeGroup, error) {
+func (mig *gceMig) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
-func (mig *gceMig) Delete() error {
+func (mig *gceMig) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (mig *gceMig) Autoprovisioned() bool {
+func (mig *gceMig) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (mig *gceMig) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return mig.gceManager.GetMigOptions(mig, defaults), nil
+func (mig *gceMig) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+	return mig.gceManager.GetMigOptions(ctx, mig, defaults), nil
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (mig *gceMig) TemplateNodeInfo() (*framework.NodeInfo, error) {
-	node, err := mig.gceManager.GetMigTemplateNode(mig)
+func (mig *gceMig) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
+	node, err := mig.gceManager.GetMigTemplateNode(ctx, mig)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -38,7 +39,7 @@ type gceManagerMock struct {
 	mock.Mock
 }
 
-func (m *gceManagerMock) GetMigSize(mig Mig) (int64, error) {
+func (m *gceManagerMock) GetMigSize(ctx context.Context, mig Mig) (int64, error) {
 	args := m.Called(mig)
 	return args.Get(0).(int64), args.Error(1)
 }
@@ -48,27 +49,27 @@ func (m *gceManagerMock) IsMigStable(mig Mig) (bool, error) {
 	return args.Get(0).(bool), args.Error(1)
 }
 
-func (m *gceManagerMock) SetMigSize(mig Mig, size int64) error {
+func (m *gceManagerMock) SetMigSize(ctx context.Context, mig Mig, size int64) error {
 	args := m.Called(mig, size)
 	return args.Error(0)
 }
 
-func (m *gceManagerMock) DeleteInstances(instances []GceRef) error {
+func (m *gceManagerMock) DeleteInstances(ctx context.Context, instances []GceRef) error {
 	args := m.Called(instances)
 	return args.Error(0)
 }
 
-func (m *gceManagerMock) GetMigForInstance(instance GceRef) (Mig, error) {
+func (m *gceManagerMock) GetMigForInstance(ctx context.Context, instance GceRef) (Mig, error) {
 	args := m.Called(instance)
 	return args.Get(0).(*gceMig), args.Error(1)
 }
 
-func (m *gceManagerMock) GetMigNodes(mig Mig) ([]GceInstance, error) {
+func (m *gceManagerMock) GetMigNodes(ctx context.Context, mig Mig) ([]GceInstance, error) {
 	args := m.Called(mig)
 	return args.Get(0).([]GceInstance), args.Error(1)
 }
 
-func (m *gceManagerMock) Refresh() error {
+func (m *gceManagerMock) Refresh(ctx context.Context) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -93,17 +94,17 @@ func (m *gceManagerMock) findMigsNamed(name *regexp.Regexp) ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *gceManagerMock) GetMigOptions(mig Mig, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions {
+func (m *gceManagerMock) GetMigOptions(ctx context.Context, mig Mig, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions {
 	args := m.Called(mig, defaults)
 	return args.Get(0).(*config.NodeGroupAutoscalingOptions)
 }
 
-func (m *gceManagerMock) GetMigTemplateNode(mig Mig) (*apiv1.Node, error) {
+func (m *gceManagerMock) GetMigTemplateNode(ctx context.Context, mig Mig) (*apiv1.Node, error) {
 	args := m.Called(mig)
 	return args.Get(0).(*apiv1.Node), args.Error(1)
 }
 
-func (m *gceManagerMock) CreateInstances(mig Mig, delta int64) error {
+func (m *gceManagerMock) CreateInstances(ctx context.Context, mig Mig, delta int64) error {
 	args := m.Called(mig, delta)
 	return args.Error(0)
 }
@@ -132,7 +133,7 @@ func TestNodeGroups(t *testing.T) {
 	}
 	mig := &gceMig{gceRef: GceRef{Name: "ng1"}}
 	gceManagerMock.On("GetMigs").Return([]Mig{mig}).Once()
-	result := gce.NodeGroups()
+	result := gce.NodeGroups(context.Background())
 	assert.Equal(t, []cloudprovider.NodeGroup{mig}, result)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 }
@@ -147,7 +148,7 @@ func TestNodeGroupForNode(t *testing.T) {
 	mig := gceMig{gceRef: GceRef{Name: "ng1"}}
 	gceManagerMock.On("GetMigForInstance", mock.AnythingOfType("gce.GceRef")).Return(&mig, nil).Once()
 
-	nodeGroup, err := gce.NodeGroupForNode(n)
+	nodeGroup, err := gce.NodeGroupForNode(context.Background(), n)
 	assert.NoError(t, err)
 	assert.Equal(t, mig, *reflect.ValueOf(nodeGroup).Interface().(*gceMig))
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -165,7 +166,7 @@ func TestGetResourceLimiter(t *testing.T) {
 
 	// Return default.
 	gceManagerMock.On("GetResourceLimiter").Return((*cloudprovider.ResourceLimiter)(nil), nil).Once()
-	returnedResourceLimiter, err := gce.GetResourceLimiter()
+	returnedResourceLimiter, err := gce.GetResourceLimiter(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, resourceLimiter, returnedResourceLimiter)
 
@@ -174,13 +175,13 @@ func TestGetResourceLimiter(t *testing.T) {
 		map[string]int64{cloudprovider.ResourceNameCores: 2, cloudprovider.ResourceNameMemory: 20000000},
 		map[string]int64{cloudprovider.ResourceNameCores: 5, cloudprovider.ResourceNameMemory: 200000000})
 	gceManagerMock.On("GetResourceLimiter").Return(resourceLimiterGKE, nil).Once()
-	returnedResourceLimiterGKE, err := gce.GetResourceLimiter()
+	returnedResourceLimiterGKE, err := gce.GetResourceLimiter(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, returnedResourceLimiterGKE, resourceLimiterGKE)
 
 	// Error in GceManager.
 	gceManagerMock.On("GetResourceLimiter").Return((*cloudprovider.ResourceLimiter)(nil), fmt.Errorf("some error")).Once()
-	_, err = gce.GetResourceLimiter()
+	_, err = gce.GetResourceLimiter(context.Background())
 	assert.Error(t, err)
 }
 
@@ -275,7 +276,7 @@ func TestMig(t *testing.T) {
 
 	// Test TargetSize.
 	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(2), nil).Once()
-	targetSize, err := mig1.TargetSize()
+	targetSize, err := mig1.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, targetSize)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -283,18 +284,18 @@ func TestMig(t *testing.T) {
 	// Test IncreaseSize.
 	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(2), nil).Once()
 	gceManagerMock.On("CreateInstances", mock.AnythingOfType("*gce.gceMig"), int64(1)).Return(nil).Once()
-	err = mig1.IncreaseSize(1)
+	err = mig1.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test IncreaseSize - fail on wrong size.
-	err = mig1.IncreaseSize(0)
+	err = mig1.IncreaseSize(context.Background(), 0)
 	assert.Error(t, err)
 	assert.Equal(t, "size increase must be positive", err.Error())
 
 	// Test IncreaseSize - fail on too big delta.
 	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(2), nil).Once()
-	err = mig1.IncreaseSize(1000)
+	err = mig1.IncreaseSize(context.Background(), 1000)
 	assert.Error(t, err)
 	assert.Equal(t, "size increase too large - desired:1002 max:1000", err.Error())
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -323,12 +324,12 @@ func TestMig(t *testing.T) {
 			},
 		}, nil).Once()
 	gceManagerMock.On("SetMigSize", mock.AnythingOfType("*gce.gceMig"), int64(2)).Return(nil).Once()
-	err = mig1.DecreaseTargetSize(-1)
+	err = mig1.DecreaseTargetSize(context.Background(), -1)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test DecreaseTargetSize - fail on positive delta.
-	err = mig1.DecreaseTargetSize(1)
+	err = mig1.DecreaseTargetSize(context.Background(), 1)
 	assert.Error(t, err)
 	assert.Equal(t, "size decrease must be negative", err.Error())
 
@@ -355,7 +356,7 @@ func TestMig(t *testing.T) {
 				NumericId: 333,
 			},
 		}, nil).Once()
-	err = mig1.DecreaseTargetSize(-2)
+	err = mig1.DecreaseTargetSize(context.Background(), -2)
 	assert.Error(t, err)
 	assert.Equal(t, "attempt to delete existing nodes targetSize:3 delta:-2 existingNodes: 2", err.Error())
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -365,7 +366,7 @@ func TestMig(t *testing.T) {
 	node := BuildTestNode("gke-cluster-1-default-pool-f7607aac-dck1", 1000, 1000)
 	node.Spec.ProviderID = "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-dck1"
 
-	belongs, err := mig1.Belongs(node)
+	belongs, err := mig1.Belongs(context.Background(), node)
 	assert.NoError(t, err)
 	assert.True(t, belongs)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -383,7 +384,7 @@ func TestMig(t *testing.T) {
 	}
 	gceManagerMock.On("GetMigForInstance", mock.AnythingOfType("gce.GceRef")).Return(mig2, nil).Once()
 
-	belongs, err = mig1.Belongs(node)
+	belongs, err = mig1.Belongs(context.Background(), node)
 	assert.NoError(t, err)
 	assert.False(t, belongs)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -399,13 +400,13 @@ func TestMig(t *testing.T) {
 	gceManagerMock.On("GetMigForInstance", n1ref).Return(mig1, nil).Once()
 	gceManagerMock.On("GetMigForInstance", n2ref).Return(mig1, nil).Once()
 	gceManagerMock.On("DeleteInstances", []GceRef{n1ref, n2ref}).Return(nil).Once()
-	err = mig1.DeleteNodes([]*apiv1.Node{n1, n2})
+	err = mig1.DeleteNodes(context.Background(), []*apiv1.Node{n1, n2})
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
 	// Test DeleteNodes - fail on reaching min size.
 	gceManagerMock.On("GetMigSize", mock.AnythingOfType("*gce.gceMig")).Return(int64(0), nil).Once()
-	err = mig1.DeleteNodes([]*apiv1.Node{n1, n2})
+	err = mig1.DeleteNodes(context.Background(), []*apiv1.Node{n1, n2})
 	assert.Error(t, err)
 	assert.Equal(t, "min size reached, nodes will not be deleted", err.Error())
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
@@ -414,7 +415,7 @@ func TestMig(t *testing.T) {
 	gceManagerMock.On("GetMigForInstance", n1ref).Return(mig1, nil).Once()
 	gceManagerMock.On("GetMigForInstance", n2ref).Return(mig1, nil).Once()
 	gceManagerMock.On("DeleteInstances", []GceRef{n1ref, n2ref}).Return(nil).Once()
-	err = mig1.ForceDeleteNodes([]*apiv1.Node{n1, n2})
+	err = mig1.ForceDeleteNodes(context.Background(), []*apiv1.Node{n1, n2})
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
@@ -440,7 +441,7 @@ func TestMig(t *testing.T) {
 				NumericId: 2,
 			},
 		}, nil).Once()
-	nodes, err := mig1.Nodes()
+	nodes, err := mig1.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g", nodes[0].Id)
 	assert.Equal(t, cloudprovider.InstanceRunning, nodes[0].Status.State)
@@ -452,7 +453,7 @@ func TestMig(t *testing.T) {
 
 	// Test TemplateNodeInfo.
 	gceManagerMock.On("GetMigTemplateNode", mock.AnythingOfType("*gce.gceMig")).Return(&apiv1.Node{}, nil).Once()
-	templateNodeInfo, err := mig2.TemplateNodeInfo()
+	templateNodeInfo, err := mig2.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, templateNodeInfo)
 	assert.NotNil(t, templateNodeInfo.Node())

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -77,33 +77,33 @@ var (
 // GceManager handles GCE communication and data caching.
 type GceManager interface {
 	// Refresh triggers refresh of cached resources.
-	Refresh() error
+	Refresh(ctx context.Context) error
 	// Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
 	Cleanup() error
 
 	// GetMigs returns list of registered MIGs.
 	GetMigs() []Mig
 	// GetMigNodes returns mig nodes.
-	GetMigNodes(mig Mig) ([]GceInstance, error)
+	GetMigNodes(ctx context.Context, mig Mig) ([]GceInstance, error)
 	// GetMigForInstance returns MIG to which the given instance belongs.
-	GetMigForInstance(instance GceRef) (Mig, error)
+	GetMigForInstance(ctx context.Context, instance GceRef) (Mig, error)
 	// GetMigTemplateNode returns a template node for MIG.
-	GetMigTemplateNode(mig Mig) (*apiv1.Node, error)
+	GetMigTemplateNode(ctx context.Context, mig Mig) (*apiv1.Node, error)
 	// GetResourceLimiter returns resource limiter.
 	GetResourceLimiter() (*cloudprovider.ResourceLimiter, error)
 	// GetMigSize gets MIG size.
-	GetMigSize(mig Mig) (int64, error)
+	GetMigSize(ctx context.Context, mig Mig) (int64, error)
 	// GetMigOptions returns MIG's NodeGroupAutoscalingOptions
-	GetMigOptions(mig Mig, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions
+	GetMigOptions(ctx context.Context, mig Mig, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions
 	// IsMigStable returns whether the MIG is stable. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.
 	IsMigStable(mig Mig) (bool, error)
 
 	// SetMigSize sets MIG size.
-	SetMigSize(mig Mig, size int64) error
+	SetMigSize(ctx context.Context, mig Mig, size int64) error
 	// DeleteInstances deletes the given instances. All instances must be controlled by the same MIG.
-	DeleteInstances(instances []GceRef) error
+	DeleteInstances(ctx context.Context, instances []GceRef) error
 	// CreateInstances creates delta new instances in a given mig.
-	CreateInstances(mig Mig, delta int64) error
+	CreateInstances(ctx context.Context, mig Mig, delta int64) error
 }
 
 type gceManagerImpl struct {
@@ -211,12 +211,12 @@ func CreateGceManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGr
 		return nil, err
 	}
 
-	if err := manager.forceRefresh(); err != nil {
+	if err := manager.forceRefresh(context.TODO()); err != nil {
 		return nil, err
 	}
 
 	go wait.Until(func() {
-		if err := manager.migInfoProvider.RegenerateMigInstancesCache(); err != nil {
+		if err := manager.migInfoProvider.RegenerateMigInstancesCache(context.TODO()); err != nil {
 			klog.Errorf("Error while regenerating Mig cache: %v", err)
 		}
 	}, time.Hour, manager.interrupt)
@@ -231,22 +231,23 @@ func (m *gceManagerImpl) Cleanup() error {
 }
 
 // registerMig registers mig in GceManager. Returns true if the node group didn't exist before or its config has changed.
-func (m *gceManagerImpl) registerMig(mig Mig) bool {
-	changed := m.cache.RegisterMig(mig)
+func (m *gceManagerImpl) registerMig(ctx context.Context, mig Mig) bool {
+	logger := klog.FromContext(ctx)
+	changed := m.cache.RegisterMig(ctx, mig)
 	if changed {
 		// Try to build a node from template to validate that this group
 		// can be scaled up from 0 nodes.
 		// We may never need to do it, so just log error if it fails.
-		if _, err := m.GetMigTemplateNode(mig); err != nil {
-			klog.Errorf("Can't build node from template for %s, won't be able to scale from 0: %v", mig.GceRef().String(), err)
+		if _, err := m.GetMigTemplateNode(ctx, mig); err != nil {
+			logger.Error(err, "Can't build node from mig template. Won't be able to scale from 0.", "mig", mig.GceRef())
 		}
 	}
 	return changed
 }
 
 // GetMigSize gets MIG size.
-func (m *gceManagerImpl) GetMigSize(mig Mig) (int64, error) {
-	return m.migInfoProvider.GetMigTargetSize(mig.GceRef())
+func (m *gceManagerImpl) GetMigSize(ctx context.Context, mig Mig) (int64, error) {
+	return m.migInfoProvider.GetMigTargetSize(ctx, mig.GceRef())
 }
 
 // IsMigStable returns whether the MIG is stable.
@@ -255,10 +256,11 @@ func (m *gceManagerImpl) IsMigStable(mig Mig) (bool, error) {
 }
 
 // SetMigSize sets MIG size.
-func (m *gceManagerImpl) SetMigSize(mig Mig, size int64) error {
-	klog.V(0).Infof("Setting mig size %s to %d", mig.Id(), size)
-	m.cache.InvalidateMigTargetSize(mig.GceRef())
-	err := m.GceService.ResizeMig(mig.GceRef(), size)
+func (m *gceManagerImpl) SetMigSize(ctx context.Context, mig Mig, size int64) error {
+	logger := klog.FromContext(ctx)
+	logger.V(0).Info("Setting mig size", "mig", mig.GceRef(), "size", size)
+	m.cache.InvalidateMigTargetSize(ctx, mig.GceRef())
+	err := m.GceService.ResizeMig(ctx, mig.GceRef(), size)
 	if err != nil {
 		return err
 	}
@@ -267,16 +269,16 @@ func (m *gceManagerImpl) SetMigSize(mig Mig, size int64) error {
 }
 
 // DeleteInstances deletes the given instances. All instances must be controlled by the same MIG.
-func (m *gceManagerImpl) DeleteInstances(instances []GceRef) error {
+func (m *gceManagerImpl) DeleteInstances(ctx context.Context, instances []GceRef) error {
 	if len(instances) == 0 {
 		return nil
 	}
-	commonMig, err := m.GetMigForInstance(instances[0])
+	commonMig, err := m.GetMigForInstance(ctx, instances[0])
 	if err != nil {
 		return err
 	}
 	for _, instance := range instances {
-		mig, err := m.GetMigForInstance(instance)
+		mig, err := m.GetMigForInstance(ctx, instance)
 		if err != nil {
 			return err
 		}
@@ -284,9 +286,9 @@ func (m *gceManagerImpl) DeleteInstances(instances []GceRef) error {
 			return fmt.Errorf("cannot delete instances which don't belong to the same MIG.")
 		}
 	}
-	m.cache.InvalidateMigTargetSize(commonMig.GceRef())
-	m.cache.InvalidateMigInstances(commonMig.GceRef())
-	return m.GceService.DeleteInstances(commonMig.GceRef(), instances)
+	m.cache.InvalidateMigTargetSize(ctx, commonMig.GceRef())
+	m.cache.InvalidateMigInstances(ctx, commonMig.GceRef())
+	return m.GceService.DeleteInstances(ctx, commonMig.GceRef(), instances)
 }
 
 // GetMigs returns list of registered MIGs.
@@ -295,41 +297,42 @@ func (m *gceManagerImpl) GetMigs() []Mig {
 }
 
 // GetMigForInstance returns MIG to which the given instance belongs.
-func (m *gceManagerImpl) GetMigForInstance(instance GceRef) (Mig, error) {
-	return m.migInfoProvider.GetMigForInstance(instance)
+func (m *gceManagerImpl) GetMigForInstance(ctx context.Context, instance GceRef) (Mig, error) {
+	return m.migInfoProvider.GetMigForInstance(ctx, instance)
 }
 
 // GetMigNodes returns mig nodes.
-func (m *gceManagerImpl) GetMigNodes(mig Mig) ([]GceInstance, error) {
-	return m.migInfoProvider.GetMigInstances(mig.GceRef())
+func (m *gceManagerImpl) GetMigNodes(ctx context.Context, mig Mig) ([]GceInstance, error) {
+	return m.migInfoProvider.GetMigInstances(ctx, mig.GceRef())
 }
 
 // Refresh triggers refresh of cached resources.
-func (m *gceManagerImpl) Refresh() error {
-	m.cache.InvalidateAllMigInstances()
-	m.cache.InvalidateAllMigTargetSizes()
-	m.cache.InvalidateAllMigIsStable()
+func (m *gceManagerImpl) Refresh(ctx context.Context) error {
+	m.cache.InvalidateAllMigInstances(ctx)
+	m.cache.InvalidateAllMigTargetSizes(ctx)
+	m.cache.InvalidateAllMigIsStable(ctx)
 	m.cache.InvalidateAllMigBasenames()
 	m.cache.InvalidateAllListManagedInstancesResults()
-	m.cache.InvalidateAllMigInstanceTemplateNames()
+	m.cache.InvalidateAllMigInstanceTemplateNames(ctx)
 	if m.lastRefresh.Add(refreshInterval).After(time.Now()) {
 		return nil
 	}
 
-	if err := m.forceRefresh(); err != nil {
+	if err := m.forceRefresh(ctx); err != nil {
 		return err
 	}
 
 	migs := m.migLister.GetMigs()
-	m.cache.DropInstanceTemplatesForMissingMigs(migs)
+	m.cache.DropInstanceTemplatesForMissingMigs(ctx, migs)
 	return nil
 }
 
-func (m *gceManagerImpl) CreateInstances(mig Mig, delta int64) error {
+func (m *gceManagerImpl) CreateInstances(ctx context.Context, mig Mig, delta int64) error {
+	logger := klog.FromContext(ctx)
 	if delta == 0 {
 		return nil
 	}
-	instances, err := m.GetMigNodes(mig)
+	instances, err := m.GetMigNodes(ctx, mig)
 	if err != nil {
 		return err
 	}
@@ -337,19 +340,19 @@ func (m *gceManagerImpl) CreateInstances(mig Mig, delta int64) error {
 	for _, ins := range instances {
 		instanceIds = append(instanceIds, ins.Id)
 	}
-	baseName, err := m.migInfoProvider.GetMigBasename(mig.GceRef())
+	baseName, err := m.migInfoProvider.GetMigBasename(ctx, mig.GceRef())
 	if err != nil {
 		return fmt.Errorf("can't upscale %s: failed to collect BaseInstanceName: %w", mig.GceRef(), err)
 	}
-	m.cache.InvalidateMigTargetSize(mig.GceRef())
+	m.cache.InvalidateMigTargetSize(ctx, mig.GceRef())
 	totalReqs := int((delta + createInstancesRequestLimit - 1) / createInstancesRequestLimit)
 	remaining := delta
 	for i := 0; i < totalReqs; i++ {
 		increment := min(remaining, createInstancesRequestLimit)
 		if totalReqs > 1 {
-			klog.Infof("Sending chunked GCE createInstances request. Request: %d/%d RequestSize: %v", i+1, totalReqs, increment)
+			logger.Info("Sending chunked GCE createInstances request.", "request", fmt.Sprintf("%d/%d", i+1, totalReqs), "requestSize", increment)
 		}
-		ids, err := m.GceService.CreateInstances(mig.GceRef(), baseName, increment, instanceIds)
+		ids, err := m.GceService.CreateInstances(ctx, mig.GceRef(), baseName, increment, instanceIds)
 		if err != nil {
 			return err
 		}
@@ -361,41 +364,43 @@ func (m *gceManagerImpl) CreateInstances(mig Mig, delta int64) error {
 	return nil
 }
 
-func (m *gceManagerImpl) forceRefresh() error {
-	m.clearMachinesCache()
-	if err := m.fetchAutoMigs(); err != nil {
-		klog.Errorf("Failed to fetch MIGs: %v", err)
+func (m *gceManagerImpl) forceRefresh(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
+	m.clearMachinesCache(ctx)
+	if err := m.fetchAutoMigs(ctx); err != nil {
+		logger.Error(err, "Failed to fetch MIGs")
 		return err
 	}
-	m.refreshAutoscalingOptions()
+	m.refreshAutoscalingOptions(ctx)
 	m.lastRefresh = time.Now()
-	klog.V(2).Infof("Refreshed GCE resources, next refresh after %v", m.lastRefresh.Add(refreshInterval))
+	logger.V(2).Info("Refreshed GCE resources", "nextRefreshAfter", m.lastRefresh.Add(refreshInterval))
 	return nil
 }
 
-func (m *gceManagerImpl) refreshAutoscalingOptions() {
+func (m *gceManagerImpl) refreshAutoscalingOptions(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	for _, mig := range m.migLister.GetMigs() {
-		template, err := m.migInfoProvider.GetMigInstanceTemplate(mig.GceRef())
+		template, err := m.migInfoProvider.GetMigInstanceTemplate(ctx, mig.GceRef())
 		if err != nil {
-			klog.Warningf("Not evaluating autoscaling options for %q MIG: failed to find corresponding instance template: %v", mig.GceRef(), err)
+			logger.Info("Not evaluating autoscaling options for mig: failed to find corresponding instance template", "mig", mig.GceRef(), "err", err)
 			continue
 		}
 		if template.Properties == nil {
-			klog.Warningf("Failed to extract autoscaling options from %q metadata: instance template is incomplete", template.Name)
+			logger.Info("Failed to extract autoscaling options from metadata: instance template is incomplete", "templateName", template.Name)
 			continue
 		}
-		kubeEnv, err := m.migInfoProvider.GetMigKubeEnv(mig.GceRef())
+		kubeEnv, err := m.migInfoProvider.GetMigKubeEnv(ctx, mig.GceRef())
 		if err != nil {
-			klog.Warningf("Failed to extract autoscaling options from %q instance template's metadata: can't get KubeEnv: %v", template.Name, err)
+			logger.Info("Failed to extract autoscaling options from instance template", "templateName", template.Name, "err", err)
 			continue
 		}
-		options, err := extractAutoscalingOptionsFromKubeEnv(kubeEnv)
+		options, err := extractAutoscalingOptionsFromKubeEnv(ctx, kubeEnv)
 		if err != nil {
-			klog.Warningf("Failed to extract autoscaling options from %q instance template's metadata: %v", template.Name, err)
+			logger.Info("Failed to extract autoscaling options from instance template's metadata", "templateName", template.Name, "err", err)
 			continue
 		}
 		if !reflect.DeepEqual(m.cache.GetAutoscalingOptions(mig.GceRef()), options) {
-			klog.V(4).Infof("Extracted autoscaling options from %q instance template KubeEnv: %v", template.Name, options)
+			logger.V(4).Info("Extracted autoscaling options from instance template KubeEnv", "templateName", template.Name, "options", options)
 		}
 		m.cache.SetAutoscalingOptions(mig.GceRef(), options)
 	}
@@ -410,14 +415,14 @@ func (m *gceManagerImpl) fetchExplicitMigs(specs []string) error {
 		if err != nil {
 			return err
 		}
-		if m.registerMig(mig) {
+		if m.registerMig(context.TODO(), mig) {
 			changed = true
 		}
 		m.explicitlyConfigured[mig.GceRef()] = true
 	}
 
 	if changed {
-		return m.migInfoProvider.RegenerateMigInstancesCache()
+		return m.migInfoProvider.RegenerateMigInstancesCache(context.TODO())
 	}
 	return nil
 }
@@ -464,13 +469,14 @@ func (m *gceManagerImpl) buildMigFromSpec(s *dynamic.NodeGroupSpec) (Mig, error)
 
 // Fetch automatically discovered MIGs. These MIGs should be unregistered if
 // they no longer exist in GCE.
-func (m *gceManagerImpl) fetchAutoMigs() error {
+func (m *gceManagerImpl) fetchAutoMigs(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
 	exists := make(map[GceRef]bool)
 	var changed int32 = 0
 
 	toRegister := make([]Mig, 0)
 	for _, cfg := range m.migAutoDiscoverySpecs {
-		links, err := m.findMigsNamed(cfg.Re)
+		links, err := m.findMigsNamed(ctx, cfg.Re)
 		if err != nil {
 			return fmt.Errorf("cannot autodiscover managed instance groups: %v", err)
 		}
@@ -485,30 +491,30 @@ func (m *gceManagerImpl) fetchAutoMigs() error {
 				// This MIG was explicitly configured, but would also be
 				// autodiscovered. We want the explicitly configured min and max
 				// nodes to take precedence.
-				klog.V(3).Infof("Ignoring explicitly configured MIG %s in autodiscovery.", mig.GceRef().String())
+				logger.V(3).Info("Ignoring explicitly configured MIG in autodiscovery", "mig", mig.GceRef())
 				continue
 			}
 			toRegister = append(toRegister, mig)
 		}
 	}
 
-	workqueue.ParallelizeUntil(context.Background(), m.concurrentGceRefreshes, len(toRegister), func(piece int) {
+	workqueue.ParallelizeUntil(ctx, m.concurrentGceRefreshes, len(toRegister), func(piece int) {
 		mig := toRegister[piece]
-		if m.registerMig(mig) {
-			klog.V(3).Infof("Autodiscovered MIG %s", mig.GceRef().String())
+		if m.registerMig(ctx, mig) {
+			logger.V(3).Info("Autodiscovered MIG", "mig", mig.GceRef())
 			atomic.StoreInt32(&changed, int32(1))
 		}
 	}, workqueue.WithChunkSize(m.concurrentGceRefreshes))
 
 	for _, mig := range m.GetMigs() {
 		if !exists[mig.GceRef()] && !m.explicitlyConfigured[mig.GceRef()] {
-			m.cache.UnregisterMig(mig)
+			m.cache.UnregisterMig(ctx, mig)
 			atomic.StoreInt32(&changed, int32(1))
 		}
 	}
 
 	if atomic.LoadInt32(&changed) > 0 {
-		return m.migInfoProvider.RegenerateMigInstancesCache()
+		return m.migInfoProvider.RegenerateMigInstancesCache(ctx)
 	}
 
 	return nil
@@ -519,7 +525,8 @@ func (m *gceManagerImpl) GetResourceLimiter() (*cloudprovider.ResourceLimiter, e
 	return m.cache.GetResourceLimiter()
 }
 
-func (m *gceManagerImpl) clearMachinesCache() {
+func (m *gceManagerImpl) clearMachinesCache(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	if m.machinesCacheLastRefresh.Add(machinesRefreshInterval).After(time.Now()) {
 		return
 	}
@@ -527,7 +534,7 @@ func (m *gceManagerImpl) clearMachinesCache() {
 	m.cache.InvalidateAllMachines()
 	nextRefresh := time.Now()
 	m.machinesCacheLastRefresh = nextRefresh
-	klog.V(2).Infof("Cleared machine types cache, next clear after %v", nextRefresh)
+	logger.V(2).Info("Cleared machine types cache", "nextClearAfter", nextRefresh)
 }
 
 // Code borrowed from gce cloud provider. Reuse the original as soon as it becomes public.
@@ -554,32 +561,32 @@ func getProjectAndLocation(regional bool) (string, string, error) {
 	return projectID, location, nil
 }
 
-func (m *gceManagerImpl) findMigsNamed(name *regexp.Regexp) ([]string, error) {
+func (m *gceManagerImpl) findMigsNamed(ctx context.Context, name *regexp.Regexp) ([]string, error) {
 	if m.regional {
-		return m.findMigsInRegion(m.location, name)
+		return m.findMigsInRegion(ctx, m.location, name)
 	}
-	return m.GceService.FetchMigsWithName(m.location, name)
+	return m.GceService.FetchMigsWithName(ctx, m.location, name)
 }
 
-func (m *gceManagerImpl) getZones(region string) ([]string, error) {
-	zones, err := m.GceService.FetchZones(region)
+func (m *gceManagerImpl) getZones(ctx context.Context, region string) ([]string, error) {
+	zones, err := m.GceService.FetchZones(ctx, region)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get zones for GCE region %s: %v", region, err)
 	}
 	return zones, nil
 }
 
-func (m *gceManagerImpl) findMigsInRegion(region string, name *regexp.Regexp) ([]string, error) {
+func (m *gceManagerImpl) findMigsInRegion(ctx context.Context, region string, name *regexp.Regexp) ([]string, error) {
 	links := make([]string, 0)
-	zones, err := m.getZones(region)
+	zones, err := m.getZones(ctx, region)
 	if err != nil {
 		return nil, err
 	}
 
 	zoneLinks := make([][]string, len(zones))
 	errors := make([]error, len(zones))
-	workqueue.ParallelizeUntil(context.Background(), len(zones), len(zones), func(piece int) {
-		zoneLinks[piece], errors[piece] = m.GceService.FetchMigsWithName(zones[piece], name)
+	workqueue.ParallelizeUntil(ctx, len(zones), len(zones), func(piece int) {
+		zoneLinks[piece], errors[piece] = m.GceService.FetchMigsWithName(ctx, zones[piece], name)
 	})
 
 	for _, err := range errors {
@@ -598,26 +605,26 @@ func (m *gceManagerImpl) findMigsInRegion(region string, name *regexp.Regexp) ([
 }
 
 // GetMigOptions merges default options with user-provided options as specified in the MIG's instance template metadata
-func (m *gceManagerImpl) GetMigOptions(mig Mig, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions {
+func (m *gceManagerImpl) GetMigOptions(ctx context.Context, mig Mig, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions {
 	migRef := mig.GceRef()
 	options := m.cache.GetAutoscalingOptions(migRef)
 	if options == nil {
 		return &defaults
 	}
 
-	if opt, ok := getFloat64Option(options, migRef.Name, config.DefaultScaleDownUtilizationThresholdKey); ok {
+	if opt, ok := getFloat64Option(ctx, options, migRef.Name, config.DefaultScaleDownUtilizationThresholdKey); ok {
 		defaults.ScaleDownUtilizationThreshold = opt
 	}
-	if opt, ok := getFloat64Option(options, migRef.Name, config.DefaultScaleDownGpuUtilizationThresholdKey); ok {
+	if opt, ok := getFloat64Option(ctx, options, migRef.Name, config.DefaultScaleDownGpuUtilizationThresholdKey); ok {
 		defaults.ScaleDownGpuUtilizationThreshold = opt
 	}
-	if opt, ok := getDurationOption(options, migRef.Name, config.DefaultScaleDownUnneededTimeKey); ok {
+	if opt, ok := getDurationOption(ctx, options, migRef.Name, config.DefaultScaleDownUnneededTimeKey); ok {
 		defaults.ScaleDownUnneededTime = opt
 	}
-	if opt, ok := getDurationOption(options, migRef.Name, config.DefaultScaleDownUnreadyTimeKey); ok {
+	if opt, ok := getDurationOption(ctx, options, migRef.Name, config.DefaultScaleDownUnreadyTimeKey); ok {
 		defaults.ScaleDownUnreadyTime = opt
 	}
-	if opt, ok := getDurationOption(options, migRef.Name, config.DefaultMaxNodeProvisionTimeKey); ok {
+	if opt, ok := getDurationOption(ctx, options, migRef.Name, config.DefaultMaxNodeProvisionTimeKey); ok {
 		defaults.MaxNodeProvisionTime = opt
 	}
 
@@ -625,24 +632,24 @@ func (m *gceManagerImpl) GetMigOptions(mig Mig, defaults config.NodeGroupAutosca
 }
 
 // GetMigTemplateNode constructs a node from GCE instance template of the given MIG.
-func (m *gceManagerImpl) GetMigTemplateNode(mig Mig) (*apiv1.Node, error) {
-	template, err := m.migInfoProvider.GetMigInstanceTemplate(mig.GceRef())
+func (m *gceManagerImpl) GetMigTemplateNode(ctx context.Context, mig Mig) (*apiv1.Node, error) {
+	template, err := m.migInfoProvider.GetMigInstanceTemplate(ctx, mig.GceRef())
 	if err != nil {
 		return nil, err
 	}
-	kubeEnv, err := m.migInfoProvider.GetMigKubeEnv(mig.GceRef())
+	kubeEnv, err := m.migInfoProvider.GetMigKubeEnv(ctx, mig.GceRef())
 	if err != nil {
 		return nil, err
 	}
-	machineType, err := m.migInfoProvider.GetMigMachineType(mig.GceRef())
+	machineType, err := m.migInfoProvider.GetMigMachineType(ctx, mig.GceRef())
 	if err != nil {
 		return nil, err
 	}
-	migOsInfo, err := m.templates.MigOsInfo(mig.Id(), kubeEnv)
+	migOsInfo, err := m.templates.MigOsInfo(ctx, mig.Id(), kubeEnv)
 	if err != nil {
 		return nil, err
 	}
-	return m.templates.BuildNodeFromTemplate(mig, migOsInfo, template, kubeEnv, machineType.CPU, machineType.Memory, nil, m.reserved, m.localSSDDiskSizeProvider)
+	return m.templates.BuildNodeFromTemplate(ctx, mig, migOsInfo, template, kubeEnv, machineType.CPU, machineType.Memory, nil, m.reserved, m.localSSDDiskSizeProvider)
 }
 
 // parseMIGAutoDiscoverySpecs returns any provided NodeGroupAutoDiscoverySpecs

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -491,7 +492,7 @@ func TestDeleteInstances(t *testing.T) {
 		},
 	}
 
-	err := g.DeleteInstances(instances)
+	err := g.DeleteInstances(context.Background(), instances)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
 
@@ -512,7 +513,7 @@ func TestDeleteInstances(t *testing.T) {
 		},
 	}
 
-	err = g.DeleteInstances(instances)
+	err = g.DeleteInstances(context.Background(), instances)
 	assert.Error(t, err)
 	assert.Equal(t, "cannot delete instances which don't belong to the same MIG.", err.Error())
 	mock.AssertExpectationsForObjects(t, server)
@@ -569,17 +570,17 @@ func TestGetAndSetMigSize(t *testing.T) {
 		)).Once()
 
 	// getting size for defaultPoolMig should trigger listing all the InstanceGroupManagers
-	defaultPoolMigSize, err := g.GetMigSize(defaultPoolMig)
+	defaultPoolMigSize, err := g.GetMigSize(context.Background(), defaultPoolMig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(7), defaultPoolMigSize)
 	mock.AssertExpectationsForObjects(t, server)
 
 	// extra queries for defaultPoolMig and extraPoolMig should not result in any extra API calls
-	defaultPoolMigSize, err = g.GetMigSize(defaultPoolMig)
+	defaultPoolMigSize, err = g.GetMigSize(context.Background(), defaultPoolMig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(7), defaultPoolMigSize)
 
-	extraPoolMigSize, err := g.GetMigSize(extraPoolMig)
+	extraPoolMigSize, err := g.GetMigSize(context.Background(), extraPoolMig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(8), extraPoolMigSize)
 	mock.AssertExpectationsForObjects(t, server)
@@ -587,12 +588,12 @@ func TestGetAndSetMigSize(t *testing.T) {
 	// set target size for extraPoolMig; will require resize API call and API call for polling for resize operation
 	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-b/instanceGroupManagers/%s/resize", extraPoolMigName)).Return(setMigSizeResponse).Once()
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1505739408819-5597646964339-eb839c88-28805931/wait").Return(setMigSizeOperationResponse).Once()
-	err = g.SetMigSize(extraPoolMig, 4)
+	err = g.SetMigSize(context.Background(), extraPoolMig, 4)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
 
 	// query for size of resized extraPoolMig; no extra API calls
-	extraPoolMigSize, err = g.GetMigSize(extraPoolMig)
+	extraPoolMigSize, err = g.GetMigSize(context.Background(), extraPoolMig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(4), extraPoolMigSize)
 	mock.AssertExpectationsForObjects(t, server)
@@ -603,20 +604,20 @@ func TestGetAndSetMigSize(t *testing.T) {
 	// query for size of resized extraPool2Mig; execting API call refreshing target size for this MIG
 	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-c/instanceGroupManagers/%s", extraPool2MigName)).Return(buildInstanceGroupManagerResponse(zoneC, extraPool2MigName, 9)).Once()
 
-	extraPool2MigSize, err := g.GetMigSize(extraPool2Mig)
+	extraPool2MigSize, err := g.GetMigSize(context.Background(), extraPool2Mig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(9), extraPool2MigSize)
 	mock.AssertExpectationsForObjects(t, server)
 
 	// another query for size of extraPool2Mig will not result in any API calls
-	extraPool2MigSize, err = g.GetMigSize(extraPool2Mig)
+	extraPool2MigSize, err = g.GetMigSize(context.Background(), extraPool2Mig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(9), extraPool2MigSize)
 	mock.AssertExpectationsForObjects(t, server)
 
 	// let's invalidate target size cache
 	// TODO we should probably call g.Refresh here but that imples more API calls. Leaving just partial cache invalidation for now
-	g.cache.InvalidateAllMigTargetSizes()
+	g.cache.InvalidateAllMigTargetSizes(context.Background())
 
 	// now if w query size of any mig whole cache should be refreshed by listing InstanceGroupManagers; we expect two calls
 	// for zoneB and zoneC
@@ -630,7 +631,7 @@ func TestGetAndSetMigSize(t *testing.T) {
 			buildListInstanceGroupManagersResponsePart(extraPool2MigName, zoneC, 9),
 		)).Once()
 
-	extraPool2MigSize, err = g.GetMigSize(extraPool2Mig)
+	extraPool2MigSize, err = g.GetMigSize(context.Background(), extraPool2Mig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(9), extraPool2MigSize)
 	mock.AssertExpectationsForObjects(t, server)
@@ -648,13 +649,13 @@ func TestGetMigSizeListCallFails(t *testing.T) {
 	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-b/instanceGroupManagers/%s", defaultPoolMigName)).Return(buildInstanceGroupManagerResponse(zoneB, defaultPoolMigName, 7)).Once()
 
 	// getting size for defaultPoolMig should trigger listing all the InstanceGroupManagers
-	defaultPoolMigSize, err := g.GetMigSize(defaultPoolMig)
+	defaultPoolMigSize, err := g.GetMigSize(context.Background(), defaultPoolMig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(7), defaultPoolMigSize)
 	mock.AssertExpectationsForObjects(t, server)
 
 	// extra queries for defaultPoolMig and extraPoolMig should not result in any extra API calls
-	defaultPoolMigSize, err = g.GetMigSize(defaultPoolMig)
+	defaultPoolMigSize, err = g.GetMigSize(context.Background(), defaultPoolMig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(7), defaultPoolMigSize)
 
@@ -662,7 +663,7 @@ func TestGetMigSizeListCallFails(t *testing.T) {
 	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-b/instanceGroupManagers/%s", extraPoolMigName)).Return(buildInstanceGroupManagerResponse(zoneB, extraPoolMigName, 8)).Once()
 
 	// getting size for extraPoolMig should trigger get call for this MIG
-	extraPoolMigSize, err := g.GetMigSize(extraPoolMig)
+	extraPoolMigSize, err := g.GetMigSize(context.Background(), extraPoolMig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(8), extraPoolMigSize)
 	mock.AssertExpectationsForObjects(t, server)
@@ -675,8 +676,8 @@ func TestGetMigForInstance(t *testing.T) {
 
 	setupTestDefaultPool(g, false)
 	g.cache.InvalidateAllMigBasenames()
-	g.cache.InvalidateAllInstancesToMig()
-	g.cache.InvalidateAllMigInstances()
+	g.cache.InvalidateAllInstancesToMig(context.Background())
+	g.cache.InvalidateAllMigInstances(context.Background())
 
 	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers").Return(
 		buildListInstanceGroupManagersResponse(
@@ -690,7 +691,7 @@ func TestGetMigForInstance(t *testing.T) {
 		Name:    "gke-cluster-1-default-pool-f7607aac-f1hm",
 	}
 
-	mig, err := g.GetMigForInstance(gceRef1)
+	mig, err := g.GetMigForInstance(context.Background(), gceRef1)
 	assert.NoError(t, err)
 	assert.NotNil(t, mig)
 	assert.Equal(t, "gke-cluster-1-default-pool", mig.GceRef().Name)
@@ -700,7 +701,7 @@ func TestGetMigForInstance(t *testing.T) {
 		Zone:    zoneB,
 		Name:    "gke-cluster-1-default-pool-f7607aac-0000", // instance from unknown MIG
 	}
-	mig, err = g.GetMigForInstance(gceRef2)
+	mig, err = g.GetMigForInstance(context.Background(), gceRef2)
 	assert.NoError(t, err)
 	assert.Nil(t, mig)
 	_, found := g.cache.instancesFromUnknownMig[gceRef2]
@@ -727,7 +728,7 @@ func TestGetMigNodesBasic(t *testing.T) {
 		maxSize:    1000,
 	}
 
-	nodes, err := g.GetMigNodes(mig)
+	nodes, err := g.GetMigNodes(context.Background(), mig)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(nodes))
 	assert.Equal(t, "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g", nodes[0].Id)
@@ -1068,7 +1069,7 @@ func TestGetMigNodesComplex(t *testing.T) {
 		minSize:    0,
 		maxSize:    1000,
 	}
-	nodes, err := g.GetMigNodes(mig)
+	nodes, err := g.GetMigNodes(context.Background(), mig)
 
 	assert.NoError(t, err)
 	assert.Equal(t, len(testCases), len(nodes))
@@ -1159,7 +1160,7 @@ func TestFetchAutoMigsZonal(t *testing.T) {
 		{Re: regexp.MustCompile("UNUSED"), MinSize: min, MaxSize: max},
 	}
 
-	assert.NoError(t, g.fetchAutoMigs())
+	assert.NoError(t, g.fetchAutoMigs(context.Background()))
 
 	migs := g.GetMigs()
 	assert.Equal(t, 2, len(migs))
@@ -1199,9 +1200,9 @@ func TestFetchAutoMigsUnregistersMissingMigs(t *testing.T) {
 		minSize:    1,
 		maxSize:    10,
 	}
-	assert.True(t, g.registerMig(unregister))
+	assert.True(t, g.registerMig(context.Background(), unregister))
 
-	assert.NoError(t, g.fetchAutoMigs())
+	assert.NoError(t, g.fetchAutoMigs(context.Background()))
 
 	migs := g.GetMigs()
 	assert.Equal(t, 1, len(migs))
@@ -1232,7 +1233,7 @@ func TestFetchAutoMigsRegional(t *testing.T) {
 		{Re: regexp.MustCompile("UNUSED"), MinSize: min, MaxSize: max},
 	}
 
-	assert.NoError(t, g.fetchAutoMigs())
+	assert.NoError(t, g.fetchAutoMigs(context.Background()))
 
 	migs := g.GetMigs()
 	assert.Equal(t, 2, len(migs))
@@ -1332,7 +1333,7 @@ func TestGetMigTemplateNode(t *testing.T) {
 		maxSize:    1000,
 	}
 
-	node, err := g.GetMigTemplateNode(mig)
+	node, err := g.GetMigTemplateNode(context.Background(), mig)
 	assert.NoError(t, err)
 	assert.NotNil(t, node)
 	mock.AssertExpectationsForObjects(t, server)
@@ -1346,8 +1347,8 @@ func validateMigExists(t *testing.T, migs []Mig, zone string, name string, minSi
 	}
 	for _, mig := range migs {
 		if mig.GceRef() == ref {
-			assert.Equal(t, minSize, mig.MinSize())
-			assert.Equal(t, maxSize, mig.MaxSize())
+			assert.Equal(t, minSize, mig.MinSize(context.Background()))
+			assert.Equal(t, maxSize, mig.MaxSize(context.Background()))
 			return
 		}
 	}
@@ -1503,7 +1504,7 @@ func TestAppendInstances(t *testing.T) {
 	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers/gke-cluster-1-default-pool/listManagedInstances").Return(buildFourRunningInstancesOnDefaultMigManagedInstancesResponse(zoneB)).Once()
 	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-b/instanceGroupManagers/%v/createInstances", defaultPoolMig.gceRef.Name)).Return(createInstancesResponse).Once()
 	server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1624366531120-5c55a4e128c15-fc5daa90-e1ef6c32/wait").Return(createInstancesOperationResponse).Once()
-	err := g.CreateInstances(defaultPoolMig, 2)
+	err := g.CreateInstances(context.Background(), defaultPoolMig, 2)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, server)
 }
@@ -1542,7 +1543,7 @@ func TestCreateInstancesWithMultipleRequests(t *testing.T) {
 		t.Run(fmt.Sprintf("delta=%v", tt.delta), func(t *testing.T) {
 			server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-b/instanceGroupManagers/%v/createInstances", mig.gceRef.Name)).Return(createInstancesResponse).Times(tt.wantRequests)
 			server.On("handle", "/projects/project1/zones/us-central1-b/operations/operation-1624366531120-5c55a4e128c15-fc5daa90-e1ef6c32/wait").Return(createInstancesOperationResponse).Times(tt.wantRequests)
-			err := g.CreateInstances(mig, int64(tt.delta))
+			err := g.CreateInstances(context.Background(), mig, int64(tt.delta))
 			assert.NoError(t, err)
 		})
 	}
@@ -1612,7 +1613,7 @@ func TestGetMigOptions(t *testing.T) {
 			mgr := newTestGceManager(t, "", false)
 			mig := setupTestDefaultPool(mgr, true)
 			mgr.cache.SetAutoscalingOptions(mig.GceRef(), c.opts)
-			actual := mgr.GetMigOptions(mig, *defaultOptions)
+			actual := mgr.GetMigOptions(context.Background(), mig, *defaultOptions)
 			assert.Equal(t, c.expected, actual)
 		})
 	}

--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"math"
 	"strconv"
 	"time"
@@ -56,7 +57,8 @@ const DefaultBootDiskSizeGB = 100
 
 // NodePrice returns a price of running the given node for a given period of time.
 // All prices are in USD.
-func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
+func (model *GcePriceModel) NodePrice(ctx context.Context, node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
+	logger := klog.FromContext(ctx)
 	price := 0.0
 	basePriceFound := false
 	machineType := ""
@@ -74,7 +76,7 @@ func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, end
 		price = basePricePerHour * getHours(startTime, endTime)
 		basePriceFound = true
 	} else {
-		klog.Warningf("Pricing information not found for instance type %v; will fallback to default pricing", machineType)
+		logger.Info("Pricing information not found for instance type, will fall back to default pricing model", "instanceType", machineType)
 	}
 	if !basePriceFound {
 		price = model.getBasePrice(node.Status.Capacity, machineType, startTime, endTime)
@@ -95,7 +97,7 @@ func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, end
 	// Boot disk price
 	bootDiskSize, _ := strconv.ParseInt(node.Annotations[BootDiskSizeAnnotation], 10, 64)
 	if bootDiskSize == 0 {
-		klog.V(5).Infof("Boot disk size is not found for node %s, using default size %v", node.Name, DefaultBootDiskSizeGB)
+		logger.V(5).Info("Boot disk size is not found for node. Using defult size.", "node", klog.KObj(node), "defaultSize", DefaultBootDiskSizeGB)
 		bootDiskSize = DefaultBootDiskSizeGB
 	}
 	bootDiskType := node.Annotations[BootDiskTypeAnnotation]
@@ -103,7 +105,7 @@ func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, end
 		bootDiskType = val
 	}
 	if bootDiskType == "" {
-		klog.V(5).Infof("Boot disk type is not found for node %s, using default type %s", node.Name, DefaultBootDiskType)
+		logger.V(5).Info("Boot disk type is not found for node. Using default type.", "node", klog.KObj(node), "defaultType", DefaultBootDiskType)
 		bootDiskType = DefaultBootDiskType
 	}
 	bootDiskPrice := model.PriceInfo.BootDiskPricePerHour()[bootDiskType]
@@ -122,7 +124,7 @@ func (model *GcePriceModel) NodePrice(node *apiv1.Node, startTime time.Time, end
 				if _, found := priceMapToUse[gpuType]; found {
 					gpuPrice = priceMapToUse[gpuType]
 				} else {
-					klog.Warningf("Pricing information not found for GPU type %v; will fallback to default pricing", gpuType)
+					logger.Info("Pricing information not found for GPU type, will fallback to default pricing", "gpuType", gpuType)
 				}
 			}
 		}
@@ -155,7 +157,7 @@ func (model *GcePriceModel) getPreemptibleDiscount(node *apiv1.Node) float64 {
 
 // PodPrice returns a theoretical minimum price of running a pod for a given
 // period of time on a perfectly matching machine.
-func (model *GcePriceModel) PodPrice(pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
+func (model *GcePriceModel) PodPrice(ctx context.Context, pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
 	podRequests := podutils.PodRequests(pod)
 	price := model.getBasePrice(podRequests, "", startTime, endTime) + model.getAdditionalPrice(podRequests, startTime, endTime)
 	return price, nil

--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"math"
 	"strconv"
 	"testing"
@@ -225,9 +226,9 @@ func TestGetNodePrice(t *testing.T) {
 			model := NewGcePriceModel(NewGcePriceInfo(), localssdsize.NewSimpleLocalSSDProvider())
 			now := time.Now()
 
-			price1, err := model.NodePrice(tc.cheaperNode, now, now.Add(time.Hour))
+			price1, err := model.NodePrice(context.Background(), tc.cheaperNode, now, now.Add(time.Hour))
 			assert.NoError(t, err)
-			price2, err := model.NodePrice(tc.expensiveNode, now, now.Add(time.Hour))
+			price2, err := model.NodePrice(context.Background(), tc.expensiveNode, now, now.Add(time.Hour))
 			assert.NoError(t, err)
 			if price1 >= tc.priceComparisonCoefficient*price2 {
 				t.Errorf("Failed price comparison, price1=%v price2=%v price2*coefficient=%v", price1, price2, price2*tc.priceComparisonCoefficient)
@@ -244,11 +245,11 @@ func TestGetPodPrice(t *testing.T) {
 	model := NewGcePriceModel(NewGcePriceInfo(), localssdsize.NewSimpleLocalSSDProvider())
 	now := time.Now()
 
-	price1, err := model.PodPrice(pod1, now, now.Add(time.Hour))
+	price1, err := model.PodPrice(context.Background(), pod1, now, now.Add(time.Hour))
 	assert.NoError(t, err)
-	price2, err := model.PodPrice(pod2, now, now.Add(time.Hour))
+	price2, err := model.PodPrice(context.Background(), pod2, now, now.Add(time.Hour))
 	assert.NoError(t, err)
-	price3, err := model.PodPrice(pod3, now, now.Add(time.Hour))
+	price3, err := model.PodPrice(context.Background(), pod3, now, now.Add(time.Hour))
 	assert.NoError(t, err)
 	// 2 times bigger pod should cost twice as much.
 	assert.True(t, math.Abs(price1*2-price2) < 0.001)

--- a/cluster-autoscaler/cloudprovider/gce/gce_reserved.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_reserved.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -87,7 +88,8 @@ type GceReserved struct{}
 
 // CalculateKernelReserved computes how much memory Linux kernel will reserve.
 // TODO(jkaniuk): account for crashkernel reservation on RHEL / CentOS
-func (r *GceReserved) CalculateKernelReserved(m MigOsInfo, physicalMemory int64) int64 {
+func (r *GceReserved) CalculateKernelReserved(ctx context.Context, m MigOsInfo, physicalMemory int64) int64 {
+	logger := klog.FromContext(ctx)
 	os := m.Os()
 	osDistribution := m.OsDistribution()
 	arch := m.Arch()
@@ -122,13 +124,14 @@ func (r *GceReserved) CalculateKernelReserved(m MigOsInfo, physicalMemory int64)
 	case OperatingSystemWindows:
 		return 0
 	default:
-		klog.Errorf("CalculateKernelReserved called for unknown operating system %v", os)
+		logger.Error(nil, "CalculateKernelReserved called for unknown operating system", "os", os)
 		return 0
 	}
 }
 
 // ParseEvictionHardOrGetDefault tries to parse evictionHard map, else fills defaults to be used.
-func ParseEvictionHardOrGetDefault(evictionHard map[string]string) *EvictionHard {
+func ParseEvictionHardOrGetDefault(ctx context.Context, evictionHard map[string]string) *EvictionHard {
+	logger := klog.FromContext(ctx)
 	if evictionHard == nil {
 		return &EvictionHard{
 			MemoryEvictionQuantity:        defaultKubeletEvictionHardMemory,
@@ -140,7 +143,7 @@ func ParseEvictionHardOrGetDefault(evictionHard map[string]string) *EvictionHard
 	// CalculateOrDefault for Memory
 	memory, found := evictionHard[MemoryEvictionHardTag]
 	if !found {
-		klog.V(4).Info("evictionHard memory tag not found, using default")
+		logger.V(4).Info("evictionHard memory tag not found, using default")
 		evictionReturn.MemoryEvictionQuantity = defaultKubeletEvictionHardMemory
 	} else {
 		memQuantity, err := resource.ParseQuantity(memory)
@@ -149,7 +152,7 @@ func ParseEvictionHardOrGetDefault(evictionHard map[string]string) *EvictionHard
 		} else {
 			value, possible := memQuantity.AsInt64()
 			if !possible {
-				klog.Errorf("unable to parse eviction ratio for memory: %v", err)
+				logger.Error(err, "unable to parse eviction ratio for memory")
 				evictionReturn.MemoryEvictionQuantity = defaultKubeletEvictionHardMemory
 			} else {
 				evictionReturn.MemoryEvictionQuantity = value
@@ -160,12 +163,12 @@ func ParseEvictionHardOrGetDefault(evictionHard map[string]string) *EvictionHard
 	// CalculateOrDefault for Ephemeral Storage
 	ephRatio, found := evictionHard[EphemeralStorageEvictionHardTag]
 	if !found {
-		klog.V(4).Info("evictionHard ephemeral storage tag not found, using default")
+		logger.V(4).Info("evictionHard ephemeral storage tag not found, using default")
 		evictionReturn.EphemeralStorageEvictionRatio = defaultKubeletEvictionHardEphemeralStorageRatio
 	} else {
 		value, err := parsePercentageToRatio(ephRatio)
 		if err != nil {
-			klog.Errorf("unable to parse eviction ratio for ephemeral storage: %v", err)
+			logger.Error(err, "Unable to parse eviction ratio for ephemeral storage")
 			evictionReturn.EphemeralStorageEvictionRatio = defaultKubeletEvictionHardEphemeralStorageRatio
 		} else {
 			if value < 0.0 || value > 1.0 {
@@ -251,7 +254,8 @@ var ephemeralStorageOnLocalSSDFilesystemOverheadInKiBByOSAndDiskCount = map[Oper
 // so interpolating wouldn't make much sense. Instead, we use the next count for
 // which we measured a filesystem overhead, which is a safer approximation
 // (better to reserve more and not scale up than not enough and not schedule).
-func EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(diskCount int64, osDistribution OperatingSystemDistribution) int64 {
+func EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(ctx context.Context, diskCount int64, osDistribution OperatingSystemDistribution) int64 {
+	logger := klog.FromContext(ctx)
 	var measuredCount int64
 	if diskCount <= 8 {
 		measuredCount = diskCount
@@ -263,14 +267,15 @@ func EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(diskCount int64, osDist
 
 	o, ok := ephemeralStorageOnLocalSSDFilesystemOverheadInKiBByOSAndDiskCount[osDistribution]
 	if !ok {
-		klog.Errorf("Ephemeral storage backed by local SSDs is not supported for image family %v", osDistribution)
+		logger.Error(nil, "Ephemeral storage backed by local SSDs is not supported for image family", "osDistribution", osDistribution)
 		return 0
 	}
 	return o[measuredCount] * KiB
 }
 
 // CalculateOSReservedEphemeralStorage estimates how much ephemeral storage OS will reserve and eviction threshold
-func (r *GceReserved) CalculateOSReservedEphemeralStorage(m MigOsInfo, diskSize int64) int64 {
+func (r *GceReserved) CalculateOSReservedEphemeralStorage(ctx context.Context, m MigOsInfo, diskSize int64) int64 {
+	logger := klog.FromContext(ctx)
 	osDistribution := m.OsDistribution()
 	arch := m.Arch()
 	switch osDistribution {
@@ -290,7 +295,7 @@ func (r *GceReserved) CalculateOSReservedEphemeralStorage(m MigOsInfo, diskSize 
 		storage += int64(math.Ceil(0.010 * GiB))  // over-provisioning buffer
 		return storage
 	default:
-		klog.Errorf("CalculateReservedAndEvictionEphemeralStorage called for unknown os distribution %v", osDistribution)
+		logger.Error(nil, "CalculateReservedAndEvictionEphemeralStorage called for unknown os distribution", "osDistribution", osDistribution)
 		return 0
 	}
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_reserved_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_reserved_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -109,7 +110,7 @@ func TestCalculateKernelReservedLinux(t *testing.T) {
 		r := &GceReserved{}
 		t.Run(fmt.Sprintf("%v", idx), func(t *testing.T) {
 			m := NewMigOsInfo(OperatingSystemLinux, tc.osDistribution, tc.arch)
-			reserved := r.CalculateKernelReserved(m, tc.physicalMemory)
+			reserved := r.CalculateKernelReserved(context.Background(), m, tc.physicalMemory)
 			if tc.osDistribution == OperatingSystemDistributionUbuntu {
 				assert.Equal(t, tc.reservedMemory+int64(math.Min(correctionConstant*float64(tc.physicalMemory), maximumCorrectionValue)+ubuntuSpecificOffset), reserved)
 			} else if tc.osDistribution == OperatingSystemDistributionCOS {
@@ -152,7 +153,7 @@ func TestEphemeralStorageOnLocalSSDFilesystemOverheadInBytes(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.scenario, func(t *testing.T) {
-			actual := EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(tc.diskCount, tc.osDistribution)
+			actual := EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(context.Background(), tc.diskCount, tc.osDistribution)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -35,25 +35,27 @@ import (
 // MigInfoProvider allows obtaining information about MIGs
 type MigInfoProvider interface {
 	// GetMigInstances returns instances for a given MIG ref
-	GetMigInstances(migRef GceRef) ([]GceInstance, error)
+	GetMigInstances(ctx context.Context, migRef GceRef) ([]GceInstance, error)
 	// GetMigForInstance returns MIG ref for a given instance
-	GetMigForInstance(instanceRef GceRef) (Mig, error)
+	GetMigForInstance(ctx context.Context, instanceRef GceRef) (Mig, error)
 	// RegenerateMigInstancesCache regenerates MIGs to instances mapping cache
-	RegenerateMigInstancesCache() error
-	// GetMigTargetSize returns target size for given MIG ref
-	GetMigTargetSize(migRef GceRef) (int64, error)
+	RegenerateMigInstancesCache(ctx context.
+		// GetMigTargetSize returns target size for given MIG ref
+		Context) error
+
+	GetMigTargetSize(ctx context.Context, migRef GceRef) (int64, error)
 	// GetMigBasename returns basename for given MIG ref
-	GetMigBasename(migRef GceRef) (string, error)
+	GetMigBasename(ctx context.Context, migRef GceRef) (string, error)
 	// GetMigInstanceTemplateName returns instance template name for given MIG ref
-	GetMigInstanceTemplateName(migRef GceRef) (InstanceTemplateName, error)
+	GetMigInstanceTemplateName(ctx context.Context, migRef GceRef) (InstanceTemplateName, error)
 	// GetMigInstanceTemplate returns instance template for given MIG ref
-	GetMigInstanceTemplate(migRef GceRef) (*gce.InstanceTemplate, error)
+	GetMigInstanceTemplate(ctx context.Context, migRef GceRef) (*gce.InstanceTemplate, error)
 	// GetMigKubeEnv returns kube-env for given MIG ref
-	GetMigKubeEnv(migRef GceRef) (KubeEnv, error)
+	GetMigKubeEnv(ctx context.Context, migRef GceRef) (KubeEnv, error)
 	// GetMigMachineType returns machine type used by a MIG.
 	// For custom machines cpu and memory information is based on parsing
 	// machine name. For standard types it's retrieved from GCE API.
-	GetMigMachineType(migRef GceRef) (MachineType, error)
+	GetMigMachineType(ctx context.Context, migRef GceRef) (MachineType, error)
 	// Returns the pagination behavior of the listManagedInstances Results API method for a given MIG ref
 	GetListManagedInstancesResults(migRef GceRef) (string, error)
 	// GetMigIsStable returns whether given MIG is stable. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.
@@ -107,32 +109,32 @@ func NewCachingMigInfoProvider(cache *GceCache, migLister MigLister, gceClient A
 }
 
 // GetMigInstances returns instances for a given MIG ref
-func (c *cachingMigInfoProvider) GetMigInstances(migRef GceRef) ([]GceInstance, error) {
-	instances, found := c.cache.GetMigInstances(migRef)
+func (c *cachingMigInfoProvider) GetMigInstances(ctx context.Context, migRef GceRef) ([]GceInstance, error) {
+	instances, found := c.cache.GetMigInstances(ctx, migRef)
 	if found {
 		return instances, nil
 	}
 
 	// MIG is not in the cache.
-	err := c.fillMigInstances(migRef)
+	err := c.fillMigInstances(ctx, migRef)
 	if err != nil {
 		return nil, err
 	}
-	instances, _ = c.cache.GetMigInstances(migRef)
+	instances, _ = c.cache.GetMigInstances(ctx, migRef)
 	return instances, nil
 }
 
 // GetMigForInstance returns MIG ref for a given instance
-func (c *cachingMigInfoProvider) GetMigForInstance(instanceRef GceRef) (Mig, error) {
+func (c *cachingMigInfoProvider) GetMigForInstance(ctx context.Context, instanceRef GceRef) (Mig, error) {
 	c.migInstanceMutex.Lock()
 	defer c.migInstanceMutex.Unlock()
 
-	mig, found, err := c.getCachedMigForInstance(instanceRef)
+	mig, found, err := c.getCachedMigForInstance(ctx, instanceRef)
 	if found {
 		return mig, err
 	}
 
-	mig = c.findMigWithMatchingBasename(instanceRef)
+	mig = c.findMigWithMatchingBasename(ctx, instanceRef)
 	if mig == nil {
 		return nil, nil
 	}
@@ -144,12 +146,12 @@ func (c *cachingMigInfoProvider) GetMigForInstance(instanceRef GceRef) (Mig, err
 		return nil, nil
 	}
 
-	err = c.fillMigInstances(mig.GceRef())
+	err = c.fillMigInstances(ctx, mig.GceRef())
 	if err != nil {
 		return nil, err
 	}
 	// Check in the cache again after it's been refilled
-	mig, found, err = c.getCachedMigForInstance(instanceRef)
+	mig, found, err = c.getCachedMigForInstance(ctx, instanceRef)
 	if !found {
 		c.cache.MarkInstanceMigUnknown(instanceRef)
 	}
@@ -157,32 +159,32 @@ func (c *cachingMigInfoProvider) GetMigForInstance(instanceRef GceRef) (Mig, err
 
 }
 
-func (c *cachingMigInfoProvider) getCachedMigForInstance(instanceRef GceRef) (Mig, bool, error) {
-	if migRef, found := c.cache.GetMigForInstance(instanceRef); found {
+func (c *cachingMigInfoProvider) getCachedMigForInstance(ctx context.Context, instanceRef GceRef) (Mig, bool, error) {
+	if migRef, found := c.cache.GetMigForInstance(ctx, instanceRef); found {
 		mig, found := c.cache.GetMig(migRef)
 		if !found {
 			return nil, true, fmt.Errorf("instance %v belongs to unregistered mig %v", instanceRef, migRef)
 		}
 		return mig, true, nil
-	} else if c.cache.IsMigUnknownForInstance(instanceRef) {
+	} else if c.cache.IsMigUnknownForInstance(ctx, instanceRef) {
 		return nil, true, nil
 	}
 	return nil, false, nil
 }
 
 // RegenerateMigInstancesCache regenerates MIGs to instances mapping cache
-func (c *cachingMigInfoProvider) RegenerateMigInstancesCache() error {
-	c.cache.InvalidateAllMigInstances()
-	c.cache.InvalidateAllInstancesToMig()
+func (c *cachingMigInfoProvider) RegenerateMigInstancesCache(ctx context.Context) error {
+	c.cache.InvalidateAllMigInstances(ctx)
+	c.cache.InvalidateAllInstancesToMig(ctx)
 
 	if c.bulkGceMigInstancesListingEnabled {
-		return c.bulkListMigInstances()
+		return c.bulkListMigInstances(ctx)
 	}
 
 	migs := c.migLister.GetMigs()
 	errors := make([]error, len(migs))
-	workqueue.ParallelizeUntil(context.Background(), c.concurrentGceRefreshes, len(migs), func(piece int) {
-		errors[piece] = c.fillMigInstances(migs[piece].GceRef())
+	workqueue.ParallelizeUntil(ctx, c.concurrentGceRefreshes, len(migs), func(piece int) {
+		errors[piece] = c.fillMigInstances(ctx, migs[piece].GceRef())
 	}, workqueue.WithChunkSize(c.concurrentGceRefreshes))
 
 	for _, err := range errors {
@@ -193,15 +195,15 @@ func (c *cachingMigInfoProvider) RegenerateMigInstancesCache() error {
 	return nil
 }
 
-func (c *cachingMigInfoProvider) bulkListMigInstances() error {
+func (c *cachingMigInfoProvider) bulkListMigInstances(ctx context.Context) error {
 	c.cache.InvalidateMigInstancesStateCount()
-	err := c.fillMigInfoCache()
+	err := c.fillMigInfoCache(ctx)
 	if err != nil {
 		return err
 	}
-	instances, listErr := c.listInstancesInAllZonesWithMigs()
+	instances, listErr := c.listInstancesInAllZonesWithMigs(ctx)
 	migToInstances := groupInstancesToMigs(instances)
-	updateErr := c.updateMigInstancesCache(migToInstances)
+	updateErr := c.updateMigInstancesCache(ctx, migToInstances)
 
 	if listErr != nil {
 		return listErr
@@ -209,7 +211,7 @@ func (c *cachingMigInfoProvider) bulkListMigInstances() error {
 	return updateErr
 }
 
-func (c *cachingMigInfoProvider) listInstancesInAllZonesWithMigs() ([]GceInstance, error) {
+func (c *cachingMigInfoProvider) listInstancesInAllZonesWithMigs(ctx context.Context) ([]GceInstance, error) {
 	var zones []string
 	for zone := range c.listAllZonesWithMigs() {
 		zones = append(zones, zone)
@@ -217,10 +219,10 @@ func (c *cachingMigInfoProvider) listInstancesInAllZonesWithMigs() ([]GceInstanc
 	var allInstances []GceInstance
 	errors := make([]error, len(zones))
 	zoneInstances := make([][]GceInstance, len(zones))
-	defer metrics.UpdateDurationFromStart(metrics.BulkListAllGceInstances, time.Now())
+	defer metrics.UpdateDurationFromStart(ctx, metrics.BulkListAllGceInstances, time.Now())
 
-	workqueue.ParallelizeUntil(context.Background(), len(zones), len(zones), func(piece int) {
-		zoneInstances[piece], errors[piece] = c.gceClient.FetchAllInstances(c.projectId, zones[piece], "")
+	workqueue.ParallelizeUntil(ctx, len(zones), len(zones), func(piece int) {
+		zoneInstances[piece], errors[piece] = c.gceClient.FetchAllInstances(ctx, c.projectId, zones[piece], "")
 	})
 
 	for _, instances := range zoneInstances {
@@ -267,12 +269,13 @@ func (c *cachingMigInfoProvider) isMigCreatingOrDeletingInstances(mig Mig) bool 
 }
 
 // updateMigInstancesCache updates the mig instances for each mig
-func (c *cachingMigInfoProvider) updateMigInstancesCache(migToInstances map[GceRef][]GceInstance) error {
-	defer metrics.UpdateDurationFromStart(metrics.BulkListMigInstances, time.Now())
+func (c *cachingMigInfoProvider) updateMigInstancesCache(ctx context.Context, migToInstances map[GceRef][]GceInstance) error {
+	logger := klog.FromContext(ctx)
+	defer metrics.UpdateDurationFromStart(ctx, metrics.BulkListMigInstances, time.Now())
 	inconsistentInstancesMigsCount := 0
 	defer func() {
 		if inconsistentInstancesMigsCount > 0 {
-			klog.Warningf("Inconsistent instances migs count: %v", inconsistentInstancesMigsCount)
+			logger.Info("Inconsistent instances migs count", "count", inconsistentInstancesMigsCount)
 		}
 		metrics.UpdateInconsistentInstancesMigsCount(inconsistentInstancesMigsCount)
 	}()
@@ -285,7 +288,7 @@ func (c *cachingMigInfoProvider) updateMigInstancesCache(migToInstances map[GceR
 		// - missing/malformed "created-by" reference
 		// we use an igm.ListInstances call as the authoritative source of instance information
 		if !c.isMigInstancesConsistent(mig, migToInstances) {
-			if err := c.fillMigInstances(migRef); err != nil {
+			if err := c.fillMigInstances(ctx, migRef); err != nil {
 				errors = append(errors, err)
 			}
 			inconsistentInstancesMigsCount += 1
@@ -295,7 +298,7 @@ func (c *cachingMigInfoProvider) updateMigInstancesCache(migToInstances map[GceR
 		// mig instances are re-fetched along with instance.Status.ErrorInfo for migs with
 		// instances in creating or deleting state
 		if c.isMigCreatingOrDeletingInstances(mig) {
-			if err := c.fillMigInstances(migRef); err != nil {
+			if err := c.fillMigInstances(ctx, migRef); err != nil {
 				errors = append(errors, err)
 			}
 			continue
@@ -314,10 +317,10 @@ func (c *cachingMigInfoProvider) updateMigInstancesCache(migToInstances map[GceR
 	return nil
 }
 
-func (c *cachingMigInfoProvider) findMigWithMatchingBasename(instanceRef GceRef) Mig {
+func (c *cachingMigInfoProvider) findMigWithMatchingBasename(ctx context.Context, instanceRef GceRef) Mig {
 	for _, mig := range c.migLister.GetMigs() {
 		migRef := mig.GceRef()
-		basename, err := c.GetMigBasename(migRef)
+		basename, err := c.GetMigBasename(ctx, migRef)
 		if err == nil && migRef.Project == instanceRef.Project && migRef.Zone == instanceRef.Zone && strings.HasPrefix(instanceRef.Name, basename) {
 			return mig
 		}
@@ -325,16 +328,17 @@ func (c *cachingMigInfoProvider) findMigWithMatchingBasename(instanceRef GceRef)
 	return nil
 }
 
-func (c *cachingMigInfoProvider) fillMigInstances(migRef GceRef) error {
-	if val, ok := c.cache.GetMigInstancesUpdateTime(migRef); ok {
+func (c *cachingMigInfoProvider) fillMigInstances(ctx context.Context, migRef GceRef) error {
+	logger := klog.FromContext(ctx)
+	if val, ok := c.cache.GetMigInstancesUpdateTime(ctx, migRef); ok {
 		// do not regenerate MIG instances cache if last refresh happened recently.
 		if c.timeProvider.Now().Sub(val) < c.migInstancesMinRefreshWaitTime {
-			klog.V(4).Infof("Not regenerating MIG instances cache for %s, as it was refreshed in last MinRefreshWaitTime (%s).", migRef.String(), c.migInstancesMinRefreshWaitTime)
+			logger.V(4).Info("Not regenerating MIG instances cache for mig as it was refreshed in last MinRefreshWaitTime", "mig", migRef, "MinRefreshWaitTime", c.migInstancesMinRefreshWaitTime)
 			return nil
 		}
 	}
-	klog.V(4).Infof("Regenerating MIG instances cache for %s", migRef.String())
-	instances, err := c.gceClient.FetchMigInstances(migRef)
+	logger.V(4).Info("Regenerating MIG instances cache for mig", "mig", migRef)
+	instances, err := c.gceClient.FetchMigInstances(ctx, migRef)
 	if err != nil {
 		c.migLister.HandleMigIssue(migRef, err)
 		return err
@@ -343,11 +347,11 @@ func (c *cachingMigInfoProvider) fillMigInstances(migRef GceRef) error {
 	return c.cache.SetMigInstances(migRef, instances, c.timeProvider.Now())
 }
 
-func (c *cachingMigInfoProvider) GetMigTargetSize(migRef GceRef) (int64, error) {
+func (c *cachingMigInfoProvider) GetMigTargetSize(ctx context.Context, migRef GceRef) (int64, error) {
 	c.migInfoMutex.Lock()
 	defer c.migInfoMutex.Unlock()
 
-	targetSize, found := c.cache.GetMigTargetSize(migRef)
+	targetSize, found := c.cache.GetMigTargetSize(ctx, migRef)
 	if found {
 		return targetSize, nil
 	}
@@ -355,10 +359,10 @@ func (c *cachingMigInfoProvider) GetMigTargetSize(migRef GceRef) (int64, error) 
 	var err error
 	if c.cache.IsMigTargetSizeCacheEmpty() {
 		// Cache is cold after Refresh() -- list all MIGs and populate the cache.
-		err = c.fillMigInfoCache()
+		err = c.fillMigInfoCache(ctx)
 	}
 
-	targetSize, found = c.cache.GetMigTargetSize(migRef)
+	targetSize, found = c.cache.GetMigTargetSize(ctx, migRef)
 	if found && err == nil {
 		return targetSize, nil
 	}
@@ -367,18 +371,18 @@ func (c *cachingMigInfoProvider) GetMigTargetSize(migRef GceRef) (int64, error) 
 	//  * InvalidateMigTargetSize was called for this specific mig, so it's not found in cache
 	//  * fillMigInfoCache returned an error
 	//  * MIG not found
-	err = c.fillSingleMigInfo(migRef)
+	err = c.fillSingleMigInfo(ctx, migRef)
 	if err != nil {
 		return 0, err
 	}
-	targetSize, found = c.cache.GetMigTargetSize(migRef)
+	targetSize, found = c.cache.GetMigTargetSize(ctx, migRef)
 	if !found {
 		return 0, fmt.Errorf("target size for %v not found in cache after refresh", migRef)
 	}
 	return targetSize, nil
 }
 
-func (c *cachingMigInfoProvider) GetMigBasename(migRef GceRef) (string, error) {
+func (c *cachingMigInfoProvider) GetMigBasename(ctx context.Context, migRef GceRef) (string, error) {
 	c.migInfoMutex.Lock()
 	defer c.migInfoMutex.Unlock()
 
@@ -387,13 +391,13 @@ func (c *cachingMigInfoProvider) GetMigBasename(migRef GceRef) (string, error) {
 		return basename, nil
 	}
 
-	err := c.fillMigInfoCache()
+	err := c.fillMigInfoCache(ctx)
 	basename, found = c.cache.GetMigBasename(migRef)
 	if err == nil && found {
 		return basename, nil
 	}
 
-	err = c.fillSingleMigInfo(migRef)
+	err = c.fillSingleMigInfo(ctx, migRef)
 	if err != nil {
 		return "", err
 	}
@@ -404,45 +408,45 @@ func (c *cachingMigInfoProvider) GetMigBasename(migRef GceRef) (string, error) {
 	return basename, nil
 }
 
-func (c *cachingMigInfoProvider) GetMigInstanceTemplateName(migRef GceRef) (InstanceTemplateName, error) {
+func (c *cachingMigInfoProvider) GetMigInstanceTemplateName(ctx context.Context, migRef GceRef) (InstanceTemplateName, error) {
 	c.migInfoMutex.Lock()
 	defer c.migInfoMutex.Unlock()
 
-	instanceTemplateName, found := c.cache.GetMigInstanceTemplateName(migRef)
+	instanceTemplateName, found := c.cache.GetMigInstanceTemplateName(ctx, migRef)
 	if found {
 		return instanceTemplateName, nil
 	}
 
-	err := c.fillMigInfoCache()
-	instanceTemplateName, found = c.cache.GetMigInstanceTemplateName(migRef)
+	err := c.fillMigInfoCache(ctx)
+	instanceTemplateName, found = c.cache.GetMigInstanceTemplateName(ctx, migRef)
 	if err == nil && found {
 		return instanceTemplateName, nil
 	}
 
-	err = c.fillSingleMigInfo(migRef)
+	err = c.fillSingleMigInfo(ctx, migRef)
 	if err != nil {
 		return InstanceTemplateName{}, err
 	}
-	instanceTemplateName, found = c.cache.GetMigInstanceTemplateName(migRef)
+	instanceTemplateName, found = c.cache.GetMigInstanceTemplateName(ctx, migRef)
 	if !found {
 		return InstanceTemplateName{}, fmt.Errorf("instance template name for %v not found in cache after refresh", migRef)
 	}
 	return instanceTemplateName, nil
 }
 
-func (c *cachingMigInfoProvider) GetMigInstanceTemplate(migRef GceRef) (*gce.InstanceTemplate, error) {
-	instanceTemplateName, err := c.GetMigInstanceTemplateName(migRef)
+func (c *cachingMigInfoProvider) GetMigInstanceTemplate(ctx context.Context, migRef GceRef) (*gce.InstanceTemplate, error) {
+	logger := klog.FromContext(ctx)
+	instanceTemplateName, err := c.GetMigInstanceTemplateName(ctx, migRef)
 	if err != nil {
 		return nil, err
 	}
 
-	template, found := c.cache.GetMigInstanceTemplate(migRef)
+	template, found := c.cache.GetMigInstanceTemplate(ctx, migRef)
 	if found && template.Name == instanceTemplateName.Name {
 		return template, nil
 	}
-
-	klog.V(2).Infof("Instance template of mig %v changed to %v", migRef.Name, instanceTemplateName.Name)
-	template, err = c.gceClient.FetchMigTemplate(migRef, instanceTemplateName.Name, instanceTemplateName.Regional)
+	logger.V(2).Info("Instance template of mig", "mig", migRef, "templateName", instanceTemplateName.Name)
+	template, err = c.gceClient.FetchMigTemplate(ctx, migRef, instanceTemplateName.Name, instanceTemplateName.Regional)
 	if err != nil {
 		return nil, err
 	}
@@ -450,18 +454,18 @@ func (c *cachingMigInfoProvider) GetMigInstanceTemplate(migRef GceRef) (*gce.Ins
 	return template, nil
 }
 
-func (c *cachingMigInfoProvider) GetMigKubeEnv(migRef GceRef) (KubeEnv, error) {
-	instanceTemplateName, err := c.GetMigInstanceTemplateName(migRef)
+func (c *cachingMigInfoProvider) GetMigKubeEnv(ctx context.Context, migRef GceRef) (KubeEnv, error) {
+	instanceTemplateName, err := c.GetMigInstanceTemplateName(ctx, migRef)
 	if err != nil {
 		return KubeEnv{}, err
 	}
 
-	kubeEnv, kubeEnvFound := c.cache.GetMigKubeEnv(migRef)
+	kubeEnv, kubeEnvFound := c.cache.GetMigKubeEnv(ctx, migRef)
 	if kubeEnvFound && kubeEnv.templateName == instanceTemplateName.Name {
 		return kubeEnv, nil
 	}
 
-	template, err := c.GetMigInstanceTemplate(migRef)
+	template, err := c.GetMigInstanceTemplate(ctx, migRef)
 	if err != nil {
 		return KubeEnv{}, err
 	}
@@ -474,7 +478,8 @@ func (c *cachingMigInfoProvider) GetMigKubeEnv(migRef GceRef) (KubeEnv, error) {
 }
 
 // filMigInfoCache needs to be called with migInfoMutex locked
-func (c *cachingMigInfoProvider) fillMigInfoCache() error {
+func (c *cachingMigInfoProvider) fillMigInfoCache(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
 	var zones []string
 	for zone := range c.listAllZonesWithMigs() {
 		zones = append(zones, zone)
@@ -482,7 +487,7 @@ func (c *cachingMigInfoProvider) fillMigInfoCache() error {
 
 	migs := make([][]*gce.InstanceGroupManager, len(zones))
 	errors := make([]error, len(zones))
-	workqueue.ParallelizeUntil(context.Background(), len(zones), len(zones), func(piece int) {
+	workqueue.ParallelizeUntil(ctx, len(zones), len(zones), func(piece int) {
 		migs[piece], errors[piece] = c.gceClient.FetchAllMigs(zones[piece])
 	})
 
@@ -490,7 +495,7 @@ func (c *cachingMigInfoProvider) fillMigInfoCache() error {
 	failedZoneCount := 0
 	for idx, err := range errors {
 		if err != nil {
-			klog.Errorf("Error listing migs from zone %v; err=%v", zones[idx], err)
+			logger.Error(err, "Error listing migs from zone", "zone", zones[idx])
 			failedZones[zones[idx]] = err
 			failedZoneCount++
 		}
@@ -519,7 +524,7 @@ func (c *cachingMigInfoProvider) fillMigInfoCache() error {
 					// At this point we assume its the default project but this could eventually lead to a cache miss
 					// if the project information is incorrect.
 					projectId = c.projectId
-					klog.Errorf("Unable to extract projectID from MIG self link: %s, err: %v", zoneMig.SelfLink, err)
+					logger.Error(err, "Unable to extract projectID from MIG self link", "selfLink", zoneMig.SelfLink)
 				}
 			}
 			zoneMigRef := GceRef{
@@ -529,7 +534,7 @@ func (c *cachingMigInfoProvider) fillMigInfoCache() error {
 			}
 
 			if registeredMigRefs[zoneMigRef] {
-				c.setMigInfoCache(zoneMigRef, zoneMig)
+				c.setMigInfoCache(ctx, zoneMigRef, zoneMig)
 			}
 		}
 	}
@@ -539,26 +544,27 @@ func (c *cachingMigInfoProvider) fillMigInfoCache() error {
 
 // RefreshMigInfo updates the cached information for a specific MIG without rebuilding the full zone cache
 func (c *cachingMigInfoProvider) RefreshMigInfo(migRef GceRef) error {
-	return c.fillSingleMigInfo(migRef)
+	return c.fillSingleMigInfo(context.TODO(), migRef)
 }
 
-func (c *cachingMigInfoProvider) fillSingleMigInfo(migRef GceRef) error {
-	igm, err := c.gceClient.FetchMig(migRef)
+func (c *cachingMigInfoProvider) fillSingleMigInfo(ctx context.Context, migRef GceRef) error {
+	igm, err := c.gceClient.FetchMig(ctx, migRef)
 	if err != nil {
 		c.migLister.HandleMigIssue(migRef, err)
 		return err
 	}
-	c.setMigInfoCache(migRef, igm)
+	c.setMigInfoCache(ctx, migRef, igm)
 	return nil
 }
 
-func (c *cachingMigInfoProvider) setMigInfoCache(migRef GceRef, mig *gce.InstanceGroupManager) {
+func (c *cachingMigInfoProvider) setMigInfoCache(ctx context.Context, migRef GceRef, mig *gce.InstanceGroupManager) {
+	logger := klog.FromContext(ctx)
 	c.cache.SetMigTargetSize(migRef, mig.TargetSize+mig.TargetSuspendedSize)
 	c.cache.SetMigBasename(migRef, mig.BaseInstanceName)
 	if mig.Status != nil {
 		c.cache.SetMigIsStable(migRef, mig.Status.IsStable)
 	} else {
-		klog.Warningf("MIG %v has nil status, assuming isStable=false", migRef)
+		logger.Info("MIG has nil status, assuming isStable=false", "mig", migRef)
 		c.cache.SetMigIsStable(migRef, false)
 	}
 	c.cache.SetListManagedInstancesResults(migRef, mig.ListManagedInstancesResults)
@@ -578,13 +584,13 @@ func (c *cachingMigInfoProvider) GetMigIsStable(migRef GceRef) (bool, error) {
 		return isStable, nil
 	}
 
-	err := c.fillMigInfoCache()
+	err := c.fillMigInfoCache(context.TODO())
 	isStable, found = c.cache.GetMigIsStable(migRef)
 	if err == nil && found {
 		return isStable, nil
 	}
 
-	err = c.fillSingleMigInfo(migRef)
+	err = c.fillSingleMigInfo(context.TODO(), migRef)
 	if err != nil {
 		return false, err
 	}
@@ -624,8 +630,8 @@ func (c *cachingMigInfoProvider) listAllZonesWithMigs() map[string]bool {
 	return zones
 }
 
-func (c *cachingMigInfoProvider) GetMigMachineType(migRef GceRef) (MachineType, error) {
-	template, err := c.GetMigInstanceTemplate(migRef)
+func (c *cachingMigInfoProvider) GetMigMachineType(ctx context.Context, migRef GceRef) (MachineType, error) {
+	template, err := c.GetMigInstanceTemplate(ctx, migRef)
 	if err != nil {
 		return MachineType{}, err
 	}
@@ -636,7 +642,7 @@ func (c *cachingMigInfoProvider) GetMigMachineType(migRef GceRef) (MachineType, 
 	zone := migRef.Zone
 	machine, found := c.cache.GetMachine(machineName, zone)
 	if !found {
-		rawMachine, err := c.gceClient.FetchMachineType(zone, machineName)
+		rawMachine, err := c.gceClient.FetchMachineType(ctx, zone, machineName)
 		if err != nil {
 			c.migLister.HandleMigIssue(migRef, err)
 			return MachineType{}, err
@@ -660,13 +666,13 @@ func (c *cachingMigInfoProvider) GetListManagedInstancesResults(migRef GceRef) (
 		return listManagedInstancesResults, nil
 	}
 
-	err := c.fillMigInfoCache()
+	err := c.fillMigInfoCache(context.TODO())
 	listManagedInstancesResults, found = c.cache.GetListManagedInstancesResults(migRef)
 	if err == nil && found {
 		return listManagedInstancesResults, nil
 	}
 
-	err = c.fillSingleMigInfo(migRef)
+	err = c.fillSingleMigInfo(context.TODO(), migRef)
 	if err != nil {
 		return "", err
 	}

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -119,7 +120,7 @@ type mockAutoscalingGceClient struct {
 	fetchListManagedInstancesResults func(GceRef) (string, error)
 }
 
-func (client *mockAutoscalingGceClient) FetchMachineType(zone, machineName string) (*gce.MachineType, error) {
+func (client *mockAutoscalingGceClient) FetchMachineType(ctx context.Context, zone, machineName string) (*gce.MachineType, error) {
 	return client.fetchMachineType(zone, machineName)
 }
 
@@ -131,43 +132,43 @@ func (client *mockAutoscalingGceClient) FetchAllMigs(zone string) ([]*gce.Instan
 	return client.fetchMigs(zone)
 }
 
-func (client *mockAutoscalingGceClient) FetchAllInstances(project, zone string, filter string) ([]GceInstance, error) {
+func (client *mockAutoscalingGceClient) FetchAllInstances(ctx context.Context, project, zone string, filter string) ([]GceInstance, error) {
 	return client.fetchAllInstances(project, zone, filter)
 }
 
-func (client *mockAutoscalingGceClient) FetchMig(migRef GceRef) (*gce.InstanceGroupManager, error) {
+func (client *mockAutoscalingGceClient) FetchMig(ctx context.Context, migRef GceRef) (*gce.InstanceGroupManager, error) {
 	return client.fetchMig(migRef)
 }
 
-func (client *mockAutoscalingGceClient) FetchMigTargetSize(migRef GceRef) (int64, error) {
+func (client *mockAutoscalingGceClient) FetchMigTargetSize(ctx context.Context, migRef GceRef) (int64, error) {
 	return client.fetchMigTargetSize(migRef)
 }
 
-func (client *mockAutoscalingGceClient) FetchMigBasename(migRef GceRef) (string, error) {
+func (client *mockAutoscalingGceClient) FetchMigBasename(ctx context.Context, migRef GceRef) (string, error) {
 	return client.fetchMigBasename(migRef)
 }
 
-func (client *mockAutoscalingGceClient) FetchListManagedInstancesResults(migRef GceRef) (string, error) {
+func (client *mockAutoscalingGceClient) FetchListManagedInstancesResults(ctx context.Context, migRef GceRef) (string, error) {
 	return client.fetchListManagedInstancesResults(migRef)
 }
 
-func (client *mockAutoscalingGceClient) FetchMigInstances(migRef GceRef) ([]GceInstance, error) {
+func (client *mockAutoscalingGceClient) FetchMigInstances(ctx context.Context, migRef GceRef) ([]GceInstance, error) {
 	return client.fetchMigInstances(migRef)
 }
 
-func (client *mockAutoscalingGceClient) FetchMigTemplateName(migRef GceRef) (InstanceTemplateName, error) {
+func (client *mockAutoscalingGceClient) FetchMigTemplateName(ctx context.Context, migRef GceRef) (InstanceTemplateName, error) {
 	return client.fetchMigTemplateName(migRef)
 }
 
-func (client *mockAutoscalingGceClient) FetchMigTemplate(migRef GceRef, templateName string, regional bool) (*gce.InstanceTemplate, error) {
+func (client *mockAutoscalingGceClient) FetchMigTemplate(ctx context.Context, migRef GceRef, templateName string, regional bool) (*gce.InstanceTemplate, error) {
 	return client.fetchMigTemplate(migRef, templateName, regional)
 }
 
-func (client *mockAutoscalingGceClient) FetchMigsWithName(_ string, _ *regexp.Regexp) ([]string, error) {
+func (client *mockAutoscalingGceClient) FetchMigsWithName(ctx context.Context, _ string, _ *regexp.Regexp) ([]string, error) {
 	return nil, nil
 }
 
-func (client *mockAutoscalingGceClient) FetchZones(_ string) ([]string, error) {
+func (client *mockAutoscalingGceClient) FetchZones(ctx context.Context, _ string) ([]string, error) {
 	return nil, nil
 }
 
@@ -187,19 +188,19 @@ func (client *mockAutoscalingGceClient) FetchReservationsInProject(_ string) ([]
 	return nil, nil
 }
 
-func (client *mockAutoscalingGceClient) ResizeMig(_ GceRef, _ int64) error {
+func (client *mockAutoscalingGceClient) ResizeMig(ctx context.Context, _ GceRef, _ int64) error {
 	return nil
 }
 
-func (client *mockAutoscalingGceClient) DeleteInstances(_ GceRef, _ []GceRef) error {
+func (client *mockAutoscalingGceClient) DeleteInstances(ctx context.Context, _ GceRef, _ []GceRef) error {
 	return nil
 }
 
-func (client *mockAutoscalingGceClient) CreateInstances(_ GceRef, _ string, _ int64, _ []string) ([]string, error) {
+func (client *mockAutoscalingGceClient) CreateInstances(ctx context.Context, _ GceRef, _ string, _ int64, _ []string) ([]string, error) {
 	return nil, nil
 }
 
-func (client *mockAutoscalingGceClient) WaitForOperation(_, _, _, _ string) error {
+func (client *mockAutoscalingGceClient) WaitForOperation(ctx context.Context, _, _, _, _ string) error {
 	return nil
 }
 
@@ -263,14 +264,14 @@ func TestFillMigInstances(t *testing.T) {
 			assert.True(t, ok)
 			provider.timeProvider = &fakeTime{now: timeNow}
 
-			assert.NoError(t, provider.fillMigInstances(migRef))
+			assert.NoError(t, provider.fillMigInstances(context.Background(), migRef))
 			assert.Equal(t, tc.wantClientCalls, callCounter[migRef])
 
-			updateTime, updateTimeFound := tc.cache.GetMigInstancesUpdateTime(migRef)
+			updateTime, updateTimeFound := tc.cache.GetMigInstancesUpdateTime(context.Background(), migRef)
 			assert.True(t, updateTimeFound)
 			assert.Equal(t, tc.wantUpdateTime, updateTime)
 
-			instances, instancesFound := tc.cache.GetMigInstances(migRef)
+			instances, instancesFound := tc.cache.GetMigInstances(context.Background(), migRef)
 			assert.True(t, instancesFound)
 			assert.ElementsMatch(t, tc.wantInstances, instances)
 		})
@@ -386,10 +387,10 @@ func TestMigInfoProviderGetMigForInstance(t *testing.T) {
 			migLister := NewMigLister(tc.cache)
 			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, false)
 
-			mig, err := provider.GetMigForInstance(instanceRef)
+			mig, err := provider.GetMigForInstance(context.Background(), instanceRef)
 
-			cachedMigRef, cached := tc.cache.GetMigForInstance(instanceRef)
-			cachedMigUnknown := tc.cache.IsMigUnknownForInstance(instanceRef)
+			cachedMigRef, cached := tc.cache.GetMigForInstance(context.Background(), instanceRef)
+			cachedMigUnknown := tc.cache.IsMigUnknownForInstance(context.Background(), instanceRef)
 
 			assert.Equal(t, tc.expectedMig, mig)
 			assert.Equal(t, tc.expectedErr, err)
@@ -463,9 +464,9 @@ func TestGetMigInstances(t *testing.T) {
 			assert.True(t, ok)
 			provider.timeProvider = &fakeTime{now: newRefreshTime}
 
-			instances, err := provider.GetMigInstances(mig.GceRef())
-			cachedInstances, cached := tc.cache.GetMigInstances(mig.GceRef())
-			refreshTime, refreshed := tc.cache.GetMigInstancesUpdateTime(mig.GceRef())
+			instances, err := provider.GetMigInstances(context.Background(), mig.GceRef())
+			cachedInstances, cached := tc.cache.GetMigInstances(context.Background(), mig.GceRef())
+			refreshTime, refreshed := tc.cache.GetMigInstancesUpdateTime(context.Background(), mig.GceRef())
 
 			assert.Equal(t, tc.expectedInstances, instances)
 			assert.Equal(t, tc.expectedErr, err)
@@ -692,7 +693,7 @@ func TestRegenerateMigInstancesCache(t *testing.T) {
 			}
 			migLister := NewMigLister(tc.cache)
 			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, tc.projectId, 1, 0*time.Second, tc.bulkGceMigInstancesListingEnabled, false)
-			err := provider.RegenerateMigInstancesCache()
+			err := provider.RegenerateMigInstancesCache(context.Background())
 
 			assert.Equal(t, tc.expectedErr, err)
 			if tc.expectedErr == nil {
@@ -817,8 +818,8 @@ func TestGetMigTargetSize(t *testing.T) {
 			migLister := NewMigLister(tc.cache)
 			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, true)
 
-			targetSize, err := provider.GetMigTargetSize(tc.migQuery.GceRef())
-			cachedTargetSize, found := tc.cache.GetMigTargetSize(tc.migQuery.GceRef())
+			targetSize, err := provider.GetMigTargetSize(context.Background(), tc.migQuery.GceRef())
+			cachedTargetSize, found := tc.cache.GetMigTargetSize(context.Background(), tc.migQuery.GceRef())
 
 			assert.Equal(t, tc.expectedErr, err)
 			assert.Equal(t, tc.expectedErr == nil, found)
@@ -876,7 +877,7 @@ func TestGetMigTargetSize_Optimization(t *testing.T) {
 			migLister := NewMigLister(tc.cache)
 			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, true)
 
-			size, err := provider.GetMigTargetSize(mig.GceRef())
+			size, err := provider.GetMigTargetSize(context.Background(), mig.GceRef())
 			assert.NoError(t, err)
 			assert.Equal(t, targetSize, size)
 			assert.Equal(t, tc.shouldCallFetchAllMigs, fetchAllMigsCalled, "FetchAllMigs call status mismatch")
@@ -928,7 +929,7 @@ func TestRefreshMigInfo(t *testing.T) {
 			err := provider.RefreshMigInfo(tc.migQuery.GceRef())
 			assert.Equal(t, tc.expectedErr, err)
 
-			cachedTargetSize, found := tc.cache.GetMigTargetSize(tc.migQuery.GceRef())
+			cachedTargetSize, found := tc.cache.GetMigTargetSize(context.Background(), tc.migQuery.GceRef())
 			assert.Equal(t, tc.expectedErr == nil, found)
 			if tc.expectedErr == nil {
 				assert.Equal(t, tc.expectedTargetSize, cachedTargetSize)
@@ -1007,7 +1008,7 @@ func TestGetMigBasename(t *testing.T) {
 			migLister := NewMigLister(tc.cache)
 			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, false)
 
-			basename, err := provider.GetMigBasename(mig.GceRef())
+			basename, err := provider.GetMigBasename(context.Background(), mig.GceRef())
 			cachedBasename, found := tc.cache.GetMigBasename(mig.GceRef())
 
 			assert.Equal(t, tc.expectedErr, err)
@@ -1181,8 +1182,8 @@ func TestGetMigInstanceTemplateName(t *testing.T) {
 			migLister := NewMigLister(tc.cache)
 			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, false)
 
-			instanceTemplateName, err := provider.GetMigInstanceTemplateName(mig.GceRef())
-			cachedInstanceTemplateName, found := tc.cache.GetMigInstanceTemplateName(mig.GceRef())
+			instanceTemplateName, err := provider.GetMigInstanceTemplateName(context.Background(), mig.GceRef())
+			cachedInstanceTemplateName, found := tc.cache.GetMigInstanceTemplateName(context.Background(), mig.GceRef())
 
 			assert.Equal(t, tc.expectedErr, err)
 			assert.Equal(t, tc.expectedErr == nil, found)
@@ -1280,8 +1281,8 @@ func TestGetMigInstanceTemplate(t *testing.T) {
 			migLister := NewMigLister(tc.cache)
 			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, false)
 
-			template, err := provider.GetMigInstanceTemplate(mig.GceRef())
-			cachedTemplate, found := tc.cache.GetMigInstanceTemplate(mig.GceRef())
+			template, err := provider.GetMigInstanceTemplate(context.Background(), mig.GceRef())
+			cachedTemplate, found := tc.cache.GetMigInstanceTemplate(context.Background(), mig.GceRef())
 
 			assert.Equal(t, tc.expectedErr, err)
 			if tc.expectedErr == nil {
@@ -1474,8 +1475,8 @@ func TestGetMigInstanceKubeEnv(t *testing.T) {
 			migLister := NewMigLister(tc.cache)
 			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, false)
 
-			kubeEnv, err := provider.GetMigKubeEnv(mig.GceRef())
-			cachedKubeEnv, found := tc.cache.GetMigKubeEnv(mig.GceRef())
+			kubeEnv, err := provider.GetMigKubeEnv(context.Background(), mig.GceRef())
+			cachedKubeEnv, found := tc.cache.GetMigKubeEnv(context.Background(), mig.GceRef())
 
 			assert.Equal(t, tc.expectedErr, err)
 			if tc.expectedErr == nil {
@@ -1567,7 +1568,7 @@ func TestGetMigMachineType(t *testing.T) {
 			}
 			migLister := NewMigLister(cache)
 			provider := NewCachingMigInfoProvider(cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, false)
-			machine, err := provider.GetMigMachineType(mig.GceRef())
+			machine, err := provider.GetMigMachineType(context.Background(), mig.GceRef())
 			if tc.expectError {
 				assert.Error(t, err)
 			} else {
@@ -1633,10 +1634,10 @@ func TestMultipleFillMigInstancesCallsLimited(t *testing.T) {
 				timeProvider:                   ft,
 			}
 			ft.now = tc.firstCallTime
-			err := provider.fillMigInstances(mig.GceRef())
+			err := provider.fillMigInstances(context.Background(), mig.GceRef())
 			assert.NoError(t, err)
 			ft.now = tc.secondCallTime
-			err = provider.fillMigInstances(mig.GceRef())
+			err = provider.fillMigInstances(context.Background(), mig.GceRef())
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedCallsToFetchMigInstances, callCounter[mig.GceRef()])
 		})
@@ -1690,7 +1691,7 @@ func TestListInstancesInAllZonesWithMigs(t *testing.T) {
 				gceClient:              client,
 				concurrentGceRefreshes: 1,
 			}
-			instances, err := provider.listInstancesInAllZonesWithMigs()
+			instances, err := provider.listInstancesInAllZonesWithMigs(context.Background())
 
 			if tc.wantErr {
 				assert.NotNil(t, err)
@@ -1925,10 +1926,10 @@ func TestUpdateMigInstancesCache(t *testing.T) {
 				gceClient:    client,
 				timeProvider: &realTime{},
 			}
-			err := provider.updateMigInstancesCache(tc.migToInstances)
+			err := provider.updateMigInstancesCache(context.Background(), tc.migToInstances)
 			assert.NoError(t, err)
 			for migRef, want := range tc.wantInstances {
-				instances, found := cache.GetMigInstances(migRef)
+				instances, found := cache.GetMigInstances(context.Background(), migRef)
 				assert.True(t, found)
 				assert.Equal(t, want, instances)
 			}

--- a/cluster-autoscaler/cloudprovider/gce/os_reserved.go
+++ b/cluster-autoscaler/cloudprovider/gce/os_reserved.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package gce
 
+import "context"
+
 // MigOsInfo store os parameters.
 type MigOsInfo interface {
 	// Os return operating system.
@@ -30,9 +32,9 @@ type MigOsInfo interface {
 type OsReservedCalculator interface {
 	// CalculateKernelReserved computes how much memory OS kernel will reserve.
 	// NodeVersion parameter is optional. If empty string is passed a result calculated using default node version will be returned.
-	CalculateKernelReserved(m MigOsInfo, physicalMemory int64) int64
+	CalculateKernelReserved(ctx context.Context, m MigOsInfo, physicalMemory int64) int64
 
 	// CalculateOSReservedEphemeralStorage estimates how much ephemeral storage OS will reserve and eviction threshold.
 	// NodeVersion parameter is optional. If empty string is passed a result calculated using default node version will be returned.
-	CalculateOSReservedEphemeralStorage(m MigOsInfo, diskSize int64) int64
+	CalculateOSReservedEphemeralStorage(ctx context.Context, m MigOsInfo, diskSize int64) int64
 }

--- a/cluster-autoscaler/cloudprovider/gce/templates.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -66,7 +67,7 @@ func (t *GceTemplateBuilder) getAcceleratorCount(accelerators []*gce.Accelerator
 }
 
 // BuildCapacity builds a list of resource capacities given list of hardware.
-func (t *GceTemplateBuilder) BuildCapacity(m MigOsInfo, cpu int64, mem int64, accelerators []*gce.AcceleratorConfig,
+func (t *GceTemplateBuilder) BuildCapacity(ctx context.Context, m MigOsInfo, cpu int64, mem int64, accelerators []*gce.AcceleratorConfig,
 	ephemeralStorage int64, ephemeralStorageLocalSSDCount int64, pods *int64, r OsReservedCalculator, extendedResources apiv1.ResourceList) (apiv1.ResourceList, error) {
 	capacity := apiv1.ResourceList{}
 	if pods == nil {
@@ -76,7 +77,7 @@ func (t *GceTemplateBuilder) BuildCapacity(m MigOsInfo, cpu int64, mem int64, ac
 	}
 
 	capacity[apiv1.ResourceCPU] = *resource.NewQuantity(cpu, resource.DecimalSI)
-	memTotal := mem - r.CalculateKernelReserved(m, mem)
+	memTotal := mem - r.CalculateKernelReserved(ctx, m, mem)
 	capacity[apiv1.ResourceMemory] = *resource.NewQuantity(memTotal, resource.DecimalSI)
 
 	if accelerators != nil && len(accelerators) > 0 {
@@ -86,9 +87,9 @@ func (t *GceTemplateBuilder) BuildCapacity(m MigOsInfo, cpu int64, mem int64, ac
 	if ephemeralStorage > 0 {
 		var storageTotal int64
 		if ephemeralStorageLocalSSDCount > 0 {
-			storageTotal = ephemeralStorage - EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(ephemeralStorageLocalSSDCount, m.OsDistribution())
+			storageTotal = ephemeralStorage - EphemeralStorageOnLocalSSDFilesystemOverheadInBytes(ctx, ephemeralStorageLocalSSDCount, m.OsDistribution())
 		} else {
-			storageTotal = ephemeralStorage - r.CalculateOSReservedEphemeralStorage(m, ephemeralStorage)
+			storageTotal = ephemeralStorage - r.CalculateOSReservedEphemeralStorage(ctx, m, ephemeralStorage)
 		}
 		capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(int64(math.Max(float64(storageTotal), 0)), resource.DecimalSI)
 	}
@@ -102,12 +103,12 @@ func (t *GceTemplateBuilder) BuildCapacity(m MigOsInfo, cpu int64, mem int64, ac
 
 // BuildAllocatableFromKubeEnv builds node allocatable based on capacity of the node and
 // value of kubeEnv.
-func (t *GceTemplateBuilder) BuildAllocatableFromKubeEnv(capacity apiv1.ResourceList, kubeEnv KubeEnv, evictionHard *EvictionHard) (apiv1.ResourceList, error) {
-	kubeReserved, err := extractKubeReservedFromKubeEnv(kubeEnv)
+func (t *GceTemplateBuilder) BuildAllocatableFromKubeEnv(ctx context.Context, capacity apiv1.ResourceList, kubeEnv KubeEnv, evictionHard *EvictionHard) (apiv1.ResourceList, error) {
+	kubeReserved, err := extractKubeReservedFromKubeEnv(ctx, kubeEnv)
 	if err != nil {
 		return nil, err
 	}
-	reserved, err := parseKubeReserved(kubeReserved)
+	reserved, err := parseKubeReserved(ctx, kubeReserved)
 	if err != nil {
 		return nil, err
 	}
@@ -135,28 +136,30 @@ func (t *GceTemplateBuilder) CalculateAllocatable(capacity apiv1.ResourceList, k
 }
 
 // MigOsInfo return os detailes information that stored in template.
-func (t *GceTemplateBuilder) MigOsInfo(migId string, kubeEnv KubeEnv) (MigOsInfo, error) {
-	os := extractOperatingSystemFromKubeEnv(kubeEnv)
+func (t *GceTemplateBuilder) MigOsInfo(ctx context.Context, migId string, kubeEnv KubeEnv) (MigOsInfo, error) {
+	logger := klog.FromContext(ctx)
+	os := extractOperatingSystemFromKubeEnv(ctx, kubeEnv)
 	if os == OperatingSystemUnknown {
 		return nil, fmt.Errorf("could not obtain os from kube-env from template metadata")
 	}
 
-	osDistribution := extractOperatingSystemDistributionFromKubeEnv(kubeEnv)
+	osDistribution := extractOperatingSystemDistributionFromKubeEnv(ctx, kubeEnv)
 	if osDistribution == OperatingSystemDistributionUnknown {
 		osDistribution = OperatingSystemDistributionDefault
-		klog.V(5).Infof("could not obtain os-distribution from kube-env from template metadata, falling back to %q", osDistribution)
+		logger.V(5).Info("Could not obtain os-distribution from kube-env from template metadata, falling back", "osDistribution", osDistribution)
 	}
 
-	arch, err := extractSystemArchitectureFromKubeEnv(kubeEnv)
+	arch, err := extractSystemArchitectureFromKubeEnv(ctx, kubeEnv)
 	if err != nil {
 		arch = DefaultArch
-		klog.V(5).Infof("Couldn't extract architecture from kube-env for MIG %q, falling back to %q. Error: %v", migId, arch, err)
+		logger.V(5).Info("Couldn't extract architecture from kube-env for MIG. Falling back.", "migId", migId, "fallbackArch", arch, "err", err)
 	}
 	return NewMigOsInfo(os, osDistribution, arch), nil
 }
 
 // BuildNodeFromTemplate builds node from provided GCE template.
-func (t *GceTemplateBuilder) BuildNodeFromTemplate(mig Mig, migOsInfo MigOsInfo, template *gce.InstanceTemplate, kubeEnv KubeEnv, cpu int64, mem int64, pods *int64, reserved OsReservedCalculator, localSSDSizeProvider localssdsize.LocalSSDSizeProvider) (*apiv1.Node, error) {
+func (t *GceTemplateBuilder) BuildNodeFromTemplate(ctx context.Context, mig Mig, migOsInfo MigOsInfo, template *gce.InstanceTemplate, kubeEnv KubeEnv, cpu int64, mem int64, pods *int64, reserved OsReservedCalculator, localSSDSizeProvider localssdsize.LocalSSDSizeProvider) (*apiv1.Node, error) {
+	logger := klog.FromContext(ctx)
 
 	if template.Properties == nil {
 		return nil, fmt.Errorf("instance template %s has no properties", template.Name)
@@ -174,7 +177,7 @@ func (t *GceTemplateBuilder) BuildNodeFromTemplate(mig Mig, migOsInfo MigOsInfo,
 	addBootDiskAnnotations(&node, template.Properties)
 	var ephemeralStorage int64 = -1
 	var err error
-	if !isBootDiskEphemeralStorageWithInstanceTemplateDisabled(kubeEnv) {
+	if !isBootDiskEphemeralStorageWithInstanceTemplateDisabled(ctx, kubeEnv) {
 		// ephemeral storage is backed up by boot disk
 		ephemeralStorage, err = getBootDiskEphemeralStorageFromInstanceTemplateProperties(template.Properties)
 	} else {
@@ -186,7 +189,7 @@ func (t *GceTemplateBuilder) BuildNodeFromTemplate(mig Mig, migOsInfo MigOsInfo,
 	if localSsdCount > 0 {
 		addAnnotation(&node, LocalSsdCountAnnotation, strconv.FormatInt(localSsdCount, 10))
 	}
-	ephemeralStorageLocalSsdCount := ephemeralStorageLocalSSDCount(kubeEnv)
+	ephemeralStorageLocalSsdCount := ephemeralStorageLocalSSDCount(ctx, kubeEnv)
 	if err == nil && ephemeralStorageLocalSsdCount > 0 {
 		localSSDDiskSize := localSSDSizeProvider.SSDSizeInGiB(template.Properties.MachineType)
 		ephemeralStorage, err = getEphemeralStorageOnLocalSsd(localSsdCount, ephemeralStorageLocalSsdCount, int64(localSSDDiskSize))
@@ -195,13 +198,14 @@ func (t *GceTemplateBuilder) BuildNodeFromTemplate(mig Mig, migOsInfo MigOsInfo,
 		return nil, fmt.Errorf("could not fetch ephemeral storage from instance template: %v", err)
 	}
 
-	extendedResources, err := extractExtendedResourcesFromKubeEnv(kubeEnv)
+	extendedResources, err := extractExtendedResourcesFromKubeEnv(ctx, kubeEnv)
 	if err != nil {
-		// External Resources are optional and should not break the template creation
-		klog.Errorf("could not fetch extended resources from instance template: %v", err)
+		logger.
+			// External Resources are optional and should not break the template creation
+			Error(err, "Could not fetch extended resources from instance template")
 	}
 
-	capacity, err := t.BuildCapacity(migOsInfo, cpu, mem, template.Properties.GuestAccelerators, ephemeralStorage, ephemeralStorageLocalSsdCount, pods, reserved, extendedResources)
+	capacity, err := t.BuildCapacity(ctx, migOsInfo, cpu, mem, template.Properties.GuestAccelerators, ephemeralStorage, ephemeralStorageLocalSsdCount, pods, reserved, extendedResources)
 	if err != nil {
 		return nil, err
 	}
@@ -213,33 +217,33 @@ func (t *GceTemplateBuilder) BuildNodeFromTemplate(mig Mig, migOsInfo MigOsInfo,
 
 	if kubeEnv.env != nil {
 		// Extract labels
-		kubeEnvLabels, err := extractLabelsFromKubeEnv(kubeEnv)
+		kubeEnvLabels, err := extractLabelsFromKubeEnv(ctx, kubeEnv)
 		if err != nil {
 			return nil, err
 		}
 		node.Labels = cloudprovider.JoinStringMaps(node.Labels, kubeEnvLabels)
 
 		// Extract taints
-		kubeEnvTaints, err := extractTaintsFromKubeEnv(kubeEnv)
+		kubeEnvTaints, err := extractTaintsFromKubeEnv(ctx, kubeEnv)
 		if err != nil {
 			return nil, err
 		}
 		node.Spec.Taints = append(node.Spec.Taints, kubeEnvTaints...)
 
 		// Extract Eviction Hard
-		evictionHardFromKubeEnv, err := extractEvictionHardFromKubeEnv(kubeEnv)
+		evictionHardFromKubeEnv, err := extractEvictionHardFromKubeEnv(ctx, kubeEnv)
 		if err != nil || len(evictionHardFromKubeEnv) == 0 {
-			klog.Warning("unable to get evictionHardFromKubeEnv values, continuing without it.")
+			logger.Info("Unable to get evictionHardFromKubeEnv values, continuing without it.")
 		}
-		evictionHard := ParseEvictionHardOrGetDefault(evictionHardFromKubeEnv)
+		evictionHard := ParseEvictionHardOrGetDefault(ctx, evictionHardFromKubeEnv)
 
-		if allocatable, err := t.BuildAllocatableFromKubeEnv(node.Status.Capacity, kubeEnv, evictionHard); err == nil {
+		if allocatable, err := t.BuildAllocatableFromKubeEnv(ctx, node.Status.Capacity, kubeEnv, evictionHard); err == nil {
 			nodeAllocatable = allocatable
 		}
 	}
 
 	if nodeAllocatable == nil {
-		klog.Warningf("could not extract kube-reserved from kubeEnv for mig %q, setting allocatable to capacity.", mig.GceRef().Name)
+		logger.Info("Could not extract kube-reserved from kubeEnv for mig. Setting allocable capacity.", "mig", mig.GceRef())
 		node.Status.Allocatable = node.Status.Capacity
 	} else {
 		node.Status.Allocatable = nodeAllocatable
@@ -256,10 +260,11 @@ func (t *GceTemplateBuilder) BuildNodeFromTemplate(mig Mig, migOsInfo MigOsInfo,
 	return &node, nil
 }
 
-func ephemeralStorageLocalSSDCount(kubeEnv KubeEnv) int64 {
-	v, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "ephemeral_storage_local_ssd_count")
+func ephemeralStorageLocalSSDCount(ctx context.Context, kubeEnv KubeEnv) int64 {
+	logger := klog.FromContext(ctx)
+	v, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "ephemeral_storage_local_ssd_count")
 	if err != nil {
-		klog.Warningf("cannot extract ephemeral_storage_local_ssd_count from kube-env, default to 0: %v", err)
+		logger.Info("Cannot extract ephemeral_storage_local_ssd_count from kube-env, default to 0", "err", err)
 		return 0
 	}
 
@@ -269,7 +274,7 @@ func ephemeralStorageLocalSSDCount(kubeEnv KubeEnv) int64 {
 
 	n, err := strconv.Atoi(v)
 	if err != nil {
-		klog.Warningf("cannot parse ephemeral_storage_local_ssd_count value, default to 0: %v", err)
+		logger.Info("Cannot parse ephemeral_storage_local_ssd_count value, default to 0", "err", err)
 		return 0
 	}
 
@@ -301,8 +306,8 @@ func getEphemeralStorageOnLocalSsd(localSsdCount, ephemeralStorageLocalSsdCount,
 // isBootDiskEphemeralStorageWithInstanceTemplateDisabled will allow bypassing Disk Size of Boot Disk from being
 // picked up from Instance Template and used as Ephemeral Storage, in case other type of storage are used
 // as ephemeral storage
-func isBootDiskEphemeralStorageWithInstanceTemplateDisabled(kubeEnv KubeEnv) bool {
-	v, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "BLOCK_EPH_STORAGE_BOOT_DISK")
+func isBootDiskEphemeralStorageWithInstanceTemplateDisabled(ctx context.Context, kubeEnv KubeEnv) bool {
+	v, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "BLOCK_EPH_STORAGE_BOOT_DISK")
 	if err == nil && found && v == "true" {
 		return true
 	}
@@ -350,7 +355,8 @@ func BuildGenericLabels(ref GceRef, machineType string, nodeName string, os Oper
 	return result, nil
 }
 
-func parseKubeReserved(kubeReserved string) (apiv1.ResourceList, error) {
+func parseKubeReserved(ctx context.Context, kubeReserved string) (apiv1.ResourceList, error) {
+	logger := klog.FromContext(ctx)
 	resourcesMap, err := parseKeyValueListToMap(kubeReserved)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract kube-reserved from kube-env: %q", err)
@@ -363,7 +369,7 @@ func parseKubeReserved(kubeReserved string) (apiv1.ResourceList, error) {
 				reservedResources[apiv1.ResourceName(name)] = q
 			}
 		default:
-			klog.Warningf("ignoring resource from kube-reserved: %q", name)
+			logger.Info("Ignoring resource from kube-reserved", "resourceName", name)
 		}
 	}
 	return reservedResources, nil
@@ -371,16 +377,17 @@ func parseKubeReserved(kubeReserved string) (apiv1.ResourceList, error) {
 
 // GetLabelsFromKubeEnv returns labels from kube-env
 func GetLabelsFromKubeEnv(kubeEnv KubeEnv) (map[string]string, error) {
-	return extractLabelsFromKubeEnv(kubeEnv)
+	return extractLabelsFromKubeEnv(context.TODO(), kubeEnv)
 }
 
-func extractLabelsFromKubeEnv(kubeEnv KubeEnv) (map[string]string, error) {
+func extractLabelsFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) (map[string]string, error) {
+	logger := klog.FromContext(ctx)
 	// In v1.10+, labels are only exposed for the autoscaler via AUTOSCALER_ENV_VARS
 	// see kubernetes/kubernetes#61119. We try AUTOSCALER_ENV_VARS first, then
 	// fall back to the old way.
-	labels, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "node_labels")
+	labels, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "node_labels")
 	if err != nil {
-		klog.Errorf("error while trying to extract node_labels from AUTOSCALER_ENV_VARS: %v", err)
+		logger.Error(err, "Error while trying to extract node_labels from AUTOSCALER_ENV_VARS")
 	}
 	if !found {
 		labels, _ = kubeEnv.Var("NODE_LABELS")
@@ -390,16 +397,17 @@ func extractLabelsFromKubeEnv(kubeEnv KubeEnv) (map[string]string, error) {
 
 // GetTaintsFromKubeEnv returns labels from kube-env
 func GetTaintsFromKubeEnv(kubeEnv KubeEnv) ([]apiv1.Taint, error) {
-	return extractTaintsFromKubeEnv(kubeEnv)
+	return extractTaintsFromKubeEnv(context.TODO(), kubeEnv)
 }
 
-func extractTaintsFromKubeEnv(kubeEnv KubeEnv) ([]apiv1.Taint, error) {
+func extractTaintsFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) ([]apiv1.Taint, error) {
+	logger := klog.FromContext(ctx)
 	// In v1.10+, taints are only exposed for the autoscaler via AUTOSCALER_ENV_VARS
 	// see kubernetes/kubernetes#61119. We try AUTOSCALER_ENV_VARS first, then
 	// fall back to the old way.
-	taints, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "node_taints")
+	taints, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "node_taints")
 	if err != nil {
-		klog.Errorf("error while trying to extract node_taints from AUTOSCALER_ENV_VARS: %v", err)
+		logger.Error(err, "Error while trying to extract node_taints from AUTOSCALER_ENV_VARS")
 	}
 	if !found {
 		taints, _ = kubeEnv.Var("NODE_TAINTS")
@@ -411,13 +419,14 @@ func extractTaintsFromKubeEnv(kubeEnv KubeEnv) ([]apiv1.Taint, error) {
 	return buildTaints(taintMap)
 }
 
-func extractKubeReservedFromKubeEnv(kubeEnv KubeEnv) (string, error) {
+func extractKubeReservedFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) (string, error) {
+	logger := klog.FromContext(ctx)
 	// In v1.10+, kube-reserved is only exposed for the autoscaler via AUTOSCALER_ENV_VARS
 	// see kubernetes/kubernetes#61119. We try AUTOSCALER_ENV_VARS first, then
 	// fall back to the old way.
-	kubeReserved, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "kube_reserved")
+	kubeReserved, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "kube_reserved")
 	if err != nil {
-		klog.Errorf("error while trying to extract kube_reserved from AUTOSCALER_ENV_VARS: %v", err)
+		logger.Error(err, "Error while trying to extract kube_reserved from AUTOSCALER_ENV_VARS")
 	}
 	if !found {
 		kubeletArgs, _ := kubeEnv.Var("KUBELET_TEST_ARGS")
@@ -432,10 +441,11 @@ func extractKubeReservedFromKubeEnv(kubeEnv KubeEnv) (string, error) {
 	return kubeReserved, nil
 }
 
-func extractExtendedResourcesFromKubeEnv(kubeEnv KubeEnv) (apiv1.ResourceList, error) {
-	extendedResourcesAsString, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "extended_resources")
+func extractExtendedResourcesFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) (apiv1.ResourceList, error) {
+	logger := klog.FromContext(ctx)
+	extendedResourcesAsString, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "extended_resources")
 	if err != nil {
-		klog.Warningf("error while obtaining extended_resources from AUTOSCALER_ENV_VARS; %v", err)
+		logger.Info("Error while obtaining extended_resources from AUTOSCALER_ENV_VARS", "err", err)
 		return nil, err
 	}
 	var extendedResourcesMap map[string]string
@@ -447,9 +457,9 @@ func extractExtendedResourcesFromKubeEnv(kubeEnv KubeEnv) (apiv1.ResourceList, e
 	} else {
 		extendedResourcesMap = make(map[string]string)
 	}
-	nodeLabelsAsString, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "node_labels")
+	nodeLabelsAsString, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "node_labels")
 	if err != nil {
-		klog.Warningf("error while obtaining node_labels from AUTOSCALER_ENV_VARS; %v", err)
+		logger.Info("Error while obtaining node_labels from AUTOSCALER_ENV_VARS", "err", err)
 		return nil, err
 	}
 	if found {
@@ -462,7 +472,7 @@ func extractExtendedResourcesFromKubeEnv(kubeEnv KubeEnv) (apiv1.ResourceList, e
 			if strings.HasPrefix(key, extendedResourcesKeyPrefix) {
 				key = strings.TrimPrefix(key, extendedResourcesKeyPrefix)
 				if _, existsBefore := extendedResourcesMap[key]; existsBefore {
-					klog.Warningf("extended resource %s defined twice in template", key)
+					logger.Info("Extended resource defined twice in template.", "resourceKey", key)
 				}
 				extendedResourcesMap[key] = value
 			}
@@ -478,7 +488,7 @@ func extractExtendedResourcesFromKubeEnv(kubeEnv KubeEnv) (apiv1.ResourceList, e
 		if q, err := resource.ParseQuantity(quantity); err == nil && q.Sign() >= 0 {
 			extendedResources[apiv1.ResourceName(name)] = q
 		} else if err != nil {
-			klog.Warningf("ignoring invalid value in extended_resources or node_labels defined in AUTOSCALER_ENV_VARS; %v", err)
+			logger.Info("Ignoring invalid value in extended_resources or node_labels defined in AUTOSCALER_ENV_VARS", "err", err)
 		}
 	}
 	return extendedResources, nil
@@ -499,15 +509,16 @@ const (
 	OperatingSystemDefault = OperatingSystemLinux
 )
 
-func extractOperatingSystemFromKubeEnv(kubeEnv KubeEnv) OperatingSystem {
-	osValue, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "os")
+func extractOperatingSystemFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) OperatingSystem {
+	logger := klog.FromContext(ctx)
+	osValue, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "os")
 	if err != nil {
-		klog.Errorf("error while obtaining os from AUTOSCALER_ENV_VARS; %v", err)
+		logger.Error(err, "error while obtaining os from AUTOSCALER_ENV_VARS")
 		return OperatingSystemUnknown
 	}
 
 	if !found {
-		klog.Warningf("no os defined in AUTOSCALER_ENV_VARS; using default %v", OperatingSystemDefault)
+		logger.Info("No os defined in AUTOSCALER_ENV_VARS; using default", "defaultOs", OperatingSystemDefault)
 		return OperatingSystemDefault
 	}
 
@@ -517,7 +528,7 @@ func extractOperatingSystemFromKubeEnv(kubeEnv KubeEnv) OperatingSystem {
 	case string(OperatingSystemWindows):
 		return OperatingSystemWindows
 	default:
-		klog.Errorf("unexpected os=%v passed via AUTOSCALER_ENV_VARS", osValue)
+		logger.Error(nil, "Unexpected os passed via AUTOSCALER_ENV_VARS", "os", osValue)
 		return OperatingSystemUnknown
 	}
 }
@@ -602,8 +613,8 @@ func (s SystemArchitecture) Name() string {
 	return string(s)
 }
 
-func extractSystemArchitectureFromKubeEnv(kubeEnv KubeEnv) (SystemArchitecture, error) {
-	archName, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "arch")
+func extractSystemArchitectureFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) (SystemArchitecture, error) {
+	archName, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "arch")
 	if err != nil {
 		return UnknownArch, fmt.Errorf("error while obtaining arch from AUTOSCALER_ENV_VARS: %v", err)
 	}
@@ -630,15 +641,16 @@ func ToSystemArchitecture(arch string) SystemArchitecture {
 	}
 }
 
-func extractOperatingSystemDistributionFromKubeEnv(kubeEnv KubeEnv) OperatingSystemDistribution {
-	osDistributionValue, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "os_distribution")
+func extractOperatingSystemDistributionFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) OperatingSystemDistribution {
+	logger := klog.FromContext(ctx)
+	osDistributionValue, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "os_distribution")
 	if err != nil {
-		klog.Errorf("error while obtaining os from AUTOSCALER_ENV_VARS; %v", err)
+		logger.Error(err, "Error while obtaining os from AUTOSCALER_ENV_VARS")
 		return OperatingSystemDistributionUnknown
 	}
 
 	if !found {
-		klog.Warningf("no os-distribution defined in AUTOSCALER_ENV_VARS; using default %v", OperatingSystemDistributionDefault)
+		logger.Info("No os-distribution defined in AUTOSCALER_ENV_VARS; using default", "defaultOsDistribution", OperatingSystemDistributionDefault)
 		return OperatingSystemDistributionDefault
 	}
 
@@ -654,19 +666,20 @@ func extractOperatingSystemDistributionFromKubeEnv(kubeEnv KubeEnv) OperatingSys
 		return OperatingSystemDistributionCOS
 	// Deprecated
 	case "cos_containerd":
-		klog.Warning("cos_containerd os distribution is deprecated")
+		logger.Info("cos_containerd os distribution is deprecated")
 		return OperatingSystemDistributionCOS
 	// Deprecated
 	case "ubuntu_containerd":
-		klog.Warning("ubuntu_containerd os distribution is deprecated")
+		logger.Info("ubuntu_containerd os distribution is deprecated")
 		return OperatingSystemDistributionUbuntu
 	default:
-		klog.Errorf("unexpected os-distribution=%v passed via AUTOSCALER_ENV_VARS", osDistributionValue)
+		logger.Error(nil, "Unexpected os-distribution", "osDistribution", osDistributionValue)
 		return OperatingSystemDistributionUnknown
 	}
 }
 
-func getFloat64Option(options map[string]string, templateName, name string) (float64, bool) {
+func getFloat64Option(ctx context.Context, options map[string]string, templateName, name string) (float64, bool) {
+	logger := klog.FromContext(ctx)
 	raw, ok := options[name]
 	if !ok {
 		return 0, false
@@ -674,14 +687,15 @@ func getFloat64Option(options map[string]string, templateName, name string) (flo
 
 	option, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
-		klog.Warningf("failed to convert autoscaling_options option %q (value %q) for MIG %q to float: %v", name, raw, templateName, err)
+		logger.Info("Failed to convert autoscaling_options option for MIG template to float", "optionName", name, "optionValue", raw, "templateName", templateName, "err", err)
 		return 0, false
 	}
 
 	return option, true
 }
 
-func getDurationOption(options map[string]string, templateName, name string) (time.Duration, bool) {
+func getDurationOption(ctx context.Context, options map[string]string, templateName, name string) (time.Duration, bool) {
+	logger := klog.FromContext(ctx)
 	raw, ok := options[name]
 	if !ok {
 		return 0, false
@@ -689,44 +703,47 @@ func getDurationOption(options map[string]string, templateName, name string) (ti
 
 	option, err := time.ParseDuration(raw)
 	if err != nil {
-		klog.Warningf("failed to convert autoscaling_options option %q (value %q) for MIG %q to duration: %v", name, raw, templateName, err)
+		logger.Info("Failed to convert autoscaling_options option for MIG template to duration", "optionName", name, "optionValue", raw, "templateName", templateName, "err", err)
 		return 0, false
 	}
 
 	return option, true
 }
 
-func extractAutoscalingOptionsFromKubeEnv(kubeEnv KubeEnv) (map[string]string, error) {
-	optionsAsString, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "autoscaling_options")
+func extractAutoscalingOptionsFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) (map[string]string, error) {
+	logger := klog.FromContext(ctx)
+	optionsAsString, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "autoscaling_options")
 	if err != nil {
-		klog.Warningf("error while obtaining autoscaling_options from AUTOSCALER_ENV_VARS: %v", err)
+		logger.Info("Error while obtaining autoscaling_options from AUTOSCALER_ENV_VARS", "err", err)
 		return nil, err
 	}
 
 	if !found {
-		klog.V(5).Info("no autoscaling_options defined in AUTOSCALER_ENV_VARS")
+		logger.V(5).Info("No autoscaling_options defined in AUTOSCALER_ENV_VARS")
 		return make(map[string]string), nil
 	}
 
 	return parseKeyValueListToMap(optionsAsString)
 }
 
-func extractEvictionHardFromKubeEnv(kubeEnv KubeEnv) (map[string]string, error) {
-	evictionHardAsString, found, err := extractAutoscalerVarFromKubeEnv(kubeEnv, "evictionHard")
+func extractEvictionHardFromKubeEnv(ctx context.Context, kubeEnv KubeEnv) (map[string]string, error) {
+	logger := klog.FromContext(ctx)
+	evictionHardAsString, found, err := extractAutoscalerVarFromKubeEnv(ctx, kubeEnv, "evictionHard")
 	if err != nil {
-		klog.Warningf("error while obtaining eviction-hard from AUTOSCALER_ENV_VARS; %v", err)
+		logger.Info("Error while obtaining eviction-hard from AUTOSCALER_ENV_VARS", "err", err)
 		return nil, err
 	}
 
 	if !found {
-		klog.Warning("no evictionHard defined in AUTOSCALER_ENV_VARS;")
+		logger.Info("No evictionHard defined in AUTOSCALER_ENV_VARS")
 		return make(map[string]string), nil
 	}
 
 	return parseKeyValueListToMap(evictionHardAsString)
 }
 
-func extractAutoscalerVarFromKubeEnv(kubeEnv KubeEnv, name string) (value string, found bool, err error) {
+func extractAutoscalerVarFromKubeEnv(ctx context.Context, kubeEnv KubeEnv, name string) (value string, found bool, err error) {
+	logger := klog.FromContext(ctx)
 	const autoscalerVars = "AUTOSCALER_ENV_VARS"
 	autoscalerVals, found := kubeEnv.Var(autoscalerVars)
 	if !found {
@@ -748,7 +765,7 @@ func extractAutoscalerVarFromKubeEnv(kubeEnv KubeEnv, name string) (value string
 			return strings.Trim(items[1], " \"'"), true, nil
 		}
 	}
-	klog.V(5).Infof("var %s not found in %s: %v", name, autoscalerVars, autoscalerVals)
+	logger.V(5).Info("Var not found in AUTOSCALER_ENV_VARS", "varName", name, "autoscalerVals", autoscalerVals)
 	return "", false, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/templates_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/templates_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -266,14 +267,14 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 			var migOsInfo MigOsInfo
 			kubeEnv, err := ExtractKubeEnv(template)
 			if err == nil {
-				migOsInfo, err = tb.MigOsInfo(mig.Id(), kubeEnv)
+				migOsInfo, err = tb.MigOsInfo(context.Background(), mig.Id(), kubeEnv)
 			}
 			if tc.expectedMigInfoErr {
 				assert.Error(t, err)
 				return
 			}
 			localSSDDiskSize := localssdsize.NewSimpleLocalSSDProvider()
-			node, err := tb.BuildNodeFromTemplate(mig, migOsInfo, template, kubeEnv, tc.physicalCpu, tc.physicalMemory, tc.pods, &GceReserved{}, localSSDDiskSize)
+			node, err := tb.BuildNodeFromTemplate(context.Background(), mig, migOsInfo, template, kubeEnv, tc.physicalCpu, tc.physicalMemory, tc.pods, &GceReserved{}, localSSDDiskSize)
 			if tc.expectedNodeTemplateErr {
 				assert.Error(t, err)
 			} else {
@@ -304,7 +305,7 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 					physicalEphemeralStorageGiB = 0
 				}
 				migOsInfo := NewMigOsInfo(OperatingSystemLinux, OperatingSystemDistributionCOS, "")
-				capacity, err := tb.BuildCapacity(migOsInfo, tc.physicalCpu, tc.physicalMemory, tc.accelerators, physicalEphemeralStorageGiB*units.GiB, tc.ephemeralStorageLocalSSDCount, tc.pods, &GceReserved{}, tc.extendedResources)
+				capacity, err := tb.BuildCapacity(context.Background(), migOsInfo, tc.physicalCpu, tc.physicalMemory, tc.accelerators, physicalEphemeralStorageGiB*units.GiB, tc.ephemeralStorageLocalSSDCount, tc.pods, &GceReserved{}, tc.extendedResources)
 				assert.NoError(t, err)
 				assertEqualResourceLists(t, "Capacity", capacity, node.Status.Capacity)
 				if !tc.kubeReserved {
@@ -312,7 +313,7 @@ func TestBuildNodeFromTemplateSetsResources(t *testing.T) {
 				} else {
 					reserved, err := makeResourceList(tc.reservedCpu, tc.reservedMemory, 0, tc.reservedEphemeralStorage)
 					assert.NoError(t, err)
-					allocatable := tb.CalculateAllocatable(capacity, reserved, ParseEvictionHardOrGetDefault(nil))
+					allocatable := tb.CalculateAllocatable(capacity, reserved, ParseEvictionHardOrGetDefault(context.Background(), nil))
 					assertEqualResourceLists(t, "Allocatable", allocatable, node.Status.Allocatable)
 				}
 			}
@@ -437,7 +438,7 @@ func TestCalculateAllocatable(t *testing.T) {
 			assert.NoError(t, err)
 			expectedAllocatable, err := makeResourceList(tc.allocatableCpu, tc.allocatableMemory, 0, tc.allocatableEphemeralStorage)
 			assert.NoError(t, err)
-			allocatable := tb.CalculateAllocatable(capacity, reserved, ParseEvictionHardOrGetDefault(nil))
+			allocatable := tb.CalculateAllocatable(capacity, reserved, ParseEvictionHardOrGetDefault(context.Background(), nil))
 			assertEqualResourceLists(t, "Allocatable", expectedAllocatable, allocatable)
 		})
 	}
@@ -485,7 +486,7 @@ func TestBuildAllocatableFromKubeEnv(t *testing.T) {
 		var allocatable apiv1.ResourceList
 		kubeEnv, err := ParseKubeEnv("test", tc.kubeEnvValue)
 		if err == nil {
-			allocatable, err = tb.BuildAllocatableFromKubeEnv(capacity, kubeEnv, ParseEvictionHardOrGetDefault(nil))
+			allocatable, err = tb.BuildAllocatableFromKubeEnv(context.Background(), capacity, kubeEnv, ParseEvictionHardOrGetDefault(context.Background(), nil))
 		}
 		if tc.expectedErr {
 			assert.Error(t, err)
@@ -540,7 +541,7 @@ func TestParseEvictionHard(t *testing.T) {
 			MemoryEvictionHardTag:           tc.memory,
 			EphemeralStorageEvictionHardTag: tc.ephemeralStorage,
 		}
-		actualOutput := ParseEvictionHardOrGetDefault(test)
+		actualOutput := ParseEvictionHardOrGetDefault(context.Background(), test)
 		assert.EqualValues(t, tc.memoryExpected, actualOutput.MemoryEvictionQuantity, "TestParseEviction Failed Memory. %v expected does not match %v actual.", tc.memoryExpected, actualOutput.MemoryEvictionQuantity)
 		assert.EqualValues(t, tc.ephemeralStorageRatioExpected, actualOutput.EphemeralStorageEvictionRatio, "TestParseEviction Failed Ephemeral Storage. %v expected does not match %v actual.", tc.memoryExpected, actualOutput.EphemeralStorageEvictionRatio)
 	}
@@ -616,7 +617,7 @@ func TestBuildCapacityMemory(t *testing.T) {
 			tb := GceTemplateBuilder{}
 			noAccelerators := make([]*gce.AcceleratorConfig, 0)
 			migOsInfo := NewMigOsInfo(tc.os, OperatingSystemDistributionCOS, "")
-			buildCapacity, err := tb.BuildCapacity(migOsInfo, tc.physicalCpu, tc.physicalMemory, noAccelerators, -1, 0, nil, &GceReserved{}, apiv1.ResourceList{})
+			buildCapacity, err := tb.BuildCapacity(context.Background(), migOsInfo, tc.physicalCpu, tc.physicalMemory, noAccelerators, -1, 0, nil, &GceReserved{}, apiv1.ResourceList{})
 			assert.NoError(t, err)
 			expectedCapacity, err := makeResourceList2(tc.physicalCpu, tc.expectedCapacityMemory, 0, 110)
 			assert.NoError(t, err)
@@ -675,7 +676,7 @@ func TestExtractAutoscalingOptionsFromKubeEnv(t *testing.T) {
 			var value map[string]string
 			kubeEnv, err := ParseKubeEnv("test", c.kubeEnvValue)
 			if err == nil {
-				value, err = extractAutoscalingOptionsFromKubeEnv(kubeEnv)
+				value, err = extractAutoscalingOptionsFromKubeEnv(context.Background(), kubeEnv)
 			}
 			assert.Equal(t, c.expectedValue, value)
 			if c.expectedErr {
@@ -743,7 +744,7 @@ func TestExtractAutoscalerVarFromKubeEnv(t *testing.T) {
 			var found bool
 			kubeEnv, err := ParseKubeEnv("test", c.kubeEnvValue)
 			if err == nil {
-				value, found, err = extractAutoscalerVarFromKubeEnv(kubeEnv, c.name)
+				value, found, err = extractAutoscalerVarFromKubeEnv(context.Background(), kubeEnv, c.name)
 			}
 			assert.Equal(t, c.expectedValue, value)
 			assert.Equal(t, c.expectedFound, found)
@@ -798,7 +799,7 @@ func TestExtractLabelsFromKubeEnv(t *testing.T) {
 			var labels map[string]string
 			kubeEnv, err := ParseKubeEnv("test", c.kubeEnvValue)
 			if err == nil {
-				labels, err = extractLabelsFromKubeEnv(kubeEnv)
+				labels, err = extractLabelsFromKubeEnv(context.Background(), kubeEnv)
 			}
 			assert.Equal(t, c.err, err)
 			if c.err != nil {
@@ -895,7 +896,7 @@ func TestExtractTaintsFromKubeEnv(t *testing.T) {
 			var taints []apiv1.Taint
 			kubeEnv, err := ParseKubeEnv("test", c.kubeEnvValue)
 			if err == nil {
-				taints, err = extractTaintsFromKubeEnv(kubeEnv)
+				taints, err = extractTaintsFromKubeEnv(context.Background(), kubeEnv)
 			}
 			assert.Equal(t, c.err, err)
 			if c.err != nil {
@@ -993,7 +994,7 @@ func TestExtractKubeReservedFromKubeEnv(t *testing.T) {
 		var reserved string
 		kubeEnv, err := ParseKubeEnv("test", tc.kubeEnvValue)
 		if err == nil {
-			reserved, err = extractKubeReservedFromKubeEnv(kubeEnv)
+			reserved, err = extractKubeReservedFromKubeEnv(context.Background(), kubeEnv)
 		}
 		assert.Equal(t, tc.expectedReserved, reserved)
 		if tc.expectedErr {
@@ -1081,7 +1082,7 @@ func TestExtractOperatingSystemFromKubeEnv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			kubeEnv, err := ParseKubeEnv("test", tc.kubeEnvValue)
 			assert.NoError(t, err)
-			actualOperatingSystem := extractOperatingSystemFromKubeEnv(kubeEnv)
+			actualOperatingSystem := extractOperatingSystemFromKubeEnv(context.Background(), kubeEnv)
 			assert.Equal(t, tc.expectedOperatingSystem, actualOperatingSystem)
 		})
 	}
@@ -1208,7 +1209,7 @@ func TestExtractOperatingSystemDistributionFromKubeEnv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			kubeEnv, err := ParseKubeEnv("test", tc.kubeEnvValue)
 			assert.NoError(t, err)
-			actualOperatingSystem := extractOperatingSystemDistributionFromKubeEnv(kubeEnv)
+			actualOperatingSystem := extractOperatingSystemDistributionFromKubeEnv(context.Background(), kubeEnv)
 			assert.Equal(t, tc.expectedOperatingSystemDistribution, actualOperatingSystem)
 		})
 	}
@@ -1323,7 +1324,7 @@ func TestExtractExtendedResourcesFromKubeEnv(t *testing.T) {
 			var extendedResources apiv1.ResourceList
 			kubeEnv, err := ParseKubeEnv("test", tc.kubeEnvValue)
 			if err == nil {
-				extendedResources, err = extractExtendedResourcesFromKubeEnv(kubeEnv)
+				extendedResources, err = extractExtendedResourcesFromKubeEnv(context.Background(), kubeEnv)
 			}
 			assertEqualResourceLists(t, "Resources", tc.expectedExtendedResources, extendedResources)
 			if tc.expectedErr {
@@ -1361,7 +1362,7 @@ func TestParseKubeReserved(t *testing.T) {
 		expectedErr: true,
 	}}
 	for _, tc := range testCases {
-		resources, err := parseKubeReserved(tc.reserved)
+		resources, err := parseKubeReserved(context.Background(), tc.reserved)
 		if tc.expectedErr {
 			assert.Error(t, err)
 			assert.Nil(t, resources)
@@ -1433,7 +1434,7 @@ func TestExtractSystemArchitectureFromKubeEnv(t *testing.T) {
 			var gotArch SystemArchitecture
 			kubeEnv, gotErr := ParseKubeEnv("test", tc.kubeEnvValue)
 			if gotErr == nil {
-				gotArch, gotErr = extractSystemArchitectureFromKubeEnv(kubeEnv)
+				gotArch, gotErr = extractSystemArchitectureFromKubeEnv(context.Background(), kubeEnv)
 			}
 			if diff := cmp.Diff(tc.wantArch, gotArch); diff != "" {
 				t.Errorf("extractSystemArchitectureFromKubeEnv diff (-want +got):\n%s", diff)
@@ -1475,12 +1476,12 @@ func TestBuildNodeFromTemplateArch(t *testing.T) {
 			if gotErr != nil {
 				t.Fatalf("ExtractKubeEnv unexpected error: %v", gotErr)
 			}
-			migOsInfo, gotErr := tb.MigOsInfo(mig.Id(), kubeEnv)
+			migOsInfo, gotErr := tb.MigOsInfo(context.Background(), mig.Id(), kubeEnv)
 			if gotErr != nil {
 				t.Fatalf("MigOsInfo unexpected error: %v", gotErr)
 			}
 			localSSDDiskSize := localssdsize.NewSimpleLocalSSDProvider()
-			gotNode, gotErr := tb.BuildNodeFromTemplate(mig, migOsInfo, template, kubeEnv, 16, 128, nil, &GceReserved{}, localSSDDiskSize)
+			gotNode, gotErr := tb.BuildNodeFromTemplate(context.Background(), mig, migOsInfo, template, kubeEnv, 16, 128, nil, &GceReserved{}, localSSDDiskSize)
 			if gotErr != nil {
 				t.Fatalf("BuildNodeFromTemplate unexpected error: %v", gotErr)
 			}

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -76,7 +76,7 @@ func (d *HetznerCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (d *HetznerCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (d *HetznerCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	groups := make([]cloudprovider.NodeGroup, 0, len(d.manager.nodeGroups))
 	for groupId := range d.manager.nodeGroups {
 		groups = append(groups, d.manager.nodeGroups[groupId])
@@ -87,7 +87,7 @@ func (d *HetznerCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (d *HetznerCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (d *HetznerCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	server, err := d.manager.serverForNode(node)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if server %s exists error: %v", node.Spec.ProviderID, err)
@@ -121,19 +121,19 @@ func (d *HetznerCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (d *HetznerCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (d *HetznerCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
-func (d *HetznerCloudProvider) Pricing() (cloudprovider.PricingModel, autoscalerErrors.AutoscalerError) {
+func (d *HetznerCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, autoscalerErrors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from
 // the cloud provider. Implementation optional.
-func (d *HetznerCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (d *HetznerCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	serverTypes, err := d.manager.cachedServerType.getAllServerTypes()
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func (d *HetznerCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // provided. The node group is not automatically created on the cloud provider
 // side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (d *HetznerCloudProvider) NewNodeGroup(
+func (d *HetznerCloudProvider) NewNodeGroup(ctx context.Context,
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
@@ -163,36 +163,36 @@ func (d *HetznerCloudProvider) NewNodeGroup(
 
 // GetResourceLimiter returns struct containing limits (max, min) for
 // resources (cores, memory etc.).
-func (d *HetznerCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (d *HetznerCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return d.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (d *HetznerCloudProvider) GPULabel() string {
+func (d *HetznerCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (d *HetznerCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (d *HetznerCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (d *HetznerCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(d, node)
+func (d *HetznerCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), d, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed,
 // i.e. go routines etc.
-func (d *HetznerCloudProvider) Cleanup() error {
+func (d *HetznerCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically
 // update cloud provider state. In particular the list of node groups returned
 // by NodeGroups() can change as a result of CloudProvider.Refresh().
-func (d *HetznerCloudProvider) Refresh() error {
+func (d *HetznerCloudProvider) Refresh(ctx context.Context) error {
 	for _, group := range d.manager.nodeGroups {
 		group.resetTargetSize(0)
 	}

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -63,18 +63,18 @@ type hetznerNodeGroupSpec struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *hetznerNodeGroup) MaxSize() int {
+func (n *hetznerNodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *hetznerNodeGroup) MinSize() int {
+func (n *hetznerNodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (n *hetznerNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *hetznerNodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
@@ -83,21 +83,21 @@ func (n *hetznerNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOption
 // be equal to Size() once everything stabilizes (new nodes finish startup and
 // registration or removed nodes are deleted completely). Implementation
 // required.
-func (n *hetznerNodeGroup) TargetSize() (int, error) {
+func (n *hetznerNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return n.targetSize, nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *hetznerNodeGroup) IncreaseSize(delta int) error {
+func (n *hetznerNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
 
 	desiredTargetSize := n.targetSize + delta
-	if desiredTargetSize > n.MaxSize() {
-		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d", n.targetSize, desiredTargetSize, n.MaxSize())
+	if desiredTargetSize > n.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d", n.targetSize, desiredTargetSize, n.MaxSize(context.TODO()))
 	}
 
 	actualDelta := delta
@@ -158,7 +158,7 @@ func (n *hetznerNodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *hetznerNodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *hetznerNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -166,15 +166,15 @@ func (n *hetznerNodeGroup) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *hetznerNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *hetznerNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	n.clusterUpdateMutex.Lock()
 	defer n.clusterUpdateMutex.Unlock()
 
 	delta := len(nodes)
 
 	targetSize := n.targetSize - delta
-	if targetSize < n.MinSize() {
-		return fmt.Errorf("size decrease is too large. current: %d desired: %d min: %d", n.targetSize, targetSize, n.MinSize())
+	if targetSize < n.MinSize(context.TODO()) {
+		return fmt.Errorf("size decrease is too large. current: %d desired: %d min: %d", n.targetSize, targetSize, n.MinSize(context.TODO()))
 	}
 
 	actualDelta := delta
@@ -219,7 +219,7 @@ func (n *hetznerNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *hetznerNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *hetznerNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -228,7 +228,7 @@ func (n *hetznerNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *hetznerNodeGroup) DecreaseTargetSize(delta int) error {
+func (n *hetznerNodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	n.targetSize = n.targetSize + delta
 	return nil
 }
@@ -239,14 +239,14 @@ func (n *hetznerNodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *hetznerNodeGroup) Debug() string {
-	return fmt.Sprintf("cluster ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *hetznerNodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("cluster ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.  It is
 // required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
-func (n *hetznerNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *hetznerNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	servers, err := n.manager.cachedServers.getServersByNodeGroupName(n.id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get servers for hcloud: %v", err)
@@ -267,7 +267,7 @@ func (n *hetznerNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // all of the labels, capacity and allocatable information as well as all pods
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
-func (n *hetznerNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *hetznerNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	resourceList, err := getMachineTypeResourceList(n.manager, n.instanceType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource list for node group %s error: %v", n.id, err)
@@ -313,14 +313,14 @@ func (n *hetznerNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 // Exist checks if the node group really exists on the cloud provider side.
 // Allows to tell the theoretical node group from the real one. Implementation
 // required.
-func (n *hetznerNodeGroup) Exist() bool {
+func (n *hetznerNodeGroup) Exist(ctx context.Context) bool {
 	_, exists := n.manager.nodeGroups[n.id]
 	return exists
 }
 
 // Create creates the node group on the cloud provider side. Implementation
 // optional.
-func (n *hetznerNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *hetznerNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	n.manager.nodeGroups[n.id] = n
 
 	return n, cloudprovider.ErrNotImplemented
@@ -329,14 +329,14 @@ func (n *hetznerNodeGroup) Create() (cloudprovider.NodeGroup, error) {
 // Delete deletes the node group on the cloud provider side.  This will be
 // executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *hetznerNodeGroup) Delete() error {
+func (n *hetznerNodeGroup) Delete(ctx context.Context) error {
 	// We do not use actual node groups but all nodes within the Hcloud project are labeled with a group
 	return nil
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled to 0.
-func (n *hetznerNodeGroup) Autoprovisioned() bool {
+func (n *hetznerNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	// All groups are auto provisioned
 	return false
 }

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
@@ -55,12 +55,12 @@ func newAutoScalingGroup(csm CloudServiceManager, sg huaweicloudsdkasmodel.Scali
 }
 
 // MaxSize returns maximum size of the node group.
-func (asg *AutoScalingGroup) MaxSize() int {
+func (asg *AutoScalingGroup) MaxSize(ctx context.Context) int {
 	return asg.maxInstanceNumber
 }
 
 // MinSize returns minimum size of the node group.
-func (asg *AutoScalingGroup) MinSize() int {
+func (asg *AutoScalingGroup) MinSize(ctx context.Context) int {
 	return asg.minInstanceNumber
 }
 
@@ -71,7 +71,7 @@ func (asg *AutoScalingGroup) MinSize() int {
 //
 // Target size is desire instance number of the auto scaling group, and not equal to current instance number if the
 // auto scaling group is in increasing or decreasing process.
-func (asg *AutoScalingGroup) TargetSize() (int, error) {
+func (asg *AutoScalingGroup) TargetSize(ctx context.Context) (int, error) {
 	desireNumber, err := asg.cloudServiceManager.GetDesireInstanceNumber(asg.groupID)
 	if err != nil {
 		klog.Warningf("failed to get group target size. groupID: %s, error: %v", asg.groupID, err)
@@ -84,7 +84,7 @@ func (asg *AutoScalingGroup) TargetSize() (int, error) {
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (asg *AutoScalingGroup) IncreaseSize(delta int) error {
+func (asg *AutoScalingGroup) IncreaseSize(ctx context.Context, delta int) error {
 	err := asg.cloudServiceManager.IncreaseSizeInstance(asg.groupID, delta)
 	if err != nil {
 		klog.Warningf("failed to increase size for group: %s, error: %v", asg.groupID, err)
@@ -95,14 +95,14 @@ func (asg *AutoScalingGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (asg *AutoScalingGroup) AtomicIncreaseSize(delta int) error {
+func (asg *AutoScalingGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (asg *AutoScalingGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *AutoScalingGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	instances, err := asg.cloudServiceManager.GetInstances(asg.groupID)
 	if err != nil {
 		klog.Warningf("failed to get instances from group: %s, error: %v", asg.groupID, err)
@@ -147,7 +147,7 @@ func (asg *AutoScalingGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (asg *AutoScalingGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (asg *AutoScalingGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -156,7 +156,7 @@ func (asg *AutoScalingGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (asg *AutoScalingGroup) DecreaseTargetSize(delta int) error {
+func (asg *AutoScalingGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	// TODO(RainbowMango): Just remove nodes from group not delete them?
 	return cloudprovider.ErrNotImplemented
 }
@@ -167,7 +167,7 @@ func (asg *AutoScalingGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (asg *AutoScalingGroup) Debug() string {
+func (asg *AutoScalingGroup) Debug(ctx context.Context) string {
 	return asg.String()
 }
 
@@ -175,7 +175,7 @@ func (asg *AutoScalingGroup) Debug() string {
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (asg *AutoScalingGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (asg *AutoScalingGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	instances, err := asg.cloudServiceManager.GetInstances(asg.groupID)
 	if err != nil {
 		klog.Warningf("failed to get nodes from group: %s, error: %v", asg.groupID, err)
@@ -191,7 +191,7 @@ func (asg *AutoScalingGroup) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (asg *AutoScalingGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (asg *AutoScalingGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	template, err := asg.cloudServiceManager.getAsgTemplate(asg.groupID)
 	if err != nil {
 		return nil, err
@@ -206,21 +206,21 @@ func (asg *AutoScalingGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (asg *AutoScalingGroup) Exist() bool {
+func (asg *AutoScalingGroup) Exist(ctx context.Context) bool {
 	// Since all group synced from remote and we do not support auto provision,
 	// so we can assume that the group always exist.
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (asg *AutoScalingGroup) Create() (cloudprovider.NodeGroup, error) {
+func (asg *AutoScalingGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (asg *AutoScalingGroup) Delete() error {
+func (asg *AutoScalingGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -228,13 +228,13 @@ func (asg *AutoScalingGroup) Delete() error {
 // was created by CA and can be deleted when scaled to 0.
 //
 // Always return false because the node group should maintained by user.
-func (asg *AutoScalingGroup) Autoprovisioned() bool {
+func (asg *AutoScalingGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (asg *AutoScalingGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (asg *AutoScalingGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package huaweicloud
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -107,7 +108,7 @@ func (hcp *huaweicloudCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups managed by this cloud provider.
-func (hcp *huaweicloudCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (hcp *huaweicloudCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	hcp.lock.RLock()
 	defer hcp.lock.RUnlock()
 
@@ -123,7 +124,7 @@ func (hcp *huaweicloudCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (hcp *huaweicloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (hcp *huaweicloudCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	if _, found := node.ObjectMeta.Labels["node-role.kubernetes.io/master"]; found {
 		return nil, nil
 	}
@@ -145,57 +146,57 @@ func (hcp *huaweicloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpr
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (hcp *huaweicloudCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (hcp *huaweicloudCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available. Not implemented.
-func (hcp *huaweicloudCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (hcp *huaweicloudCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider. Not implemented.
-func (hcp *huaweicloudCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (hcp *huaweicloudCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created. Not implemented.
-func (hcp *huaweicloudCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (hcp *huaweicloudCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (hcp *huaweicloudCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (hcp *huaweicloudCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return hcp.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (hcp *huaweicloudCloudProvider) GPULabel() string {
+func (hcp *huaweicloudCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes returns all available GPU types cloud provider supports.
-func (hcp *huaweicloudCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (hcp *huaweicloudCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (hcp *huaweicloudCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(hcp, node)
+func (hcp *huaweicloudCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), hcp, node)
 }
 
 // Cleanup currently does nothing.
-func (hcp *huaweicloudCloudProvider) Cleanup() error {
+func (hcp *huaweicloudCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 // Currently does nothing.
-func (hcp *huaweicloudCloudProvider) Refresh() error {
+func (hcp *huaweicloudCloudProvider) Refresh(ctx context.Context) error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ionoscloud
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -59,12 +60,12 @@ func init() {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *nodePool) MaxSize() int {
+func (n *nodePool) MaxSize(ctx context.Context) int {
 	return n.max
 }
 
 // MinSize returns minimum size of the node group.
-func (n *nodePool) MinSize() int {
+func (n *nodePool) MinSize(ctx context.Context) int {
 	return n.min
 }
 
@@ -72,7 +73,7 @@ func (n *nodePool) MinSize() int {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (n *nodePool) TargetSize() (int, error) {
+func (n *nodePool) TargetSize(ctx context.Context) (int, error) {
 	size, err := n.manager.GetNodeGroupTargetSize(n)
 	return size, err
 }
@@ -80,7 +81,7 @@ func (n *nodePool) TargetSize() (int, error) {
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *nodePool) IncreaseSize(delta int) error {
+func (n *nodePool) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return errors.New("size increase must be positive")
 	}
@@ -93,7 +94,7 @@ func (n *nodePool) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *nodePool) AtomicIncreaseSize(delta int) error {
+func (n *nodePool) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -101,7 +102,7 @@ func (n *nodePool) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *nodePool) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *nodePool) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	if acquired := n.manager.TryLockNodeGroup(n); !acquired {
 		return errors.New("node deletion already in progress")
 	}
@@ -117,7 +118,7 @@ func (n *nodePool) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *nodePool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *nodePool) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -126,7 +127,7 @@ func (n *nodePool) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target size. Implementation required.
-func (n *nodePool) DecreaseTargetSize(delta int) error {
+func (n *nodePool) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return errors.New("size decrease must be negative")
 	}
@@ -147,7 +148,7 @@ func (n *nodePool) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *nodePool) Debug() string {
+func (n *nodePool) Debug(ctx context.Context) string {
 	return fmt.Sprintf("ID=%s, Min=%d, Max=%d", n.id, n.min, n.max)
 }
 
@@ -155,7 +156,7 @@ func (n *nodePool) Debug() string {
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (n *nodePool) Nodes() ([]cloudprovider.Instance, error) {
+func (n *nodePool) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	return n.manager.GetInstancesForNodeGroup(n)
 }
 
@@ -166,37 +167,37 @@ func (n *nodePool) Nodes() ([]cloudprovider.Instance, error) {
 // all of the labels, capacity and allocatable information as well as all pods
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
-func (n *nodePool) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *nodePool) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (n *nodePool) Exist() bool {
+func (n *nodePool) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (n *nodePool) Create() (cloudprovider.NodeGroup, error) {
+func (n *nodePool) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *nodePool) Delete() error {
+func (n *nodePool) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (n *nodePool) Autoprovisioned() bool {
+func (n *nodePool) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (n *nodePool) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *nodePool) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, nil
 }
 
@@ -219,14 +220,14 @@ func (ic *IonosCloudCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (ic *IonosCloudCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (ic *IonosCloudCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	return ic.manager.GetNodeGroups()
 }
 
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (ic *IonosCloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (ic *IonosCloudCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	providerID := node.Spec.ProviderID
 	if nodeGroup := ic.manager.GetNodeGroupForNode(node); nodeGroup != nil {
 		klog.V(5).Infof("Found cached node group entry %s for node %s", nodeGroup.Id(), providerID)
@@ -236,7 +237,7 @@ func (ic *IonosCloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 
 	for _, nodeGroup := range ic.manager.GetNodeGroups() {
 		klog.V(5).Infof("Checking node group %s", nodeGroup.Id())
-		nodes, err := nodeGroup.Nodes()
+		nodes, err := nodeGroup.Nodes(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -255,19 +256,19 @@ func (ic *IonosCloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (ic *IonosCloudCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (ic *IonosCloudCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
-func (ic *IonosCloudCloudProvider) Pricing() (cloudprovider.PricingModel, caerrors.AutoscalerError) {
+func (ic *IonosCloudCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, caerrors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from
 // the cloud provider. Implementation optional.
-func (ic *IonosCloudCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (ic *IonosCloudCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
@@ -275,7 +276,7 @@ func (ic *IonosCloudCloudProvider) GetAvailableMachineTypes() ([]string, error) 
 // provided. The node group is not automatically created on the cloud provider
 // side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (ic *IonosCloudCloudProvider) NewNodeGroup(
+func (ic *IonosCloudCloudProvider) NewNodeGroup(ctx context.Context,
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
@@ -287,36 +288,36 @@ func (ic *IonosCloudCloudProvider) NewNodeGroup(
 
 // GetResourceLimiter returns struct containing limits (max, min) for
 // resources (cores, memory etc.).
-func (ic *IonosCloudCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (ic *IonosCloudCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return ic.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (ic *IonosCloudCloudProvider) GPULabel() string {
+func (ic *IonosCloudCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (ic *IonosCloudCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (ic *IonosCloudCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (ic *IonosCloudCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(ic, node)
+func (ic *IonosCloudCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), ic, node)
 }
 
 // Cleanup cleans up read resources before the cloud provider is destroyed,
 // i.e. go routines etc.
-func (ic *IonosCloudCloudProvider) Cleanup() error {
+func (ic *IonosCloudCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically
 // update cloud provider state. In particular the list of node groups returned
 // by NodeGroups() can change as a result of CloudProvider.Refresh().
-func (ic *IonosCloudCloudProvider) Refresh() error {
+func (ic *IonosCloudCloudProvider) Refresh(ctx context.Context) error {
 	// Currently only static node groups are supported.
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ionoscloud
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -57,114 +58,114 @@ func (s *NodeGroupTestSuite) TestId() {
 }
 
 func (s *NodeGroupTestSuite) TestDebug() {
-	s.Equal("ID=test, Min=1, Max=3", s.nodePool.Debug())
+	s.Equal("ID=test, Min=1, Max=3", s.nodePool.Debug(context.Background()))
 }
 
 func (s *NodeGroupTestSuite) TestMaxSize() {
-	s.Equal(3, s.nodePool.MaxSize())
+	s.Equal(3, s.nodePool.MaxSize(context.Background()))
 }
 
 func (s *NodeGroupTestSuite) TestMinSize() {
-	s.Equal(1, s.nodePool.MinSize())
+	s.Equal(1, s.nodePool.MinSize(context.Background()))
 }
 
 func (s *NodeGroupTestSuite) TestTemplateNodeInfo() {
-	nodeInfo, err := s.nodePool.TemplateNodeInfo()
+	nodeInfo, err := s.nodePool.TemplateNodeInfo(context.Background())
 	s.Nil(nodeInfo)
 	s.Equal(cloudprovider.ErrNotImplemented, err)
 }
 
 func (s *NodeGroupTestSuite) TestExist() {
 	var nodePool *nodePool
-	s.True((nodePool).Exist())
+	s.True((nodePool).Exist(context.Background()))
 }
 
 func (s *NodeGroupTestSuite) TestCreate() {
-	nodeGroup, err := s.nodePool.Create()
+	nodeGroup, err := s.nodePool.Create(context.Background())
 	s.Nil(nodeGroup)
 	s.Equal(cloudprovider.ErrNotImplemented, err)
 }
 
 func (s *NodeGroupTestSuite) TestDelete() {
-	err := s.nodePool.Delete()
+	err := s.nodePool.Delete(context.Background())
 	s.Equal(cloudprovider.ErrNotImplemented, err)
 }
 
 func (s *NodeGroupTestSuite) TestAutoprovisioned() {
 	var nodePool *nodePool
-	s.False(nodePool.Autoprovisioned())
+	s.False(nodePool.Autoprovisioned(context.Background()))
 }
 
 func (s *NodeGroupTestSuite) TestTargetSize_Error() {
 	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(0, errors.New("error")).Once()
-	_, err := s.nodePool.TargetSize()
+	_, err := s.nodePool.TargetSize(context.Background())
 	s.Error(err)
 }
 
 func (s *NodeGroupTestSuite) TestTargetSize_OK() {
 	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(3, nil).Once()
-	size, err := s.nodePool.TargetSize()
+	size, err := s.nodePool.TargetSize(context.Background())
 	s.NoError(err)
 	s.Equal(3, size)
 }
 
 func (s *NodeGroupTestSuite) TestIncreaseSize_InvalidDelta() {
-	s.Error(s.nodePool.IncreaseSize(0))
+	s.Error(s.nodePool.IncreaseSize(context.Background(), 0))
 }
 
 func (s *NodeGroupTestSuite) TestIncreaseSize_GetSizeError() {
 	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(0, errors.New("error")).Once()
-	s.Error(s.nodePool.IncreaseSize(2))
+	s.Error(s.nodePool.IncreaseSize(context.Background(), 2))
 }
 
 func (s *NodeGroupTestSuite) TestIncreaseSize_SetSizeError() {
 	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(2, nil).Once()
 	s.manager.On("SetNodeGroupSize", s.nodePool, 3).Return(errors.New("error")).Once()
-	s.Error(s.nodePool.IncreaseSize(1))
+	s.Error(s.nodePool.IncreaseSize(context.Background(), 1))
 }
 
 func (s *NodeGroupTestSuite) TestIncreaseSize_OK() {
 	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(2, nil).Once()
 	s.manager.On("SetNodeGroupSize", s.nodePool, 3).Return(nil).Once()
-	s.NoError(s.nodePool.IncreaseSize(1))
+	s.NoError(s.nodePool.IncreaseSize(context.Background(), 1))
 }
 
 func (s *NodeGroupTestSuite) TestDeleteNodes_Locked() {
 	s.manager.On("TryLockNodeGroup", s.nodePool).Return(false).Once()
-	s.Error(s.nodePool.DeleteNodes(s.deleteNode))
+	s.Error(s.nodePool.DeleteNodes(context.Background(), s.deleteNode))
 }
 
 func (s *NodeGroupTestSuite) TestDeleteNodes_DeleteError() {
 	s.manager.On("TryLockNodeGroup", s.nodePool).Return(true).Once()
 	s.manager.On("UnlockNodeGroup", s.nodePool).Return().Once()
 	s.manager.On("DeleteNode", s.nodePool, "testnode").Return(errors.New("error")).Once()
-	s.Error(s.nodePool.DeleteNodes(s.deleteNode))
+	s.Error(s.nodePool.DeleteNodes(context.Background(), s.deleteNode))
 }
 
 func (s *NodeGroupTestSuite) TestDeleteNodes_OK() {
 	s.manager.On("TryLockNodeGroup", s.nodePool).Return(true).Once()
 	s.manager.On("UnlockNodeGroup", s.nodePool).Return().Once()
 	s.manager.On("DeleteNode", s.nodePool, "testnode").Return(nil).Once()
-	s.NoError(s.nodePool.DeleteNodes(s.deleteNode))
+	s.NoError(s.nodePool.DeleteNodes(context.Background(), s.deleteNode))
 }
 
 func (s *NodeGroupTestSuite) TestDecreaseTargetSize_InvalidDelta() {
-	s.Error(s.nodePool.DecreaseTargetSize(0))
+	s.Error(s.nodePool.DecreaseTargetSize(context.Background(), 0))
 }
 
 func (s *NodeGroupTestSuite) TestDecreaseTargetSize_GetTargetSizeError() {
 	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(0, errors.New("error")).Once()
-	s.Error(s.nodePool.DecreaseTargetSize(-1))
+	s.Error(s.nodePool.DecreaseTargetSize(context.Background(), -1))
 }
 
 func (s *NodeGroupTestSuite) TestDecreaseTargetSize_ExceedMin() {
 	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(1, nil).Once()
-	s.Error(s.nodePool.DecreaseTargetSize(-2))
+	s.Error(s.nodePool.DecreaseTargetSize(context.Background(), -2))
 }
 
 func (s *NodeGroupTestSuite) TestDecreaseTargetSize_NotImplemented() {
 	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(1, nil).Once()
-	s.Error(s.nodePool.DecreaseTargetSize(-1))
+	s.Error(s.nodePool.DecreaseTargetSize(context.Background(), -1))
 }
 
 type CloudProviderTestSuite struct {
@@ -191,14 +192,14 @@ func (s *CloudProviderTestSuite) TestName() {
 
 func (s *CloudProviderTestSuite) TestNodeGroups() {
 	s.manager.On("GetNodeGroups").Return([]cloudprovider.NodeGroup{&nodePool{id: "test"}}).Once()
-	s.Equal([]cloudprovider.NodeGroup{&nodePool{id: "test"}}, s.provider.NodeGroups())
+	s.Equal([]cloudprovider.NodeGroup{&nodePool{id: "test"}}, s.provider.NodeGroups(context.Background()))
 }
 
 func (s *CloudProviderTestSuite) TestNodeGroupForNode_CacheHit() {
 	node := newAPINode("test")
 	s.manager.On("GetNodeGroupForNode", node).Return(&nodePool{id: "test"}).Once()
 
-	nodeGroup, err := s.provider.NodeGroupForNode(node)
+	nodeGroup, err := s.provider.NodeGroupForNode(context.Background(), node)
 	s.NoError(err)
 	s.Equal(&nodePool{id: "test"}, nodeGroup)
 }
@@ -210,7 +211,7 @@ func (s *CloudProviderTestSuite) TestNodeGroupForNode_Error() {
 	s.manager.On("GetNodeGroups").Return([]cloudprovider.NodeGroup{nodePool}).Once()
 	s.manager.On("GetInstancesForNodeGroup", nodePool).Return(nil, errors.New("error")).Once()
 
-	nodeGroup, err := s.provider.NodeGroupForNode(node)
+	nodeGroup, err := s.provider.NodeGroupForNode(context.Background(), node)
 	s.Nil(nodeGroup)
 	s.Error(err)
 }
@@ -224,7 +225,7 @@ func (s *CloudProviderTestSuite) TestNodeGroupForNode_Found() {
 		newInstance("foo"), newInstance("test"),
 	}, nil).Once()
 
-	nodeGroup, err := s.provider.NodeGroupForNode(node)
+	nodeGroup, err := s.provider.NodeGroupForNode(context.Background(), node)
 	s.Equal(nodePool, nodeGroup)
 	s.NoError(err)
 }
@@ -238,52 +239,52 @@ func (s *CloudProviderTestSuite) TestNodeGroupForNode_NotFound() {
 		newInstance("foo"), newInstance("bar"),
 	}, nil).Once()
 
-	nodeGroup, err := s.provider.NodeGroupForNode(node)
+	nodeGroup, err := s.provider.NodeGroupForNode(context.Background(), node)
 	s.Nil(nodeGroup)
 	s.NoError(err)
 }
 
 func (s *CloudProviderTestSuite) TestPricing_NotImplemented() {
 	var ionoscloud *IonosCloudCloudProvider
-	pricingModel, err := ionoscloud.Pricing()
+	pricingModel, err := ionoscloud.Pricing(context.Background())
 	s.Nil(pricingModel)
 	s.Equal(cloudprovider.ErrNotImplemented, err)
 }
 
 func (s *CloudProviderTestSuite) TestGetAvailableMachineTypes_NotImplemented() {
 	var ionoscloud *IonosCloudCloudProvider
-	machineTypes, err := ionoscloud.GetAvailableMachineTypes()
+	machineTypes, err := ionoscloud.GetAvailableMachineTypes(context.Background())
 	s.Nil(machineTypes)
 	s.Equal(cloudprovider.ErrNotImplemented, err)
 }
 
 func (s *CloudProviderTestSuite) TestNewNodeGroup_NotImplemented() {
 	var ionoscloud *IonosCloudCloudProvider
-	nodeGroup, err := ionoscloud.NewNodeGroup("test", nil, nil, nil, nil)
+	nodeGroup, err := ionoscloud.NewNodeGroup(context.Background(), "test", nil, nil, nil, nil)
 	s.Nil(nodeGroup)
 	s.Equal(cloudprovider.ErrNotImplemented, err)
 }
 
 func (s *CloudProviderTestSuite) TestGetResourceLimiter() {
-	rl, err := s.provider.GetResourceLimiter()
+	rl, err := s.provider.GetResourceLimiter(context.Background())
 	s.NotNil(rl)
 	s.NoError(err)
 }
 
 func (s *CloudProviderTestSuite) TestGPULabel() {
 	var ionoscloud *IonosCloudCloudProvider
-	s.Equal(GPULabel, ionoscloud.GPULabel())
+	s.Equal(GPULabel, ionoscloud.GPULabel(context.Background()))
 }
 
 func (s *CloudProviderTestSuite) TestGetAvailableGPUTypes() {
 	var ionoscloud *IonosCloudCloudProvider
-	s.Nil(ionoscloud.GetAvailableGPUTypes())
+	s.Nil(ionoscloud.GetAvailableGPUTypes(context.Background()))
 }
 
 func (s *CloudProviderTestSuite) TestCleanup() {
-	s.NoError(s.provider.Cleanup())
+	s.NoError(s.provider.Cleanup(context.Background()))
 }
 
 func (s *CloudProviderTestSuite) TestRefresh() {
-	s.NoError(s.provider.Refresh())
+	s.NoError(s.provider.Refresh(context.Background()))
 }

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kamatera
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -60,7 +61,7 @@ func (k *kamateraCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (k *kamateraCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (k *kamateraCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	k.manager.nodeGroupsMu.RLock()
 	nodeGroups := make([]cloudprovider.NodeGroup, 0, len(k.manager.nodeGroups))
 	for _, ng := range k.manager.nodeGroups {
@@ -73,7 +74,7 @@ func (k *kamateraCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (k *kamateraCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (k *kamateraCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	k.manager.nodeGroupsMu.RLock()
 	nodeGroups := make([]*NodeGroup, 0, len(k.manager.nodeGroups))
 	for _, ng := range k.manager.nodeGroups {
@@ -96,59 +97,59 @@ func (k *kamateraCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (k *kamateraCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (k *kamateraCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (k *kamateraCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (k *kamateraCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (k *kamateraCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (k *kamateraCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (k *kamateraCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (k *kamateraCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (k *kamateraCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (k *kamateraCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return k.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (k *kamateraCloudProvider) GPULabel() string {
+func (k *kamateraCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (k *kamateraCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (k *kamateraCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (k *kamateraCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(k, node)
+func (k *kamateraCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), k, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (k *kamateraCloudProvider) Cleanup() error {
+func (k *kamateraCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (k *kamateraCloudProvider) Refresh() error {
+func (k *kamateraCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Infof("Refreshing Kamatera node groups")
 	err := k.manager.refresh()
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kamatera
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -77,7 +78,7 @@ cluster-name=aaabbb
 		"ng2": {id: "ng2"},
 	}
 	kcp := &kamateraCloudProvider{manager: m}
-	ng := kcp.NodeGroups()
+	ng := kcp.NodeGroups(context.Background())
 	assert.Equal(t, 2, len(ng))
 	assert.Contains(t, ng, m.nodeGroups["ng1"])
 	assert.Contains(t, ng, m.nodeGroups["ng2"])
@@ -130,7 +131,7 @@ cluster-name=aaabbb
 			ProviderID: formatKamateraProviderID(defaultKamateraProviderIDPrefix, kamateraServerName1),
 		},
 	}
-	ng, err := kcp.NodeGroupForNode(node)
+	ng, err := kcp.NodeGroupForNode(context.Background(), node)
 	assert.NoError(t, err)
 	assert.Equal(t, ng1, ng)
 
@@ -140,7 +141,7 @@ cluster-name=aaabbb
 			Name: kamateraServerName4,
 		},
 	}
-	ng, err = kcp.NodeGroupForNode(node)
+	ng, err = kcp.NodeGroupForNode(context.Background(), node)
 	assert.NoError(t, err)
 	assert.Equal(t, ng2, ng)
 
@@ -153,7 +154,7 @@ cluster-name=aaabbb
 			ProviderID: "kamatera://---",
 		},
 	}
-	ng, err = kcp.NodeGroupForNode(node)
+	ng, err = kcp.NodeGroupForNode(context.Background(), node)
 	assert.NoError(t, err)
 	assert.Nil(t, ng)
 }
@@ -172,16 +173,16 @@ cluster-name=aaabbb
 		resourceLimiter: resourceLimiter,
 	}
 	assert.Equal(t, ProviderName, kcp.Name())
-	_, err := kcp.GetAvailableMachineTypes()
+	_, err := kcp.GetAvailableMachineTypes(context.Background())
 	assert.Error(t, err)
-	_, err = kcp.NewNodeGroup("", nil, nil, nil, nil)
+	_, err = kcp.NewNodeGroup(context.Background(), "", nil, nil, nil, nil)
 	assert.Error(t, err)
-	rl, err := kcp.GetResourceLimiter()
+	rl, err := kcp.GetResourceLimiter(context.Background())
 	assert.Equal(t, resourceLimiter, rl)
-	assert.Equal(t, "", kcp.GPULabel())
-	assert.Nil(t, kcp.GetAvailableGPUTypes())
-	assert.Nil(t, kcp.Cleanup())
-	_, err2 := kcp.Pricing()
+	assert.Equal(t, "", kcp.GPULabel(context.Background()))
+	assert.Nil(t, kcp.GetAvailableGPUTypes(context.Background()))
+	assert.Nil(t, kcp.Cleanup(context.Background()))
+	_, err2 := kcp.Pricing(context.Background())
 	assert.Error(t, err2)
 }
 
@@ -200,7 +201,7 @@ cluster-name=aaabbb
 			ProviderID: mockKamateraServerName(),
 		},
 	}
-	hasInstance, err := kcp.HasInstance(node)
+	hasInstance, err := kcp.HasInstance(context.Background(), node)
 	assert.True(t, hasInstance)
 	assert.Error(t, err)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
@@ -221,7 +222,7 @@ cluster-name=aaabbb
 			ProviderID: mockKamateraServerName(),
 		},
 	}
-	gpuConfig := kcp.GetNodeGpuConfig(node)
+	gpuConfig := kcp.GetNodeGpuConfig(context.Background(), node)
 	assert.Nil(t, gpuConfig)
 }
 
@@ -283,18 +284,18 @@ max-size=2
 		ObjectMeta: metav1.ObjectMeta{Name: serverName1},
 		Spec:       apiv1.NodeSpec{ProviderID: formatKamateraProviderID(defaultKamateraProviderIDPrefix, serverName1)},
 	}))
-	err = kcp.Refresh()
+	err = kcp.Refresh(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(m.nodeGroups))
 	assert.Equal(t, 2, len(m.nodeGroups["ng1"].instances))
 	// TargetSize is updated only after NodeGroupForNode is called with a related node
-	ng, err := kcp.NodeGroupForNode(&apiv1.Node{
+	ng, err := kcp.NodeGroupForNode(context.Background(), &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: serverName1,
 		},
 	})
 	assert.Equal(t, m.nodeGroups["ng1"], ng)
-	targetSize, _ := m.nodeGroups["ng1"].TargetSize()
+	targetSize, _ := m.nodeGroups["ng1"].TargetSize(context.Background())
 	assert.Equal(t, 1, targetSize)
 }
 
@@ -320,7 +321,7 @@ cluster-name=aaabbb
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
 			defer wg.Done()
-			ng := kcp.NodeGroups()
+			ng := kcp.NodeGroups(context.Background())
 			assert.Equal(t, 2, len(ng))
 		}()
 	}
@@ -373,7 +374,7 @@ cluster-name=aaabbb
 					ProviderID: kamateraCloudProviderID1,
 				},
 			}
-			ng, err := kcp.NodeGroupForNode(node)
+			ng, err := kcp.NodeGroupForNode(context.Background(), node)
 			assert.NoError(t, err)
 			assert.Equal(t, ng1, ng)
 		}()
@@ -384,7 +385,7 @@ cluster-name=aaabbb
 					ProviderID: kamateraCloudProviderID2,
 				},
 			}
-			ng, err := kcp.NodeGroupForNode(node)
+			ng, err := kcp.NodeGroupForNode(context.Background(), node)
 			assert.NoError(t, err)
 			assert.Equal(t, ng2, ng)
 		}()
@@ -414,7 +415,7 @@ cluster-name=aaabbb
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
 			defer wg.Done()
-			_ = kcp.NodeGroups()
+			_ = kcp.NodeGroups(context.Background())
 		}()
 		go func(idx int) {
 			defer wg.Done()
@@ -464,7 +465,7 @@ cluster-name=aaabbb
 					ProviderID: kamateraServerName1,
 				},
 			}
-			_, _ = kcp.NodeGroupForNode(node)
+			_, _ = kcp.NodeGroupForNode(context.Background(), node)
 		}()
 		go func(idx int) {
 			defer wg.Done()
@@ -548,10 +549,10 @@ func kcpAssertNodeGroup(
 ) *NodeGroup {
 	ng := kcpGetNodeGroup(kcp, ngID)
 	assert.NotNil(t, ng, "node group %s not found", ngID)
-	targetSize, err := ng.TargetSize()
+	targetSize, err := ng.TargetSize(context.Background())
 	assert.NoError(t, err, "failed to get target size for node group %s", ngID)
 	assert.Equal(t, expectedTargetSize, targetSize, "target size for node group %s does not match", ngID)
-	nodes, err := ng.Nodes()
+	nodes, err := ng.Nodes(context.Background())
 	assert.NoError(t, err, "failed to get nodes for node group %s", ngID)
 	assert.Equal(t, expectedNumNodes, len(nodes), "number of nodes in node group %s does not match", ngID)
 	assert.Equal(t, len(expectedInstances), len(ng.instances), "number of instances in node group %s does not match", ngID)
@@ -638,7 +639,7 @@ max-size=3
 			assert.Equal(t, kcp.manager.config.PoweroffOnScaleDown, tt.poweroffOnScaleDown)
 			// initial refresh - no servers, no instances in node group
 			kcpKClientOnListServers(kamateraClient, &kcp, []Server{}, nil).Once()
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			ng := kcpAssertNodeGroup(&kcp, t, "ng1", 0, 0, map[string]kcpExpectedInstance{})
 			// scale up to 3 instances
 			// 2 servers started creation, 1 server failed to start creation
@@ -650,7 +651,7 @@ max-size=3
 				},
 				nil,
 			).Once()
-			assert.NoError(t, ng.IncreaseSize(3))
+			assert.NoError(t, ng.IncreaseSize(context.Background(), 3))
 			instanceCreating := cloudprovider.InstanceCreating
 			kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{
 				"server1": {State: &instanceCreating, CommandId: "create-server-command-id-1", HasErrorInfo: false},
@@ -665,7 +666,7 @@ max-size=3
 			kamateraClient.On("getCommandStatus", mock.Anything, "create-server-command-id-3").Return(
 				CommandStatusError, nil,
 			).Once()
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{
 				"server1": {State: &instanceCreating, CommandId: "create-server-command-id-1", HasErrorInfo: false},
 				"server2": {State: &instanceCreating, CommandId: "", HasErrorInfo: false},
@@ -676,7 +677,7 @@ max-size=3
 			kamateraClient.On("getCommandStatus", mock.Anything, "create-server-command-id-1").Return(
 				CommandStatusComplete, nil,
 			).Once()
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{
 				"server1": {State: &instanceCreating, CommandId: "", HasErrorInfo: false},
 				"server2": {State: &instanceCreating, CommandId: "", HasErrorInfo: false},
@@ -686,7 +687,7 @@ max-size=3
 			kcpKClientOnListServers(kamateraClient, &kcp, []Server{
 				{Name: "server1", PowerOn: false, Tags: ng.serverConfig.Tags},
 			}, nil).Once()
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{
 				"server1": {State: &instanceCreating, CommandId: "", HasErrorInfo: false},
 				"server2": {State: &instanceCreating, CommandId: "", HasErrorInfo: false},
@@ -699,7 +700,7 @@ max-size=3
 				{Name: "server1", PowerOn: true, Tags: ng.serverConfig.Tags},
 				{Name: "server2", PowerOn: false, Tags: ng.serverConfig.Tags},
 			}, nil).Once()
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{
 				"server1": {State: &instanceRunning, CommandId: "", HasErrorInfo: false},
 				"server2": {State: &instanceCreating, CommandId: "", HasErrorInfo: false},
@@ -723,7 +724,7 @@ max-size=3
 				{Name: "server2", PowerOn: true, Tags: ng.serverConfig.Tags},
 				{Name: "server3", PowerOn: true, Tags: ng.serverConfig.Tags},
 			}, nil).Once()
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{
 				"server1": {State: &instanceRunning, CommandId: "", HasErrorInfo: false},
 				"server2": {State: &instanceRunning, CommandId: "", HasErrorInfo: false},
@@ -736,7 +737,7 @@ max-size=3
 			kamateraClient.On("StartServerRequest", mock.Anything, ServerRequestPoweroff, "server3").Return(
 				"server3-power-off", nil,
 			).Once()
-			assert.NoError(t, ng.DeleteNodes([]*apiv1.Node{
+			assert.NoError(t, ng.DeleteNodes(context.Background(), []*apiv1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "server1"},
 					Spec:       apiv1.NodeSpec{ProviderID: formatKamateraProviderID(kcp.manager.config.providerIDPrefix, "server1")},
@@ -762,7 +763,7 @@ max-size=3
 			).Return(CommandStatusPending, nil).Once().On(
 				"getCommandStatus", mock.Anything, "server3-power-off",
 			).Return(CommandStatusPending, nil).Once()
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			kcpAssertNodeGroup(&kcp, t, "ng1", 1, 3, map[string]kcpExpectedInstance{
 				"server1": {State: &instanceDeleting, CommandId: "server1-power-off", HasErrorInfo: false},
 				"server2": {State: &instanceRunning, CommandId: "", HasErrorInfo: false},
@@ -777,7 +778,7 @@ max-size=3
 			).Return(CommandStatusPending, nil).Once().On(
 				"getCommandStatus", mock.Anything, "server3-power-off",
 			).Return(CommandStatusPending, nil).Once()
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			kcpAssertNodeGroup(&kcp, t, "ng1", 1, 3, map[string]kcpExpectedInstance{
 				"server1": {State: &instanceDeleting, CommandId: "server1-power-off", HasErrorInfo: false},
 				"server2": {State: &instanceRunning, CommandId: "", HasErrorInfo: false},
@@ -800,7 +801,7 @@ max-size=3
 					"server1-terminate", nil,
 				).Once()
 			}
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			if tt.poweroffOnScaleDown {
 				kcpAssertNodeGroup(&kcp, t, "ng1", 1, 2, map[string]kcpExpectedInstance{
 					"server1": {State: nil, CommandId: "", HasErrorInfo: false},
@@ -829,7 +830,7 @@ max-size=3
 					"getCommandStatus", mock.Anything, "server1-terminate",
 				).Return(CommandStatusComplete, nil).Once()
 			}
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			if tt.poweroffOnScaleDown {
 				kcpAssertNodeGroup(&kcp, t, "ng1", 1, 1, map[string]kcpExpectedInstance{
 					"server1": {State: nil, CommandId: "", HasErrorInfo: false},
@@ -857,7 +858,7 @@ max-size=3
 					nil,
 				).Once()
 			}
-			assert.NoError(t, ng.IncreaseSize(2))
+			assert.NoError(t, ng.IncreaseSize(context.Background(), 2))
 			if tt.poweronOnScaleUp && tt.poweroffOnScaleDown {
 				kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{
 					"server2": {State: &instanceRunning, CommandId: "", HasErrorInfo: false},
@@ -909,7 +910,7 @@ max-size=3
 					CommandStatusError, nil,
 				).Once()
 			}
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			if tt.poweronOnScaleUp && tt.poweroffOnScaleDown {
 				kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{
 					"server1": {State: &instanceCreating, CommandId: "", HasErrorInfo: false},
@@ -953,7 +954,7 @@ max-size=3
 					{Name: "server5", PowerOn: true, Tags: ng.serverConfig.Tags},
 				}, nil).Once()
 			}
-			assert.NoError(t, kcp.Refresh())
+			assert.NoError(t, kcp.Refresh(context.Background()))
 			if tt.poweronOnScaleUp && tt.poweroffOnScaleDown {
 				// instances already registered in Kubernetes - once powered on, state changes to running
 				kcpAssertNodeGroup(&kcp, t, "ng1", 3, 3, map[string]kcpExpectedInstance{

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_manager_test.go
@@ -153,7 +153,7 @@ max-size=5
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(m.nodeGroups))
 	assert.Equal(t, 4, len(m.nodeGroups["ng1"].instances))
-	targetSize, _ := m.nodeGroups["ng1"].TargetSize()
+	targetSize, _ := m.nodeGroups["ng1"].TargetSize(context.Background())
 	assert.Equal(t, 3, targetSize)
 	assert.Equal(t, 2, len(m.nodeGroups["ng2"].instances))
 	for _, serverName := range []string{serverName4} {
@@ -166,7 +166,7 @@ max-size=5
 			},
 		})
 	}
-	targetSize, _ = m.nodeGroups["ng2"].TargetSize()
+	targetSize, _ = m.nodeGroups["ng2"].TargetSize(context.Background())
 	assert.Equal(t, 1, targetSize)
 
 	// test api error

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
@@ -53,12 +53,12 @@ type NodeGroup struct {
 var _ cloudprovider.NodeGroup = (*NodeGroup)(nil)
 
 // MaxSize returns maximum size of the node group.
-func (n *NodeGroup) MaxSize() int {
+func (n *NodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *NodeGroup) MinSize() int {
+func (n *NodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
@@ -66,7 +66,7 @@ func (n *NodeGroup) MinSize() int {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (n *NodeGroup) TargetSize() (int, error) {
+func (n *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	numInstances := 0
 	for _, instance := range n.instances {
 		if instance.Status != nil && instance.Status.State != cloudprovider.InstanceDeleting {
@@ -79,19 +79,19 @@ func (n *NodeGroup) TargetSize() (int, error) {
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *NodeGroup) IncreaseSize(delta int) error {
+func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
-	currentSize, err := n.TargetSize()
+	currentSize, err := n.TargetSize(context.TODO())
 	if err != nil {
 		return err
 	}
 	targetSize := currentSize + delta
 	klog.V(2).Infof("Increasing size of node group %s from %d to %d", n.id, currentSize, targetSize)
-	if targetSize > n.MaxSize() {
+	if targetSize > n.MaxSize(context.TODO()) {
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			currentSize, targetSize, n.MaxSize())
+			currentSize, targetSize, n.MaxSize(context.TODO()))
 	}
 	err = n.createInstances(delta)
 	if err != nil {
@@ -102,14 +102,14 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	klog.V(2).Infof("Deleting %d nodes from node group %s", len(nodes), n.id)
 	numPoweredOffInstances := 0
 	for _, instance := range n.instances {
@@ -140,7 +140,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -149,7 +149,7 @@ func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *NodeGroup) DecreaseTargetSize(delta int) error {
+func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	// requests for new nodes are always fulfilled so we cannot
 	// decrease the size without actually deleting nodes
 	return cloudprovider.ErrNotImplemented
@@ -161,15 +161,15 @@ func (n *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroup) Debug() string {
-	return fmt.Sprintf("node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *NodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	var instances []cloudprovider.Instance
 	for _, instance := range n.instances {
 		if instance.Status != nil {
@@ -188,7 +188,7 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	resourceList, err := n.getResourceList()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource list for node group %s error: %v", n.id, err)
@@ -219,32 +219,32 @@ func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (n *NodeGroup) Exist() bool {
+func (n *NodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (n *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroup) Delete() error {
+func (n *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroup) Autoprovisioned() bool {
+func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 // Implementation optional.
-func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return &config.NodeGroupAutoscalingOptions{
 		ScaleDownUtilizationThreshold:    defaults.ScaleDownUtilizationThreshold,
 		ScaleDownGpuUtilizationThreshold: defaults.ScaleDownGpuUtilizationThreshold,
@@ -317,7 +317,7 @@ func (n *NodeGroup) createInstances(count int) error {
 
 func (n *NodeGroup) extendedDebug() string {
 	// TODO: provide extended debug information regarding this node group
-	msgs := []string{n.Debug()}
+	msgs := []string{n.Debug(context.TODO())}
 	for _, instance := range n.instances {
 		msgs = append(msgs, instance.extendedDebug())
 	}

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group_test.go
@@ -90,16 +90,16 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			}
 
 			// test error on bad delta values
-			err := ng.IncreaseSize(0)
+			err := ng.IncreaseSize(context.Background(), 0)
 			assert.Error(t, err)
 			assert.Equal(t, "delta must be positive, have: 0", err.Error())
 
-			err = ng.IncreaseSize(-1)
+			err = ng.IncreaseSize(context.Background(), -1)
 			assert.Error(t, err)
 			assert.Equal(t, "delta must be positive, have: -1", err.Error())
 
 			// test error on a too large increase of nodes
-			err = ng.IncreaseSize(5)
+			err = ng.IncreaseSize(context.Background(), 5)
 			assert.Error(t, err)
 			assert.Equal(t, "size increase is too large. current: 3 desired: 8 max: 7", err.Error())
 
@@ -110,7 +110,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			).Return(
 				map[string]string{createdServerName1: "cmd-1"}, nil,
 			).Once()
-			err = ng.IncreaseSize(1)
+			err = ng.IncreaseSize(context.Background(), 1)
 			assert.NoError(t, err)
 			assert.Equal(t, 4, len(ng.instances))
 
@@ -123,7 +123,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			).Return(
 				map[string]string{createdServerName2: "cmd-2", createdServerName3: "cmd-3"}, nil,
 			).Once()
-			err = ng.IncreaseSize(2)
+			err = ng.IncreaseSize(context.Background(), 2)
 			assert.NoError(t, err)
 			assert.Equal(t, 6, len(ng.instances))
 
@@ -135,7 +135,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			).Return(
 				map[string]string{}, fmt.Errorf("error on API call"),
 			).Once()
-			err = ng.IncreaseSize(1)
+			err = ng.IncreaseSize(context.Background(), 1)
 			assert.Error(t, err, "no error on injected API call error")
 			assert.Equal(t, "error on API call", err.Error())
 		})
@@ -250,7 +250,7 @@ func TestNodeGroup_IncreaseSize_withPoweredOffServers(t *testing.T) {
 					map[string]string{createdServerName1: "cmd-create-1"}, nil,
 				).Once()
 			}
-			err := ng.IncreaseSize(1)
+			err := ng.IncreaseSize(context.Background(), 1)
 			assert.NoError(t, err)
 			assert.Equal(t, 4, len(ng.instances))
 
@@ -281,7 +281,7 @@ func TestNodeGroup_IncreaseSize_withPoweredOffServers(t *testing.T) {
 					map[string]string{createdServerName2: "cmd-create-2", createdServerName3: "cmd-create-3"}, nil,
 				).Once()
 			}
-			err = ng.IncreaseSize(2)
+			err = ng.IncreaseSize(context.Background(), 2)
 			assert.NoError(t, err)
 			assert.Equal(t, 6, len(ng.instances))
 
@@ -296,7 +296,7 @@ func TestNodeGroup_IncreaseSize_withPoweredOffServers(t *testing.T) {
 			).Return(
 				map[string]string{}, fmt.Errorf("error on API call"),
 			).Once()
-			err = ng.IncreaseSize(1)
+			err = ng.IncreaseSize(context.Background(), 1)
 			assert.Error(t, err, "no error on injected API call error")
 			assert.Equal(t, "error on API call", err.Error())
 		})
@@ -305,7 +305,7 @@ func TestNodeGroup_IncreaseSize_withPoweredOffServers(t *testing.T) {
 
 func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 	ng := &NodeGroup{}
-	err := ng.DecreaseTargetSize(-1)
+	err := ng.DecreaseTargetSize(context.Background(), -1)
 	assert.Error(t, err)
 	assert.Equal(t, "Not implemented", err.Error())
 }
@@ -373,7 +373,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 				"StartServerRequest", ctx, ServerRequestPoweroff, serverName6,
 			).Return("cmd-poweroff-6", nil).Once()
 
-			err := ng.DeleteNodes([]*apiv1.Node{
+			err := ng.DeleteNodes(context.Background(), []*apiv1.Node{
 				{Spec: apiv1.NodeSpec{ProviderID: serverProviderID1}},
 				{Spec: apiv1.NodeSpec{ProviderID: serverProviderID2}},
 				{Spec: apiv1.NodeSpec{ProviderID: serverProviderID6}},
@@ -381,7 +381,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, 6, len(ng.instances))
-			targetSize, err := ng.TargetSize()
+			targetSize, err := ng.TargetSize(context.Background())
 			assert.Equal(t, 3, targetSize)
 			assert.Equal(t, cloudprovider.InstanceDeleting, ng.instances[serverProviderID1].Status.State)
 			assert.Equal(t, cloudprovider.InstanceDeleting, ng.instances[serverProviderID2].Status.State)
@@ -391,7 +391,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			assert.Equal(t, cloudprovider.InstanceRunning, ng.instances[serverProviderID5].Status.State)
 
 			// test error on deleting a node we are not managing
-			err = ng.DeleteNodes([]*apiv1.Node{{Spec: apiv1.NodeSpec{ProviderID: mockKamateraServerName()}}})
+			err = ng.DeleteNodes(context.Background(), []*apiv1.Node{{Spec: apiv1.NodeSpec{ProviderID: mockKamateraServerName()}}})
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "cannot find this node in the node group")
 
@@ -399,7 +399,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			client.On(
 				"StartServerRequest", ctx, ServerRequestPoweroff, serverName4,
 			).Return("", fmt.Errorf("error on API call")).Once()
-			err = ng.DeleteNodes([]*apiv1.Node{
+			err = ng.DeleteNodes(context.Background(), []*apiv1.Node{
 				{Spec: apiv1.NodeSpec{ProviderID: serverProviderID4}},
 			})
 			assert.Error(t, err)
@@ -479,7 +479,7 @@ func TestNodeGroup_DeleteNodes_PoweroffBehavior(t *testing.T) {
 				"StartServerRequest", ctx, ServerRequestPoweroff, serverName,
 			).Return("cmd-poweroff", nil).Once()
 
-			err := ng.DeleteNodes([]*apiv1.Node{{Spec: apiv1.NodeSpec{ProviderID: serverProviderID}}})
+			err := ng.DeleteNodes(context.Background(), []*apiv1.Node{{Spec: apiv1.NodeSpec{ProviderID: serverProviderID}}})
 			assert.NoError(t, err)
 
 			instance := ng.instances[serverProviderID]
@@ -545,7 +545,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 
 	// test nodes returned from Nodes() are only the ones we are expecting
 	// Instance.Id should be prefixed with the configured provider ID prefix to match node.Spec.ProviderID
-	instancesList, err := ng.Nodes()
+	instancesList, err := ng.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(instancesList))
 	var serverIds []string
@@ -602,7 +602,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 			Disks: []string{"size=50"},
 		},
 	}
-	nodeInfo, err := ng.TemplateNodeInfo()
+	nodeInfo, err := ng.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, nodeInfo.Node().Status.Capacity, apiv1.ResourceList{
 		apiv1.ResourcePods:    *resource.NewQuantity(110, resource.DecimalSI),
@@ -614,7 +614,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 
 	// test with template labels
 	ng.templateLabels = []string{"disktype=ssd", "kubernetes.io/os=linux"}
-	nodeInfo, err = ng.TemplateNodeInfo()
+	nodeInfo, err = ng.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"disktype":         "ssd",
@@ -623,7 +623,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 
 	// test with invalid label format (missing =)
 	ng.templateLabels = []string{"invalidlabel", "valid=label"}
-	nodeInfo, err = ng.TemplateNodeInfo()
+	nodeInfo, err = ng.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"valid": "label",
@@ -631,7 +631,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 
 	// test with label containing = in value
 	ng.templateLabels = []string{"key=value=with=equals"}
-	nodeInfo, err = ng.TemplateNodeInfo()
+	nodeInfo, err = ng.TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"key": "value=with=equals",
@@ -658,39 +658,39 @@ func TestNodeGroup_Others(t *testing.T) {
 		},
 		manager: &mgr,
 	}
-	assert.Equal(t, 1, ng.MinSize())
-	assert.Equal(t, 7, ng.MaxSize())
-	ts, err := ng.TargetSize()
+	assert.Equal(t, 1, ng.MinSize(context.Background()))
+	assert.Equal(t, 7, ng.MaxSize(context.Background()))
+	ts, err := ng.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, ts)
 	assert.Equal(t, "ng1", ng.Id())
-	assert.Equal(t, "node group ID: ng1 (min:1 max:7)", ng.Debug())
+	assert.Equal(t, "node group ID: ng1 (min:1 max:7)", ng.Debug(context.Background()))
 	extendedDebug := strings.Split(ng.extendedDebug(), "\n")
 	assert.Equal(t, 4, len(extendedDebug))
 	assert.Contains(t, extendedDebug, "node group ID: ng1 (min:1 max:7)")
 	for _, serverName := range []string{serverName1, serverName2, serverName3} {
 		assert.Contains(t, extendedDebug, fmt.Sprintf("instance ID: %s state: Running powerOn: false commandID: ", serverName))
 	}
-	assert.Equal(t, true, ng.Exist())
-	assert.Equal(t, false, ng.Autoprovisioned())
-	_, err = ng.Create()
+	assert.Equal(t, true, ng.Exist(context.Background()))
+	assert.Equal(t, false, ng.Autoprovisioned(context.Background()))
+	_, err = ng.Create(context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, "Not implemented", err.Error())
-	err = ng.Delete()
+	err = ng.Delete(context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, "Not implemented", err.Error())
 }
 
 func TestNodeGroup_AtomicIncreaseSize(t *testing.T) {
 	ng := &NodeGroup{}
-	err := ng.AtomicIncreaseSize(1)
+	err := ng.AtomicIncreaseSize(context.Background(), 1)
 	assert.Error(t, err)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
 func TestNodeGroup_ForceDeleteNodes(t *testing.T) {
 	ng := &NodeGroup{}
-	err := ng.ForceDeleteNodes([]*apiv1.Node{})
+	err := ng.ForceDeleteNodes(context.Background(), []*apiv1.Node{})
 	assert.Error(t, err)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
@@ -705,7 +705,7 @@ func TestNodeGroup_GetOptions(t *testing.T) {
 		ZeroOrMaxNodeScaling:             true,
 		IgnoreDaemonSetsUtilization:      true,
 	}
-	opts, err := ng.GetOptions(defaults)
+	opts, err := ng.GetOptions(context.Background(), defaults)
 	assert.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.Equal(t, defaults.ScaleDownUtilizationThreshold, opts.ScaleDownUtilizationThreshold)

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -23,6 +23,7 @@ limitations under the License.
 package kubemark
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -108,23 +109,23 @@ func (kubemark *KubemarkCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (kubemark *KubemarkCloudProvider) GPULabel() string {
+func (kubemark *KubemarkCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (kubemark *KubemarkCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (kubemark *KubemarkCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (kubemark *KubemarkCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(kubemark, node)
+func (kubemark *KubemarkCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), kubemark, node)
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (kubemark *KubemarkCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (kubemark *KubemarkCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	result := make([]cloudprovider.NodeGroup, 0, len(kubemark.nodeGroups))
 	for _, nodegroup := range kubemark.nodeGroups {
 		result = append(result, nodegroup)
@@ -133,12 +134,12 @@ func (kubemark *KubemarkCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (kubemark *KubemarkCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (kubemark *KubemarkCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (kubemark *KubemarkCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	// Skip nodes that are not managed by Kubemark Cloud Provider.
 	if !strings.HasPrefix(node.Spec.ProviderID, ProviderName) {
 		return nil, nil
@@ -156,36 +157,36 @@ func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloud
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (kubemark *KubemarkCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (kubemark *KubemarkCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided.
-func (kubemark *KubemarkCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (kubemark *KubemarkCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint,
 	extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (kubemark *KubemarkCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (kubemark *KubemarkCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return kubemark.resourceLimiter, nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (kubemark *KubemarkCloudProvider) Refresh() error {
+func (kubemark *KubemarkCloudProvider) Refresh(ctx context.Context) error {
 	return nil
 }
 
 // Cleanup cleans up all resources before the cloud provider is removed
-func (kubemark *KubemarkCloudProvider) Cleanup() error {
+func (kubemark *KubemarkCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
@@ -203,22 +204,22 @@ func (nodeGroup *NodeGroup) Id() string {
 }
 
 // MinSize returns minimum size of the node group.
-func (nodeGroup *NodeGroup) MinSize() int {
+func (nodeGroup *NodeGroup) MinSize(ctx context.Context) int {
 	return nodeGroup.minSize
 }
 
 // MaxSize returns maximum size of the node group.
-func (nodeGroup *NodeGroup) MaxSize() int {
+func (nodeGroup *NodeGroup) MaxSize(ctx context.Context) int {
 	return nodeGroup.maxSize
 }
 
 // Debug returns a debug string for the nodegroup.
-func (nodeGroup *NodeGroup) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", nodeGroup.Id(), nodeGroup.MinSize(), nodeGroup.MaxSize())
+func (nodeGroup *NodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", nodeGroup.Id(), nodeGroup.MinSize(context.TODO()), nodeGroup.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (nodeGroup *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (nodeGroup *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	instances := make([]cloudprovider.Instance, 0)
 	nodes, err := nodeGroup.kubemarkController.GetNodeNamesForNodeGroup(nodeGroup.Name)
 	if err != nil {
@@ -231,12 +232,12 @@ func (nodeGroup *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // DeleteNodes deletes the specified nodes from the node group.
-func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (nodeGroup *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	size, err := nodeGroup.kubemarkController.GetNodeGroupTargetSize(nodeGroup.Name)
 	if err != nil {
 		return err
 	}
-	if size <= nodeGroup.MinSize() {
+	if size <= nodeGroup.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 	for _, node := range nodes {
@@ -248,12 +249,12 @@ func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (nodeGroup *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (nodeGroup *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // IncreaseSize increases NodeGroup size.
-func (nodeGroup *NodeGroup) IncreaseSize(delta int) error {
+func (nodeGroup *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -262,20 +263,20 @@ func (nodeGroup *NodeGroup) IncreaseSize(delta int) error {
 		return err
 	}
 	newSize := int(size) + delta
-	if newSize > nodeGroup.MaxSize() {
-		return fmt.Errorf("size increase too large, desired: %d max: %d", newSize, nodeGroup.MaxSize())
+	if newSize > nodeGroup.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large, desired: %d max: %d", newSize, nodeGroup.MaxSize(context.TODO()))
 	}
 	return nodeGroup.kubemarkController.SetNodeGroupSize(nodeGroup.Name, newSize)
 }
 
 // AtomicIncreaseSize is not implemented.
-func (nodeGroup *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (nodeGroup *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (nodeGroup *NodeGroup) TargetSize() (int, error) {
+func (nodeGroup *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	size, err := nodeGroup.kubemarkController.GetNodeGroupTargetSize(nodeGroup.Name)
 	return int(size), err
 }
@@ -283,7 +284,7 @@ func (nodeGroup *NodeGroup) TargetSize() (int, error) {
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
-func (nodeGroup *NodeGroup) DecreaseTargetSize(delta int) error {
+func (nodeGroup *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
@@ -304,33 +305,33 @@ func (nodeGroup *NodeGroup) DecreaseTargetSize(delta int) error {
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (nodeGroup *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (nodeGroup *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Exist checks if the node group really exists on the cloud provider side.
-func (nodeGroup *NodeGroup) Exist() bool {
+func (nodeGroup *NodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (nodeGroup *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (nodeGroup *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
-func (nodeGroup *NodeGroup) Delete() error {
+func (nodeGroup *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (nodeGroup *NodeGroup) Autoprovisioned() bool {
+func (nodeGroup *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (nodeGroup *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (nodeGroup *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -66,67 +66,67 @@ func BuildKubemarkCloudProvider(kubemarkController interface{}, specs []string, 
 func (kubemark *KubemarkCloudProvider) Name() string { return "" }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (kubemark *KubemarkCloudProvider) GPULabel() string {
+func (kubemark *KubemarkCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (kubemark *KubemarkCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (kubemark *KubemarkCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (kubemark *KubemarkCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+func (kubemark *KubemarkCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
 	return gpu.GetNodeGPUFromCloudProvider(kubemark, node)
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (kubemark *KubemarkCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (kubemark *KubemarkCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	return []cloudprovider.NodeGroup{}
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (kubemark *KubemarkCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (kubemark *KubemarkCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (kubemark *KubemarkCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (kubemark *KubemarkCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (kubemark *KubemarkCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (kubemark *KubemarkCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (kubemark *KubemarkCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided.
-func (kubemark *KubemarkCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (kubemark *KubemarkCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint,
 	extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (kubemark *KubemarkCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (kubemark *KubemarkCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (kubemark *KubemarkCloudProvider) Refresh() error {
+func (kubemark *KubemarkCloudProvider) Refresh(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Cleanup cleans up all resources before the cloud provider is removed
-func (kubemark *KubemarkCloudProvider) Cleanup() error {
+func (kubemark *KubemarkCloudProvider) Cleanup(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package linode
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -54,7 +55,7 @@ func (l *linodeCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (l *linodeCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (l *linodeCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodeGroups := make([]cloudprovider.NodeGroup, len(l.manager.nodeGroups))
 	i := 0
 	for _, ng := range l.manager.nodeGroups {
@@ -67,7 +68,7 @@ func (l *linodeCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (l *linodeCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (l *linodeCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	for _, ng := range l.manager.nodeGroups {
 		pool, err := ng.findLKEPoolForNode(node)
 		if err != nil {
@@ -81,53 +82,53 @@ func (l *linodeCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (l *linodeCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (l *linodeCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (l *linodeCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (l *linodeCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (l *linodeCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (l *linodeCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (l *linodeCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (l *linodeCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (l *linodeCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (l *linodeCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return l.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (l *linodeCloudProvider) GPULabel() string {
+func (l *linodeCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (l *linodeCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (l *linodeCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (l *linodeCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(l, node)
+func (l *linodeCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), l, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (l *linodeCloudProvider) Cleanup() error {
+func (l *linodeCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
@@ -159,7 +160,7 @@ func BuildLinode(
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (l *linodeCloudProvider) Refresh() error {
+func (l *linodeCloudProvider) Refresh(ctx context.Context) error {
 	return l.manager.refresh()
 }
 

--- a/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package linode
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -60,7 +61,7 @@ lke-cluster-id=456456
 		"g6-standard-2": {id: "g6-standard-2"},
 	}
 	lcp := &linodeCloudProvider{manager: m}
-	ng := lcp.NodeGroups()
+	ng := lcp.NodeGroups(context.Background())
 	assert.Equal(t, 2, len(ng))
 	assert.Contains(t, ng, m.nodeGroups["g6-standard-1"])
 	assert.Contains(t, ng, m.nodeGroups["g6-standard-2"])
@@ -126,7 +127,7 @@ lke-cluster-id=456456
 			ProviderID: "linode://555",
 		},
 	}
-	ng, err := lcp.NodeGroupForNode(node)
+	ng, err := lcp.NodeGroupForNode(context.Background(), node)
 	assert.NoError(t, err)
 	assert.Equal(t, ng1, ng)
 
@@ -136,7 +137,7 @@ lke-cluster-id=456456
 			ProviderID: "linode://666",
 		},
 	}
-	ng, err = lcp.NodeGroupForNode(node)
+	ng, err = lcp.NodeGroupForNode(context.Background(), node)
 	assert.NoError(t, err)
 	assert.Equal(t, ng2, ng)
 
@@ -146,7 +147,7 @@ lke-cluster-id=456456
 			ProviderID: "linode://999",
 		},
 	}
-	ng, err = lcp.NodeGroupForNode(node)
+	ng, err = lcp.NodeGroupForNode(context.Background(), node)
 	assert.NoError(t, err)
 	assert.Nil(t, ng)
 
@@ -156,7 +157,7 @@ lke-cluster-id=456456
 			ProviderID: "linode://aaa",
 		},
 	}
-	ng, err = lcp.NodeGroupForNode(node)
+	ng, err = lcp.NodeGroupForNode(context.Background(), node)
 	assert.Error(t, err)
 
 }
@@ -174,15 +175,15 @@ lke-cluster-id=456456
 		resourceLimiter: resourceLimiter,
 	}
 	assert.Equal(t, ProviderName, lcp.Name())
-	_, err := lcp.GetAvailableMachineTypes()
+	_, err := lcp.GetAvailableMachineTypes(context.Background())
 	assert.Error(t, err)
-	_, err = lcp.NewNodeGroup("", nil, nil, nil, nil)
+	_, err = lcp.NewNodeGroup(context.Background(), "", nil, nil, nil, nil)
 	assert.Error(t, err)
-	rl, err := lcp.GetResourceLimiter()
+	rl, err := lcp.GetResourceLimiter(context.Background())
 	assert.Equal(t, resourceLimiter, rl)
-	assert.Equal(t, "", lcp.GPULabel())
-	assert.Nil(t, lcp.GetAvailableGPUTypes())
-	assert.Nil(t, lcp.Cleanup())
-	_, err2 := lcp.Pricing()
+	assert.Equal(t, "", lcp.GPULabel(context.Background()))
+	assert.Nil(t, lcp.GetAvailableGPUTypes(context.Background()))
+	assert.Nil(t, lcp.Cleanup(context.Background()))
+	_, err2 := lcp.Pricing(context.Background())
 	assert.Error(t, err2)
 }

--- a/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
@@ -55,12 +55,12 @@ type NodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *NodeGroup) MaxSize() int {
+func (n *NodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *NodeGroup) MinSize() int {
+func (n *NodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
@@ -69,23 +69,23 @@ func (n *NodeGroup) MinSize() int {
 // be equal to Size() once everything stabilizes (new nodes finish startup and
 // registration or removed nodes are deleted completely). Implementation
 // required.
-func (n *NodeGroup) TargetSize() (int, error) {
+func (n *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return len(n.lkePools), nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *NodeGroup) IncreaseSize(delta int) error {
+func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
 
 	currentSize := len(n.lkePools)
 	targetSize := currentSize + delta
-	if targetSize > n.MaxSize() {
+	if targetSize > n.MaxSize(context.TODO()) {
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			currentSize, targetSize, n.MaxSize())
+			currentSize, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	for i := 0; i < delta; i++ {
@@ -99,7 +99,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -107,7 +107,7 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	for _, node := range nodes {
 		pool, err := n.findLKEPoolForNode(node)
 		if err != nil {
@@ -127,7 +127,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -136,7 +136,7 @@ func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *NodeGroup) DecreaseTargetSize(delta int) error {
+func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	// requests for new nodes are always fulfilled so we cannot
 	// decrease the size without actually deleting nodes
 	return cloudprovider.ErrNotImplemented
@@ -148,8 +148,8 @@ func (n *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroup) Debug() string {
-	return fmt.Sprintf("node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *NodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // extendendDebug returns a string containing detailed information regarding this node group.
@@ -174,7 +174,7 @@ func (n *NodeGroup) extendedDebug() string {
 // Nodes returns a list of all nodes that belong to this node group. It is
 // required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
-func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	nodes := make([]cloudprovider.Instance, 0)
 	for _, pool := range n.lkePools {
 		linodesCount := len(pool.Linodes)
@@ -198,39 +198,39 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // all of the labels, capacity and allocatable information as well as all pods
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
-func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Exist checks if the node group really exists on the cloud provider side.
 // Allows to tell the theoretical node group from the real one. Implementation
 // required.
-func (n *NodeGroup) Exist() bool {
+func (n *NodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation
 // optional.
-func (n *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.  This will be
 // executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroup) Delete() error {
+func (n *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroup) Autoprovisioned() bool {
+func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/linode/linode_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_node_group_test.go
@@ -66,35 +66,35 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 	).Once()
 
 	// test error on bad delta value
-	err := ng.IncreaseSize(0)
+	err := ng.IncreaseSize(context.Background(), 0)
 	assert.Error(t, err)
 
 	// test error on bad delta value
-	err = ng.IncreaseSize(-1)
+	err = ng.IncreaseSize(context.Background(), -1)
 	assert.Error(t, err)
 
 	// test error on a too large increase of nodes
-	err = ng.IncreaseSize(5)
+	err = ng.IncreaseSize(context.Background(), 5)
 	assert.Error(t, err)
 
 	// test ok to add a node
-	err = ng.IncreaseSize(1)
+	err = ng.IncreaseSize(context.Background(), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(ng.lkePools))
 
 	// test ok to add multiple nodes
-	err = ng.IncreaseSize(2)
+	err = ng.IncreaseSize(context.Background(), 2)
 	assert.NoError(t, err)
 	assert.Equal(t, 6, len(ng.lkePools))
 
 	// test error on linode API call error
-	err = ng.IncreaseSize(1)
+	err = ng.IncreaseSize(context.Background(), 1)
 	assert.Error(t, err, "no error on injected API call error")
 }
 
 func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 	ng := &NodeGroup{}
-	err := ng.DecreaseTargetSize(-1)
+	err := ng.DecreaseTargetSize(context.Background(), -1)
 	assert.Error(t, err)
 }
 
@@ -139,7 +139,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 	}
 
 	// test of on deleting nodes
-	err := ng.DeleteNodes(nodes)
+	err := ng.DeleteNodes(context.Background(), nodes)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(ng.lkePools))
 	assert.NotNil(t, ng.lkePools[3])
@@ -149,21 +149,21 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 	nodes = []*apiv1.Node{
 		{Spec: apiv1.NodeSpec{ProviderID: "linode://aaa"}},
 	}
-	err = ng.DeleteNodes(nodes)
+	err = ng.DeleteNodes(context.Background(), nodes)
 	assert.Error(t, err)
 
 	// test error on deleting a node we are not managing
 	nodes = []*apiv1.Node{
 		{Spec: apiv1.NodeSpec{ProviderID: "linode://555"}},
 	}
-	err = ng.DeleteNodes(nodes)
+	err = ng.DeleteNodes(context.Background(), nodes)
 	assert.Error(t, err)
 
 	// test error on deleting a node when the linode API call fails
 	nodes = []*apiv1.Node{
 		{Spec: apiv1.NodeSpec{ProviderID: "linode://423"}},
 	}
-	err = ng.DeleteNodes(nodes)
+	err = ng.DeleteNodes(context.Background(), nodes)
 	assert.Error(t, err)
 }
 
@@ -236,7 +236,7 @@ func TestNosdeGroup_Nodes(t *testing.T) {
 	}
 
 	// test nodes returned from Nodes() are only the ones we are expecting
-	instancesList, err := ng.Nodes()
+	instancesList, err := ng.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(instancesList))
 	assert.Contains(t, instancesList, cloudprovider.Instance{Id: "linode://423"})
@@ -264,19 +264,19 @@ func TestNodeGroup_Others(t *testing.T) {
 		maxSize:      7,
 		id:           "g6-standard-1",
 	}
-	assert.Equal(t, 1, ng.MinSize())
-	assert.Equal(t, 7, ng.MaxSize())
-	ts, err := ng.TargetSize()
+	assert.Equal(t, 1, ng.MinSize(context.Background()))
+	assert.Equal(t, 7, ng.MaxSize(context.Background()))
+	ts, err := ng.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, ts)
 	assert.Equal(t, "g6-standard-1", ng.Id())
-	assert.Equal(t, "node group ID: g6-standard-1 (min:1 max:7)", ng.Debug())
-	assert.Equal(t, true, ng.Exist())
-	assert.Equal(t, false, ng.Autoprovisioned())
-	_, err = ng.TemplateNodeInfo()
+	assert.Equal(t, "node group ID: g6-standard-1 (min:1 max:7)", ng.Debug(context.Background()))
+	assert.Equal(t, true, ng.Exist(context.Background()))
+	assert.Equal(t, false, ng.Autoprovisioned(context.Background()))
+	_, err = ng.TemplateNodeInfo(context.Background())
 	assert.Error(t, err)
-	_, err = ng.Create()
+	_, err = ng.Create(context.Background())
 	assert.Error(t, err)
-	err = ng.Delete()
+	err = ng.Delete(context.Background())
 	assert.Error(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package magnum
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -93,23 +94,23 @@ func (mcp *magnumCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (mcp *magnumCloudProvider) GPULabel() string {
+func (mcp *magnumCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (mcp *magnumCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (mcp *magnumCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (mcp *magnumCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(mcp, node)
+func (mcp *magnumCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), mcp, node)
 }
 
 // NodeGroups returns all node groups managed by this cloud provider.
-func (mcp *magnumCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (mcp *magnumCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	mcp.nodeGroupsLock.Lock()
 	defer mcp.nodeGroupsLock.Unlock()
 
@@ -129,7 +130,7 @@ func (mcp *magnumCloudProvider) AddNodeGroup(group *magnumNodeGroup) {
 }
 
 // NodeGroupForNode returns the node group that a given node belongs to.
-func (mcp *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (mcp *magnumCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	mcp.nodeGroupsLock.Lock()
 	defer mcp.nodeGroupsLock.Unlock()
 
@@ -160,28 +161,28 @@ func (mcp *magnumCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (mcp *magnumCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (mcp *magnumCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing is not implemented.
-func (mcp *magnumCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (mcp *magnumCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes is not implemented.
-func (mcp *magnumCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (mcp *magnumCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup is not implemented.
-func (mcp *magnumCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (mcp *magnumCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns resource constraints for the cloud provider
-func (mcp *magnumCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (mcp *magnumCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return mcp.resourceLimiter, nil
 }
 
@@ -190,10 +191,10 @@ func (mcp *magnumCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLim
 // Debug information for each node group is printed with logging level >= 5.
 // Every 60 seconds the node group state on the Magnum side is checked,
 // to see if there are any node groups that need to be added/removed/updated.
-func (mcp *magnumCloudProvider) Refresh() error {
+func (mcp *magnumCloudProvider) Refresh(ctx context.Context) error {
 	mcp.nodeGroupsLock.Lock()
 	for _, nodegroup := range mcp.nodeGroups {
-		klog.V(5).Info(nodegroup.Debug())
+		klog.V(5).Info(nodegroup.Debug(context.TODO()))
 	}
 	mcp.nodeGroupsLock.Unlock()
 
@@ -211,7 +212,7 @@ func (mcp *magnumCloudProvider) Refresh() error {
 }
 
 // Cleanup currently does nothing.
-func (mcp *magnumCloudProvider) Cleanup() error {
+func (mcp *magnumCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package magnum
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -99,7 +100,7 @@ func TestRefreshNodeGroupsRace(t *testing.T) {
 	// Continuously read from the node groups list.
 	go func() {
 		for time.Since(startTime) < 2*time.Second {
-			ngs := provider.NodeGroups()
+			ngs := provider.NodeGroups(context.Background())
 			assert.NotNil(t, ngs)
 		}
 		wg.Done()
@@ -128,8 +129,8 @@ func TestNodeGroups(t *testing.T) {
 
 	provider.nodeGroups = []*magnumNodeGroup{ng1, ng2}
 
-	for _, ng := range provider.NodeGroups() {
-		err := ng.IncreaseSize(1)
+	for _, ng := range provider.NodeGroups(context.Background()) {
+		err := ng.IncreaseSize(context.Background(), 1)
 		require.NoError(t, err)
 	}
 
@@ -256,7 +257,7 @@ func TestNodeInf(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(provider.nodeGroups), "wrong number of initial node groups")
 
-	nodeInfo, err := provider.nodeGroups[0].TemplateNodeInfo()
+	nodeInfo, err := provider.nodeGroups[0].TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, len(nodeInfo.Pods()), 1, "should have one template pod")
 	assert.Equal(t, nodeInfo.Node().Status.Capacity.Cpu().ToDec().Value(), int64(2000), "should match cpu capacity ")
@@ -270,7 +271,7 @@ func TestNodeInf(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(provider.nodeGroups), "wrong number of initial node groups")
 
-	nodeInfo, err = provider.nodeGroups[0].TemplateNodeInfo()
+	nodeInfo, err = provider.nodeGroups[0].TemplateNodeInfo(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(nodeInfo.Pods()), "should have one template pod")
 	assert.Equal(t, int64(2000), nodeInfo.Node().Status.Capacity.Cpu().ToDec().Value(), "should match cpu capacity ")
@@ -468,15 +469,15 @@ func TestRefreshNodeGroupsUpdate(t *testing.T) {
 	err = provider.refreshNodeGroups()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(provider.nodeGroups), "wrong number of initial node groups")
-	require.Equal(t, 1, provider.nodeGroups[0].MinSize(), "wrong initial min node count")
-	require.Equal(t, 3, provider.nodeGroups[0].MaxSize(), "wrong initial max node count")
+	require.Equal(t, 1, provider.nodeGroups[0].MinSize(context.Background()), "wrong initial min node count")
+	require.Equal(t, 3, provider.nodeGroups[0].MaxSize(context.Background()), "wrong initial max node count")
 
 	// Update the node group
 	err = provider.refreshNodeGroups()
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(provider.nodeGroups), "wrong number of node groups after refresh")
-	assert.Equal(t, 2, provider.nodeGroups[0].MinSize(), "wrong updated min node count")
-	assert.Equal(t, 4, provider.nodeGroups[0].MaxSize(), "wrong updated max node count")
+	assert.Equal(t, 2, provider.nodeGroups[0].MinSize(context.Background()), "wrong updated min node count")
+	assert.Equal(t, 4, provider.nodeGroups[0].MaxSize(context.Background()), "wrong updated max node count")
 }
 
 // TestRefreshNodeGroupsEmpty checks that refreshNodeGroups correctly
@@ -567,25 +568,25 @@ func TestProviderNodeGroupForNode(t *testing.T) {
 	manager.On("nodeGroupForNode", node4).Return("", fmt.Errorf("manager error"))
 
 	t.Run("ng1", func(t *testing.T) {
-		ng, err := provider.NodeGroupForNode(node1)
+		ng, err := provider.NodeGroupForNode(context.Background(), node1)
 		assert.NoError(t, err)
 		assert.Equal(t, nodegroup1, ng)
 	})
 
 	t.Run("ng2", func(t *testing.T) {
-		ng, err := provider.NodeGroupForNode(node2)
+		ng, err := provider.NodeGroupForNode(context.Background(), node2)
 		assert.NoError(t, err)
 		assert.Equal(t, nodegroup2, ng)
 	})
 
 	t.Run("ng3", func(t *testing.T) {
-		ng, err := provider.NodeGroupForNode(node3)
+		ng, err := provider.NodeGroupForNode(context.Background(), node3)
 		assert.NoError(t, err)
 		assert.Equal(t, nil, ng)
 	})
 
 	t.Run("error", func(t *testing.T) {
-		_, err := provider.NodeGroupForNode(node4)
+		_, err := provider.NodeGroupForNode(context.Background(), node4)
 		assert.Error(t, err)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package magnum
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -78,7 +79,7 @@ type MagnumNodeTemplate struct {
 //
 // Takes precautions so that the cluster is not modified while in an UPDATE_IN_PROGRESS state.
 // Blocks until the cluster has reached UPDATE_COMPLETE.
-func (ng *magnumNodeGroup) IncreaseSize(delta int) error {
+func (ng *magnumNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	ng.clusterUpdateLock.Lock()
 	defer ng.clusterUpdateLock.Unlock()
 
@@ -87,8 +88,8 @@ func (ng *magnumNodeGroup) IncreaseSize(delta int) error {
 	}
 
 	size := ng.targetSize
-	if size+delta > ng.MaxSize() {
-		return fmt.Errorf("size increase too large, desired:%d max:%d", size+delta, ng.MaxSize())
+	if size+delta > ng.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large, desired:%d max:%d", size+delta, ng.MaxSize(context.TODO()))
 	}
 
 	klog.V(2).Infof("Increasing size by %d, %d->%d", delta, size, size+delta)
@@ -102,12 +103,12 @@ func (ng *magnumNodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ng *magnumNodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *magnumNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // deleteNodes deletes a set of nodes chosen by the autoscaler.
-func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *magnumNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	ng.clusterUpdateLock.Lock()
 	defer ng.clusterUpdateLock.Unlock()
 
@@ -120,8 +121,8 @@ func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	klog.V(2).Infof("Deleting nodes: %v", nodeNames)
 
 	// Check that the total number of nodes to be deleted will not take the node group below its minimum size
-	if size-len(nodes) < ng.MinSize() {
-		return fmt.Errorf("size decrease too large, desired:%d min:%d", size-len(nodes), ng.MinSize())
+	if size-len(nodes) < ng.MinSize(context.TODO()) {
+		return fmt.Errorf("size decrease too large, desired:%d min:%d", size-len(nodes), ng.MinSize(context.TODO()))
 	}
 
 	var nodeRefs []NodeRef
@@ -153,12 +154,12 @@ func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ng *magnumNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ng *magnumNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DecreaseTargetSize decreases the cluster node_count in magnum.
-func (ng *magnumNodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *magnumNodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	ng.clusterUpdateLock.Lock()
 	defer ng.clusterUpdateLock.Unlock()
 
@@ -166,8 +167,8 @@ func (ng *magnumNodeGroup) DecreaseTargetSize(delta int) error {
 		return fmt.Errorf("size decrease must be negative")
 	}
 	size := ng.targetSize
-	if size+delta < ng.MinSize() {
-		return fmt.Errorf("size decrease too large, desired:%d min:%d", size+delta, ng.MinSize())
+	if size+delta < ng.MinSize(context.TODO()) {
+		return fmt.Errorf("size decrease too large, desired:%d min:%d", size+delta, ng.MinSize(context.TODO()))
 	}
 
 	klog.V(2).Infof("Decreasing target size by %d, %d->%d", delta, ng.targetSize, ng.targetSize+delta)
@@ -185,14 +186,14 @@ func (ng *magnumNodeGroup) Id() string {
 }
 
 // Debug returns a string formatted with the node group's min, max and target sizes.
-func (ng *magnumNodeGroup) Debug() string {
+func (ng *magnumNodeGroup) Debug(ctx context.Context) string {
 	ng.clusterUpdateLock.Lock()
 	defer ng.clusterUpdateLock.Unlock()
 	return fmt.Sprintf("%s min=%d max=%d target=%d", ng.id, ng.minSize, ng.maxSize, ng.targetSize)
 }
 
 // Nodes returns a list of nodes that belong to this node group.
-func (ng *magnumNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *magnumNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	ng.clusterUpdateLock.Lock()
 	defer ng.clusterUpdateLock.Unlock()
 
@@ -224,7 +225,7 @@ func (ng *magnumNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (ng *magnumNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *magnumNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	node, err := ng.buildNodeFromTemplate(ng.Id(), ng.nodeTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build node from template")
@@ -237,43 +238,43 @@ func (ng *magnumNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist returns if this node group exists.
 // Currently always returns true.
-func (ng *magnumNodeGroup) Exist() bool {
+func (ng *magnumNodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (ng *magnumNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *magnumNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.
-func (ng *magnumNodeGroup) Delete() error {
+func (ng *magnumNodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns if the nodegroup is autoprovisioned.
-func (ng *magnumNodeGroup) Autoprovisioned() bool {
+func (ng *magnumNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (ng *magnumNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *magnumNodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // MaxSize returns the maximum allowed size of the node group.
-func (ng *magnumNodeGroup) MaxSize() int {
+func (ng *magnumNodeGroup) MaxSize(ctx context.Context) int {
 	return ng.maxSize
 }
 
 // MinSize returns the minimum allowed size of the node group.
-func (ng *magnumNodeGroup) MinSize() int {
+func (ng *magnumNodeGroup) MinSize(ctx context.Context) int {
 	return ng.minSize
 }
 
 // TargetSize returns the target size of the node group.
-func (ng *magnumNodeGroup) TargetSize() (int, error) {
+func (ng *magnumNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return ng.targetSize, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package magnum
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -105,21 +106,21 @@ func TestIncreaseSize(t *testing.T) {
 	// Test all working normally
 	t.Run("success", func(t *testing.T) {
 		manager.On("updateNodeCount", testNodeGroupUUID, 2).Return(nil).Once()
-		err := ng.IncreaseSize(1)
+		err := ng.IncreaseSize(context.Background(), 1)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, ng.targetSize, "target size not updated")
 	})
 
 	// Test negative increase
 	t.Run("negative increase", func(t *testing.T) {
-		err := ng.IncreaseSize(-1)
+		err := ng.IncreaseSize(context.Background(), -1)
 		assert.Error(t, err)
 		assert.Equal(t, "size increase must be positive", err.Error())
 	})
 
 	// Test zero increase
 	t.Run("zero increase", func(t *testing.T) {
-		err := ng.IncreaseSize(0)
+		err := ng.IncreaseSize(context.Background(), 0)
 		assert.Error(t, err)
 		assert.Equal(t, "size increase must be positive", err.Error())
 	})
@@ -127,7 +128,7 @@ func TestIncreaseSize(t *testing.T) {
 	// Test increase too large
 	t.Run("increase too large", func(t *testing.T) {
 		ng.targetSize = 1
-		err := ng.IncreaseSize(10)
+		err := ng.IncreaseSize(context.Background(), 10)
 		assert.Error(t, err)
 		assert.Equal(t, "size increase too large, desired:11 max:10", err.Error())
 	})
@@ -136,7 +137,7 @@ func TestIncreaseSize(t *testing.T) {
 	t.Run("update node count fails", func(t *testing.T) {
 		ng.targetSize = 1
 		manager.On("updateNodeCount", testNodeGroupUUID, 2).Return(errors.New("manager error")).Once()
-		err := ng.IncreaseSize(1)
+		err := ng.IncreaseSize(context.Background(), 1)
 		assert.Error(t, err)
 		assert.Equal(t, "could not increase cluster size: manager error", err.Error())
 	})
@@ -150,21 +151,21 @@ func TestDecreaseSize(t *testing.T) {
 	// Test all working normally
 	t.Run("success", func(t *testing.T) {
 		manager.On("updateNodeCount", testNodeGroupUUID, 2).Return(nil).Once()
-		err := ng.DecreaseTargetSize(-1)
+		err := ng.DecreaseTargetSize(context.Background(), -1)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, ng.targetSize, "target size not updated")
 	})
 
 	// Test positive decrease
 	t.Run("positive decrease", func(t *testing.T) {
-		err := ng.DecreaseTargetSize(1)
+		err := ng.DecreaseTargetSize(context.Background(), 1)
 		assert.Error(t, err)
 		assert.Equal(t, "size decrease must be negative", err.Error())
 	})
 
 	// Test zero decrease
 	t.Run("zero decrease", func(t *testing.T) {
-		err := ng.DecreaseTargetSize(0)
+		err := ng.DecreaseTargetSize(context.Background(), 0)
 		assert.Error(t, err)
 		assert.Equal(t, "size decrease must be negative", err.Error())
 	})
@@ -172,7 +173,7 @@ func TestDecreaseSize(t *testing.T) {
 	// Test decrease too large
 	t.Run("decrease too large", func(t *testing.T) {
 		ng.targetSize = 3
-		err := ng.DecreaseTargetSize(-4)
+		err := ng.DecreaseTargetSize(context.Background(), -4)
 		assert.Error(t, err)
 		assert.Equal(t, "size decrease too large, desired:-1 min:1", err.Error())
 	})
@@ -181,7 +182,7 @@ func TestDecreaseSize(t *testing.T) {
 	t.Run("update node count fails", func(t *testing.T) {
 		ng.targetSize = 3
 		manager.On("updateNodeCount", testNodeGroupUUID, 2).Return(errors.New("manager error")).Once()
-		err := ng.DecreaseTargetSize(-1)
+		err := ng.DecreaseTargetSize(context.Background(), -1)
 		assert.Error(t, err)
 		assert.Equal(t, "could not decrease target size: manager error", err.Error())
 	})
@@ -241,7 +242,7 @@ func TestDeleteNodes(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		ng.targetSize = 10
 		manager.On("deleteNodes", testNodeGroupUUID, nodeRefs, 5).Return(nil).Once()
-		err := ng.DeleteNodes(nodesToDelete)
+		err := ng.DeleteNodes(context.Background(), nodesToDelete)
 		assert.NoError(t, err)
 		assert.Equal(t, 5, ng.targetSize)
 	})
@@ -250,7 +251,7 @@ func TestDeleteNodes(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		ng.targetSize = 10
 		manager.On("deleteNodes", testNodeGroupUUID, nodeRefs, 5).Return(errors.New("manager error")).Once()
-		err := ng.DeleteNodes(nodesToDelete)
+		err := ng.DeleteNodes(context.Background(), nodesToDelete)
 		assert.Error(t, err)
 		assert.Equal(t, "manager error deleting nodes: manager error", err.Error())
 	})
@@ -294,7 +295,7 @@ func TestNodes(t *testing.T) {
 	}
 
 	manager.On("deleteNodes", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	err := ng.DeleteNodes(nodesToDelete)
+	err := ng.DeleteNodes(context.Background(), nodesToDelete)
 	require.NoError(t, err)
 
 	allNodes := append(runningNodes, deletingNodes...)
@@ -302,7 +303,7 @@ func TestNodes(t *testing.T) {
 
 	manager.On("getNodes", testNodeGroupUUID).Return(allNodes, nil).Once()
 
-	nodes, err := ng.Nodes()
+	nodes, err := ng.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expectedNodes, nodes)
 
@@ -315,7 +316,7 @@ func TestNodes(t *testing.T) {
 
 	manager.On("getNodes", testNodeGroupUUID).Return(runningNodes, nil).Once()
 
-	nodes, err = ng.Nodes()
+	nodes, err = ng.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, runningNodes, nodes)
 	assert.Equalf(t, 0, len(ng.deletedNodes), "node group deletedNodes map was not cleaned")

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_cloud_provider.go
@@ -5,6 +5,7 @@ Copyright 2021-2023 Oracle and/or its affiliates.
 package instancepools
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -52,7 +53,7 @@ func (ocp *OciCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (ocp *OciCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (ocp *OciCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodePools := ocp.poolManager.GetInstancePools()
 	result := make([]cloudprovider.NodeGroup, 0, len(nodePools))
 	for _, nodePool := range nodePools {
@@ -64,7 +65,7 @@ func (ocp *OciCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (ocp *OciCloudProvider) NodeGroupForNode(n *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (ocp *OciCloudProvider) NodeGroupForNode(ctx context.Context, n *apiv1.Node) (cloudprovider.NodeGroup, error) {
 
 	ociRef, err := ocicommon.NodeToOciRef(n)
 	if err != nil {
@@ -91,7 +92,7 @@ func (ocp *OciCloudProvider) NodeGroupForNode(n *apiv1.Node) (cloudprovider.Node
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (ocp *OciCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (ocp *OciCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	instance, err := ocicommon.NodeToOciRef(node)
 	if err != nil {
 		klog.V(4).Infof("HasInstance: ref conversion for node %s failed: %v", node.Name, err)
@@ -113,14 +114,14 @@ func (ocp *OciCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (ocp *OciCloudProvider) Pricing() (cloudprovider.PricingModel, caerrors.AutoscalerError) {
+func (ocp *OciCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, caerrors.AutoscalerError) {
 	klog.Info("Pricing called")
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes getInstancePool all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (ocp *OciCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (ocp *OciCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	klog.Info("GetAvailableMachineTypes called")
 	return nil, cloudprovider.ErrNotImplemented
 }
@@ -128,7 +129,7 @@ func (ocp *OciCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (ocp *OciCloudProvider) NewNodeGroup(machineType string,
+func (ocp *OciCloudProvider) NewNodeGroup(ctx context.Context, machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
 	taints []apiv1.Taint,
@@ -138,35 +139,35 @@ func (ocp *OciCloudProvider) NewNodeGroup(machineType string,
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (ocp *OciCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (ocp *OciCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return ocp.rl, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (ocp *OciCloudProvider) GPULabel() string {
+func (ocp *OciCloudProvider) GPULabel(ctx context.Context) string {
 	// No labels, only taint: nvidia.com/gpu:NoSchedule
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (ocp *OciCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (ocp *OciCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return map[string]struct{}{}
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (ocp *OciCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(ocp, node)
+func (ocp *OciCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), ocp, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (ocp *OciCloudProvider) Cleanup() error {
+func (ocp *OciCloudProvider) Cleanup(ctx context.Context) error {
 	return ocp.poolManager.Cleanup()
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (ocp *OciCloudProvider) Refresh() error {
+func (ocp *OciCloudProvider) Refresh(ctx context.Context) error {
 	return ocp.poolManager.Refresh()
 }
 

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
@@ -69,8 +69,8 @@ func (ip *InstancePoolNodeGroup) IncreaseSize(ctx context.Context, delta int) er
 		return err
 	}
 
-	if size+delta > ip.MaxSize(context.Background()) {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", size+delta, ip.MaxSize(context.Background()))
+	if size+delta > ip.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", size+delta, ip.MaxSize(context.TODO()))
 	}
 
 	return ip.manager.SetInstancePoolSize(*ip, size+delta)
@@ -117,7 +117,7 @@ func (ip *InstancePoolNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1
 		return err
 	}
 
-	if size <= ip.MinSize(context.Background()) {
+	if size <= ip.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
@@ -187,7 +187,7 @@ func (ip *InstancePoolNodeGroup) Id() string {
 
 // Debug returns a string containing all information regarding this instance-pool.
 func (ip *InstancePoolNodeGroup) Debug(ctx context.Context) string {
-	return fmt.Sprintf("%s (%d:%d)", ip.Id(), ip.MinSize(context.Background()), ip.MaxSize(context.Background()))
+	return fmt.Sprintf("%s (%d:%d)", ip.Id(), ip.MinSize(context.TODO()), ip.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this instance-pool.

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
@@ -5,6 +5,7 @@ Copyright 2021-2023 Oracle and/or its affiliates.
 package instancepools
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -38,12 +39,12 @@ type nodeGroupAutoDiscovery struct {
 }
 
 // MaxSize returns maximum size of the instance-pool based node group.
-func (ip *InstancePoolNodeGroup) MaxSize() int {
+func (ip *InstancePoolNodeGroup) MaxSize(ctx context.Context) int {
 	return ip.maxSize
 }
 
 // MinSize returns minimum size of the instance-pool based node group.
-func (ip *InstancePoolNodeGroup) MinSize() int {
+func (ip *InstancePoolNodeGroup) MinSize(ctx context.Context) int {
 	return ip.minSize
 }
 
@@ -51,14 +52,14 @@ func (ip *InstancePoolNodeGroup) MinSize() int {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (ip *InstancePoolNodeGroup) TargetSize() (int, error) {
+func (ip *InstancePoolNodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return ip.manager.GetInstancePoolSize(*ip)
 }
 
 // IncreaseSize increases the size of the instance-pool based node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // instance-pool size is updated. Implementation required.
-func (ip *InstancePoolNodeGroup) IncreaseSize(delta int) error {
+func (ip *InstancePoolNodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -68,15 +69,15 @@ func (ip *InstancePoolNodeGroup) IncreaseSize(delta int) error {
 		return err
 	}
 
-	if size+delta > ip.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", size+delta, ip.MaxSize())
+	if size+delta > ip.MaxSize(context.Background()) {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", size+delta, ip.MaxSize(context.Background()))
 	}
 
 	return ip.manager.SetInstancePoolSize(*ip, size+delta)
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ip *InstancePoolNodeGroup) AtomicIncreaseSize(delta int) error {
+func (ip *InstancePoolNodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -106,7 +107,7 @@ func (ip *InstancePoolNodeGroup) deleteNodes(nodes []*apiv1.Node) error {
 // DeleteNodes deletes nodes from this instance-pool. Error is returned either on
 // failure or if the given node doesn't belong to this instance-pool. This function
 // should wait until instance-pool size is updated. Implementation required.
-func (ip *InstancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ip *InstancePoolNodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	// FYI, unregistered nodes come in as the provider id as node name.
 
 	klog.Infof("DeleteNodes called with %d node(s)", len(nodes))
@@ -116,7 +117,7 @@ func (ip *InstancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		return err
 	}
 
-	if size <= ip.MinSize() {
+	if size <= ip.MinSize(context.Background()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
@@ -124,7 +125,7 @@ func (ip *InstancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ip *InstancePoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ip *InstancePoolNodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	// FYI, unregistered nodes come in as the provider id as node name.
 
 	klog.Infof("ForceDeleteNodes called with %d node(s) (ignoring min size constraint)", len(nodes))
@@ -137,7 +138,7 @@ func (ip *InstancePoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (ip *InstancePoolNodeGroup) DecreaseTargetSize(delta int) error {
+func (ip *InstancePoolNodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
@@ -185,15 +186,15 @@ func (ip *InstancePoolNodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this instance-pool.
-func (ip *InstancePoolNodeGroup) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", ip.Id(), ip.MinSize(), ip.MaxSize())
+func (ip *InstancePoolNodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", ip.Id(), ip.MinSize(context.Background()), ip.MaxSize(context.Background()))
 }
 
 // Nodes returns a list of all nodes that belong to this instance-pool.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (ip *InstancePoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ip *InstancePoolNodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	return ip.manager.GetInstancePoolNodes(*ip)
 }
 
@@ -203,7 +204,7 @@ func (ip *InstancePoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (ip *InstancePoolNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ip *InstancePoolNodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	node, err := ip.manager.GetInstancePoolTemplateNode(*ip)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to build node info template")
@@ -219,30 +220,30 @@ func (ip *InstancePoolNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error)
 
 // Exist checks if the instance-pool based node group really exists on the cloud provider side. Allows to tell the
 // theoretical instance-pool from the real one. Implementation required.
-func (ip *InstancePoolNodeGroup) Exist() bool {
+func (ip *InstancePoolNodeGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the instance-pool based node group on the cloud provider side. Implementation optional.
-func (ip *InstancePoolNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ip *InstancePoolNodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the instance-pool based node group on the cloud provider side.
 // This will be executed only for autoprovisioned instance-pools, once their size drops to 0.
 // Implementation optional.
-func (ip *InstancePoolNodeGroup) Delete() error {
+func (ip *InstancePoolNodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // InstancePoolNodeGroup. Returning a nil will result in using default options.
-func (ip *InstancePoolNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ip *InstancePoolNodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the instance-pool based node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (ip *InstancePoolNodeGroup) Autoprovisioned() bool {
+func (ip *InstancePoolNodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager.go
@@ -398,9 +398,9 @@ func (m *InstancePoolManagerImpl) forceRefresh() error {
 
 		for instancePoolId, instancePool := range m.staticInstancePools {
 			if _, ok := staticInstancePoolsCopy[instancePoolId]; !ok {
-				klog.Infof("New instance pool discovered. [id: %s, minSize: %d, maxSize: %d]", instancePool.Id(), instancePool.MinSize(), instancePool.MaxSize())
-			} else if staticInstancePoolsCopy[instancePoolId].MinSize() != instancePool.MinSize() || staticInstancePoolsCopy[instancePoolId].MaxSize() != instancePool.MaxSize() {
-				klog.Infof("Instance pool min/max sizes are updated. [id: %s, minSize: %d, maxSize: %d]", instancePool.Id(), instancePool.MinSize(), instancePool.MaxSize())
+				klog.Infof("New instance pool discovered. [id: %s, minSize: %d, maxSize: %d]", instancePool.Id(), instancePool.MinSize(context.TODO()), instancePool.MaxSize(context.TODO()))
+			} else if staticInstancePoolsCopy[instancePoolId].MinSize(context.TODO()) != instancePool.MinSize(context.TODO()) || staticInstancePoolsCopy[instancePoolId].MaxSize(context.TODO()) != instancePool.MaxSize(context.TODO()) {
+				klog.Infof("Instance pool min/max sizes are updated. [id: %s, minSize: %d, maxSize: %d]", instancePool.Id(), instancePool.MinSize(context.TODO()), instancePool.MaxSize(context.TODO()))
 			}
 		}
 

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_cloud_provider.go
@@ -5,6 +5,9 @@ Copyright 2020-2023 Oracle and/or its affiliates.
 package nodepools
 
 import (
+	"context"
+	"strings"
+
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -14,7 +17,6 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
 	caerrors "sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/gpu"
-	"strings"
 )
 
 // ProviderName is the cloud provider name for this provider.
@@ -40,7 +42,7 @@ func (ocp *OciCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (ocp *OciCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (ocp *OciCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodePools := ocp.manager.GetNodePools()
 	result := make([]cloudprovider.NodeGroup, 0, len(nodePools))
 	for _, nodePool := range nodePools {
@@ -52,7 +54,7 @@ func (ocp *OciCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (ocp *OciCloudProvider) NodeGroupForNode(n *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (ocp *OciCloudProvider) NodeGroupForNode(ctx context.Context, n *apiv1.Node) (cloudprovider.NodeGroup, error) {
 
 	ociRef, err := ocicommon.NodeToOciRef(n)
 	if err != nil {
@@ -80,12 +82,12 @@ func (ocp *OciCloudProvider) NodeGroupForNode(n *apiv1.Node) (cloudprovider.Node
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (ocp *OciCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(ocp, node)
+func (ocp *OciCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), ocp, node)
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (ocp *OciCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (ocp *OciCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	instance, err := ocicommon.NodeToOciRef(node)
 	if err != nil {
 		return true, err
@@ -115,14 +117,14 @@ func (ocp *OciCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (ocp *OciCloudProvider) Pricing() (cloudprovider.PricingModel, caerrors.AutoscalerError) {
+func (ocp *OciCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, caerrors.AutoscalerError) {
 	klog.Info("Pricing called")
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (ocp *OciCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (ocp *OciCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	klog.Info("GetAvailableMachineTypes called")
 	return nil, cloudprovider.ErrNotImplemented
 }
@@ -130,7 +132,7 @@ func (ocp *OciCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (ocp *OciCloudProvider) NewNodeGroup(machineType string,
+func (ocp *OciCloudProvider) NewNodeGroup(ctx context.Context, machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
 	taints []apiv1.Taint,
@@ -140,27 +142,27 @@ func (ocp *OciCloudProvider) NewNodeGroup(machineType string,
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (ocp *OciCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (ocp *OciCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return ocp.rl, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (ocp *OciCloudProvider) GPULabel() string {
+func (ocp *OciCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (ocp *OciCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (ocp *OciCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return map[string]struct{}{}
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (ocp *OciCloudProvider) Cleanup() error {
+func (ocp *OciCloudProvider) Cleanup(ctx context.Context) error {
 	return ocp.manager.Cleanup()
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (ocp *OciCloudProvider) Refresh() error {
+func (ocp *OciCloudProvider) Refresh(ctx context.Context) error {
 	return ocp.manager.Refresh()
 }

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -430,9 +430,9 @@ func (m *ociManagerImpl) forceRefresh() error {
 		// compare the new and previous nodepool list to log the updates
 		for nodepoolId, nodepool := range m.staticNodePools {
 			if _, ok := staticNodePoolsCopy[nodepoolId]; !ok {
-				klog.Infof("New nodepool discovered. [id: %s ,minSize: %d, maxSize:%d]", nodepool.Id(), nodepool.MinSize(), nodepool.MaxSize())
-			} else if staticNodePoolsCopy[nodepoolId].MinSize() != nodepool.MinSize() || staticNodePoolsCopy[nodepoolId].MaxSize() != nodepool.MaxSize() {
-				klog.Infof("Nodepool min/max sizes are updated. [id: %s ,minSize: %d, maxSize:%d]", nodepool.Id(), nodepool.MinSize(), nodepool.MaxSize())
+				klog.Infof("New nodepool discovered. [id: %s ,minSize: %d, maxSize:%d]", nodepool.Id(), nodepool.MinSize(context.TODO()), nodepool.MaxSize(context.TODO()))
+			} else if staticNodePoolsCopy[nodepoolId].MinSize(context.TODO()) != nodepool.MinSize(context.TODO()) || staticNodePoolsCopy[nodepoolId].MaxSize(context.TODO()) != nodepool.MaxSize(context.TODO()) {
+				klog.Infof("Nodepool min/max sizes are updated. [id: %s ,minSize: %d, maxSize:%d]", nodepool.Id(), nodepool.MinSize(context.TODO()), nodepool.MaxSize(context.TODO()))
 			}
 		}
 

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
@@ -5,6 +5,7 @@ Copyright 2020-2023 Oracle and/or its affiliates.
 package nodepools
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -56,12 +57,12 @@ type nodeGroupAutoDiscovery struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (np *nodePool) MaxSize() int {
+func (np *nodePool) MaxSize(ctx context.Context) int {
 	return np.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (np *nodePool) MinSize() int {
+func (np *nodePool) MinSize(ctx context.Context) int {
 	return np.minSize
 }
 
@@ -91,14 +92,14 @@ var retryableKubeError = func(err error) bool {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (np *nodePool) TargetSize() (int, error) {
+func (np *nodePool) TargetSize(ctx context.Context) (int, error) {
 	return np.manager.GetNodePoolSize(np)
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (np *nodePool) IncreaseSize(delta int) error {
+func (np *nodePool) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -110,15 +111,15 @@ func (np *nodePool) IncreaseSize(delta int) error {
 		return err
 	}
 
-	if size+delta > np.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, np.MaxSize())
+	if size+delta > np.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, np.MaxSize(context.TODO()))
 	}
 
 	return np.manager.SetNodePoolSize(np, size+delta)
 }
 
 // AtomicIncreaseSize is not implemented.
-func (np *nodePool) AtomicIncreaseSize(delta int) error {
+func (np *nodePool) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -168,7 +169,7 @@ func (np *nodePool) deleteNodes(nodes []*apiv1.Node) error {
 	}
 	if nodesWithoutInstanceID > 0 {
 		klog.Warningf("%d node(s) in node pool %s have no instance ID. Falling back to DecreaseTargetSize to clean up failed node creation.", nodesWithoutInstanceID, np.Id())
-		return np.DecreaseTargetSize(-nodesWithoutInstanceID)
+		return np.DecreaseTargetSize(context.TODO(), -nodesWithoutInstanceID)
 	}
 
 	return nil
@@ -177,7 +178,7 @@ func (np *nodePool) deleteNodes(nodes []*apiv1.Node) error {
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (np *nodePool) DeleteNodes(nodes []*apiv1.Node) (err error) {
+func (np *nodePool) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) (err error) {
 	// Unregistered nodes come in as the provider id as node name.
 
 	// although technically we only need the mutex around the api calls, we should wrap the mutex
@@ -194,7 +195,7 @@ func (np *nodePool) DeleteNodes(nodes []*apiv1.Node) (err error) {
 	}
 
 	klog.Infof("Nodepool %s has size %d", np.id, size)
-	if int(size) <= np.MinSize() {
+	if int(size) <= np.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
@@ -202,7 +203,7 @@ func (np *nodePool) DeleteNodes(nodes []*apiv1.Node) (err error) {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (np *nodePool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (np *nodePool) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	// Unregistered nodes come in as the provider id as node name.
 
 	// although technically we only need the mutex around the api calls, we should wrap the mutex
@@ -221,7 +222,7 @@ func (np *nodePool) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (np *nodePool) DecreaseTargetSize(delta int) error {
+func (np *nodePool) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
@@ -310,15 +311,15 @@ func (np *nodePool) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (np *nodePool) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", np.Id(), np.MinSize(), np.MaxSize())
+func (np *nodePool) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", np.Id(), np.MinSize(context.TODO()), np.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (np *nodePool) Nodes() ([]cloudprovider.Instance, error) {
+func (np *nodePool) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	return np.manager.GetNodePoolNodes(np)
 }
 
@@ -328,7 +329,7 @@ func (np *nodePool) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (np *nodePool) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (np *nodePool) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	node, err := np.manager.GetNodePoolTemplateNode(np)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to build node pool template")
@@ -345,31 +346,31 @@ func (np *nodePool) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (np *nodePool) Exist() bool {
+func (np *nodePool) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (np *nodePool) Create() (cloudprovider.NodeGroup, error) {
+func (np *nodePool) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (np *nodePool) Delete() error {
+func (np *nodePool) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (np *nodePool) Autoprovisioned() bool {
+func (np *nodePool) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 // Implementation optional.
-func (np *nodePool) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (np *nodePool) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool_test.go
@@ -49,7 +49,7 @@ func TestDeletePastMinSize(t *testing.T) {
 		}
 		nodesToDelete = append(nodesToDelete, node)
 	}
-	err := np.DeleteNodes(nodesToDelete)
+	err := np.DeleteNodes(context.Background(), nodesToDelete)
 	if err == nil {
 		t.Fatalf("expected to have an error because node pool is at the min size")
 	}
@@ -92,7 +92,7 @@ func TestDeleteCreateErrorNodeWithoutInstanceIDDecreasesTargetSize(t *testing.T)
 		},
 	}
 
-	if err := np.DeleteNodes([]*apiv1.Node{nodeWithoutInstanceID}); err != nil {
+	if err := np.DeleteNodes(context.Background(), []*apiv1.Node{nodeWithoutInstanceID}); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if manager.deleteInstancesCalled != 0 {
@@ -172,7 +172,7 @@ func (m *mockManager) GetNodePoolSize(np NodePool) (int, error) {
 	if m.size != 0 {
 		return m.size, nil
 	}
-	return np.MinSize() + 1, nil
+	return np.MinSize(context.Background()) + 1, nil
 }
 
 func (m *mockManager) SetNodePoolSize(np NodePool, size int) error {

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -49,18 +49,18 @@ type NodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node pool.
-func (ng *NodeGroup) MaxSize() int {
+func (ng *NodeGroup) MaxSize(ctx context.Context) int {
 	return int(ng.MaxNodes)
 }
 
 // MinSize returns minimum size of the node pool.
-func (ng *NodeGroup) MinSize() int {
+func (ng *NodeGroup) MinSize(ctx context.Context) int {
 	return int(ng.MinNodes)
 }
 
 // TargetSize returns the current TARGET size of the node pool. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (ng *NodeGroup) TargetSize() (int, error) {
+func (ng *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	// By default, fetch the API desired nodes before using target size from autoscaler
 	if ng.CurrentSize == -1 {
 		return int(ng.DesiredNodes), nil
@@ -70,7 +70,7 @@ func (ng *NodeGroup) TargetSize() (int, error) {
 }
 
 // IncreaseSize increases node pool size.
-func (ng *NodeGroup) IncreaseSize(delta int) error {
+func (ng *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	// Do not use node group which does not support autoscaling
 	if !ng.Autoscale {
 		return nil
@@ -83,13 +83,13 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 		return fmt.Errorf("increase size node group delta must be positive")
 	}
 
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.TODO())
 	if err != nil {
 		return fmt.Errorf("failed to get NodeGroup target size")
 	}
 
-	if size+delta > ng.MaxSize() {
-		return fmt.Errorf("node group size would be above minimum size - desired: %d, max: %d", size+delta, ng.MaxSize())
+	if size+delta > ng.MaxSize(context.TODO()) {
+		return fmt.Errorf("node group size would be above minimum size - desired: %d, max: %d", size+delta, ng.MaxSize(context.TODO()))
 	}
 
 	// Then, forge current size and parameters
@@ -112,12 +112,12 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ng *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	// DeleteNodes is called in goroutine so it can run in parallel
 	// Goroutines created in: ScaleDown.scheduleDeleteEmptyNodes()
 	// Adding mutex to ensure CurrentSize attribute keeps consistency
@@ -132,13 +132,13 @@ func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	klog.V(4).Infof("Deleting %d node(s)", len(nodes))
 
 	// First, verify the NodeGroup can be decreased
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.TODO())
 	if err != nil {
 		return fmt.Errorf("failed to get NodeGroup target size")
 	}
 
-	if size-len(nodes) < ng.MinSize() {
-		return fmt.Errorf("node group size would be below minimum size - desired: %d, max: %d", size-len(nodes), ng.MinSize())
+	if size-len(nodes) < ng.MinSize(context.TODO()) {
+		return fmt.Errorf("node group size would be below minimum size - desired: %d, max: %d", size-len(nodes), ng.MinSize(context.TODO()))
 	}
 
 	nodeProviderIds := make([]string, 0)
@@ -167,7 +167,7 @@ func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ng *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ng *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -176,7 +176,7 @@ func (ng *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes if the size
 // when there is an option to just decrease the target.
-func (ng *NodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	// Cancellation of node provisioning is not supported yet
 	return cloudprovider.ErrNotImplemented
 }
@@ -187,13 +187,13 @@ func (ng *NodeGroup) Id() string {
 }
 
 // Debug returns a debug string for the NodeGroup.
-func (ng *NodeGroup) Debug() string {
+func (ng *NodeGroup) Debug(ctx context.Context) string {
 	// Printing name (target size - min size - max size)
-	return fmt.Sprintf("%s (%d:%d:%d)", ng.Id(), ng.CurrentSize, ng.MinSize(), ng.MaxSize())
+	return fmt.Sprintf("%s (%d:%d:%d)", ng.Id(), ng.CurrentSize, ng.MinSize(context.TODO()), ng.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (ng *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	// Fetch all nodes contained in the node group
 	nodes, err := ng.Manager.Client.ListNodePoolNodes(context.Background(), ng.Manager.ProjectID, ng.Manager.ClusterID, ng.ID)
 	if err != nil {
@@ -220,7 +220,7 @@ func (ng *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (ng *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	// Forge node template in a node group
 	node := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -263,19 +263,19 @@ func (ng *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (ng *NodeGroup) Exist() bool {
+func (ng *NodeGroup) Exist(ctx context.Context) bool {
 	return ng.Id() != ""
 }
 
 // Create creates the node group on the cloud provider side.
-func (ng *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	klog.V(4).Info("Creating a new NodeGroup")
 
 	// Forge create node pool parameters (defaulting b2-7 for now)
 	name := ng.Id()
 	size := uint32(ng.CurrentSize)
-	min := uint32(ng.MinSize())
-	max := uint32(ng.MaxSize())
+	min := uint32(ng.MinSize(context.TODO()))
+	max := uint32(ng.MaxSize(context.TODO()))
 
 	opts := sdk.CreateNodePoolOpts{
 		FlavorName:   "b2-7",
@@ -302,7 +302,7 @@ func (ng *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (ng *NodeGroup) Delete() error {
+func (ng *NodeGroup) Delete(ctx context.Context) error {
 	klog.V(4).Infof("Deleting NodeGroup %s", ng.Id())
 
 	// Call API to delete the node pool given its project and cluster
@@ -315,14 +315,14 @@ func (ng *NodeGroup) Delete() error {
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (ng *NodeGroup) Autoprovisioned() bool {
+func (ng *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	// This is not handled yet.
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (ng *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	// If node group autoscaling options nil, return defaults
 	if ng.Autoscaling == nil {
 		return nil, nil

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
@@ -197,7 +197,7 @@ func TestOVHCloudNodeGroup_MaxSize(t *testing.T) {
 	ng := newTestNodeGroup(t, "b2-7")
 
 	t.Run("check default node group max size", func(t *testing.T) {
-		max := ng.MaxSize()
+		max := ng.MaxSize(context.Background())
 
 		assert.Equal(t, 5, max)
 	})
@@ -207,7 +207,7 @@ func TestOVHCloudNodeGroup_MinSize(t *testing.T) {
 	ng := newTestNodeGroup(t, "b2-7")
 
 	t.Run("check default node group min size", func(t *testing.T) {
-		min := ng.MinSize()
+		min := ng.MinSize(context.Background())
 
 		assert.Equal(t, 1, min)
 	})
@@ -217,7 +217,7 @@ func TestOVHCloudNodeGroup_TargetSize(t *testing.T) {
 	ng := newTestNodeGroup(t, "b2-7")
 
 	t.Run("check default node group target size", func(t *testing.T) {
-		targetSize, err := ng.TargetSize()
+		targetSize, err := ng.TargetSize(context.Background())
 		assert.NoError(t, err)
 
 		assert.Equal(t, 3, targetSize)
@@ -230,22 +230,22 @@ func TestOVHCloudNodeGroup_IncreaseSize(t *testing.T) {
 	t.Run("check increase size below max size", func(t *testing.T) {
 		ng.mockCallUpdateNodePool(4, nil)
 
-		err := ng.IncreaseSize(1)
+		err := ng.IncreaseSize(context.Background(), 1)
 		assert.NoError(t, err)
 
-		targetSize, err := ng.TargetSize()
+		targetSize, err := ng.TargetSize(context.Background())
 		assert.NoError(t, err)
 
 		assert.Equal(t, 4, targetSize)
 	})
 
 	t.Run("check increase size above max size", func(t *testing.T) {
-		err := ng.IncreaseSize(5)
+		err := ng.IncreaseSize(context.Background(), 5)
 		assert.Error(t, err)
 	})
 
 	t.Run("check increase size with negative delta", func(t *testing.T) {
-		err := ng.IncreaseSize(-1)
+		err := ng.IncreaseSize(context.Background(), -1)
 		assert.Error(t, err)
 	})
 }
@@ -256,7 +256,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 	t.Run("check delete nodes above min size", func(t *testing.T) {
 		ng.mockCallUpdateNodePool(2, []string{"openstack:///instance-1"})
 
-		err := ng.DeleteNodes([]*v1.Node{
+		err := ng.DeleteNodes(context.Background(), []*v1.Node{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-1",
@@ -271,7 +271,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		targetSize, err := ng.TargetSize()
+		targetSize, err := ng.TargetSize(context.Background())
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, targetSize)
@@ -280,17 +280,17 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 	t.Run("check delete nodes empty nodes array", func(t *testing.T) {
 		ng.mockCallUpdateNodePool(2, []string{})
 
-		err := ng.DeleteNodes(nil)
+		err := ng.DeleteNodes(context.Background(), nil)
 		assert.NoError(t, err)
 
-		targetSize, err := ng.TargetSize()
+		targetSize, err := ng.TargetSize(context.Background())
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, targetSize)
 	})
 
 	t.Run("check delete nodes below min size", func(t *testing.T) {
-		err := ng.DeleteNodes([]*v1.Node{
+		err := ng.DeleteNodes(context.Background(), []*v1.Node{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-1",
@@ -322,7 +322,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 
 func TestOVHCloudNodeGroup_DecreaseTargetSize(t *testing.T) {
 	ng := newTestNodeGroup(t, "b2-7")
-	err := ng.DecreaseTargetSize(-1)
+	err := ng.DecreaseTargetSize(context.Background(), -1)
 	assert.Error(t, err)
 }
 
@@ -340,7 +340,7 @@ func TestOVHCloudNodeGroup_Debug(t *testing.T) {
 	ng := newTestNodeGroup(t, "b2-7")
 
 	t.Run("check node group debug print", func(t *testing.T) {
-		debug := ng.Debug()
+		debug := ng.Debug(context.Background())
 
 		assert.Equal(t, "pool-b2-7 (3:1:5)", debug)
 	})
@@ -352,7 +352,7 @@ func TestOVHCloudNodeGroup_Nodes(t *testing.T) {
 	t.Run("check nodes list in node group", func(t *testing.T) {
 		ng.mockCallListNodePoolNodes()
 
-		nodes, err := ng.Nodes()
+		nodes, err := ng.Nodes(context.Background())
 		assert.NoError(t, err)
 
 		assert.Equal(t, 3, len(nodes))
@@ -372,7 +372,7 @@ func TestOVHCloudNodeGroup_Nodes(t *testing.T) {
 func TestOVHCloudNodeGroup_TemplateNodeInfo(t *testing.T) {
 	t.Run("template for b2-7 flavor", func(t *testing.T) {
 		ng := newTestNodeGroup(t, "b2-7")
-		template, err := ng.TemplateNodeInfo()
+		template, err := ng.TemplateNodeInfo(context.Background())
 		assert.NoError(t, err)
 
 		node := template.Node()
@@ -392,7 +392,7 @@ func TestOVHCloudNodeGroup_TemplateNodeInfo(t *testing.T) {
 
 	t.Run("template for t1-45 flavor", func(t *testing.T) {
 		ng := newTestNodeGroup(t, "t1-45")
-		template, err := ng.TemplateNodeInfo()
+		template, err := ng.TemplateNodeInfo(context.Background())
 		assert.NoError(t, err)
 
 		node := template.Node()
@@ -431,7 +431,7 @@ func TestOVHCloudNodeGroup_TemplateNodeInfo(t *testing.T) {
 			},
 		}
 
-		template, err := ng.TemplateNodeInfo()
+		template, err := ng.TemplateNodeInfo(context.Background())
 		assert.NoError(t, err)
 
 		node := template.Node()
@@ -454,7 +454,7 @@ func TestOVHCloudNodeGroup_Exist(t *testing.T) {
 	ng := newTestNodeGroup(t, "b2-7")
 
 	t.Run("check exist is true", func(t *testing.T) {
-		exist := ng.Exist()
+		exist := ng.Exist(context.Background())
 
 		assert.True(t, exist)
 	})
@@ -466,16 +466,16 @@ func TestOVHCloudNodeGroup_Create(t *testing.T) {
 	t.Run("check create node group", func(t *testing.T) {
 		ng.mockCallCreateNodePool()
 
-		newGroup, err := ng.Create()
+		newGroup, err := ng.Create(context.Background())
 		assert.NoError(t, err)
 
-		targetSize, err := newGroup.TargetSize()
+		targetSize, err := newGroup.TargetSize(context.Background())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "pool-b2-7", newGroup.Id())
 		assert.Equal(t, 3, targetSize)
-		assert.Equal(t, 1, newGroup.MinSize())
-		assert.Equal(t, 5, newGroup.MaxSize())
+		assert.Equal(t, 1, newGroup.MinSize(context.Background()))
+		assert.Equal(t, 5, newGroup.MaxSize(context.Background()))
 	})
 }
 
@@ -485,7 +485,7 @@ func TestOVHCloudNodeGroup_Delete(t *testing.T) {
 	t.Run("check delete node group", func(t *testing.T) {
 		ng.mockCallDeleteNodePool()
 
-		err := ng.Delete()
+		err := ng.Delete(context.Background())
 		assert.NoError(t, err)
 	})
 }
@@ -494,7 +494,7 @@ func TestOVHCloudNodeGroup_Autoprovisioned(t *testing.T) {
 	ng := newTestNodeGroup(t, "b2-7")
 
 	t.Run("check auto-provisioned is false", func(t *testing.T) {
-		provisioned := ng.Autoprovisioned()
+		provisioned := ng.Autoprovisioned(context.Background())
 		assert.False(t, provisioned)
 	})
 }
@@ -530,7 +530,7 @@ func TestOVHCloudNodeGroup_IsGpu(t *testing.T) {
 func TestOVHCloudNodeGroup_GetOptions(t *testing.T) {
 	t.Run("check get autoscaling options", func(t *testing.T) {
 		ng := newTestNodeGroup(t, "b2-7")
-		opts, err := ng.GetOptions(config.NodeGroupAutoscalingOptions{})
+		opts, err := ng.GetOptions(context.Background(), config.NodeGroupAutoscalingOptions{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("%.1f", 3.2), fmt.Sprintf("%.1f", opts.ScaleDownUtilizationThreshold))
@@ -541,7 +541,7 @@ func TestOVHCloudNodeGroup_GetOptions(t *testing.T) {
 
 	t.Run("check get autoscaling options on gpu machine", func(t *testing.T) {
 		ng := newTestNodeGroup(t, "t1-45")
-		opts, err := ng.GetOptions(config.NodeGroupAutoscalingOptions{})
+		opts, err := ng.GetOptions(context.Background(), config.NodeGroupAutoscalingOptions{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, float64(0), opts.ScaleDownUtilizationThreshold)

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
@@ -109,7 +109,7 @@ func (provider *OVHCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (provider *OVHCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (provider *OVHCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	groups := make([]cloudprovider.NodeGroup, 0)
 
 	// Cast API node pools into CA node groups
@@ -135,7 +135,7 @@ func (provider *OVHCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (provider *OVHCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (provider *OVHCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	// If the provider ID is empty (only the prefix), it means that we are processing an UnregisteredNode retrieved
 	// from OVHCloud APIs, which has just started being created, and the OpenStack instance ID is not yet set.
 	// We won't be able to determine the node group of the node with the information at hand.
@@ -166,7 +166,7 @@ func (provider *OVHCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovi
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (provider *OVHCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (provider *OVHCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
@@ -189,7 +189,7 @@ func (provider *OVHCloudProvider) findNodeGroupFromLabel(node *apiv1.Node) cloud
 	}
 
 	// Find in the node groups stored in cache the one with the same name
-	for _, ng := range provider.NodeGroups() {
+	for _, ng := range provider.NodeGroups(context.TODO()) {
 		if ng.Id() == label {
 			return ng
 		}
@@ -200,9 +200,9 @@ func (provider *OVHCloudProvider) findNodeGroupFromLabel(node *apiv1.Node) cloud
 
 // findNodeGroupByListingNodes finds the associated node group from by listing all nodes under autoscaled node pools
 func (provider *OVHCloudProvider) findNodeGroupByListingNodes(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
-	for _, ng := range provider.NodeGroups() {
+	for _, ng := range provider.NodeGroups(context.TODO()) {
 		// This calls OVHCloud APIs and refreshes the cache
-		instances, err := ng.Nodes()
+		instances, err := ng.Nodes(context.TODO())
 		if err != nil {
 			return nil, fmt.Errorf("failed to list nodes in node group %s: %w", ng.Id(), err)
 		}
@@ -219,14 +219,14 @@ func (provider *OVHCloudProvider) findNodeGroupByListingNodes(node *apiv1.Node) 
 
 // Pricing returns pricing model for this cloud provider or error if not
 // available. Implementation optional.
-func (provider *OVHCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (provider *OVHCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	// This is not implemented in API
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from
 // the cloud provider. Implementation optional.
-func (provider *OVHCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (provider *OVHCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	klog.V(4).Info("Getting available machine types")
 
 	flavorsByName, err := provider.manager.getFlavorsByName()
@@ -249,7 +249,7 @@ func (provider *OVHCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // provided. The node group is not automatically created on the cloud provider
 // side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (provider *OVHCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (provider *OVHCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	ng := &NodeGroup{
 		NodePool: sdk.NodePool{
 			Name:     fmt.Sprintf("%s-%d", machineType, rand.Int63()),
@@ -266,17 +266,17 @@ func (provider *OVHCloudProvider) NewNodeGroup(machineType string, labels map[st
 
 // GetResourceLimiter returns struct containing limits (max, min) for
 // resources (cores, memory etc.).
-func (provider *OVHCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (provider *OVHCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return provider.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (provider *OVHCloudProvider) GPULabel() string {
+func (provider *OVHCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (provider *OVHCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (provider *OVHCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	klog.V(4).Info("Getting available GPU types")
 
 	flavorsByName, err := provider.manager.getFlavorsByName()
@@ -298,20 +298,20 @@ func (provider *OVHCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (provider *OVHCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(provider, node)
+func (provider *OVHCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), provider, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed,
 // i.e. go routines etc.
-func (provider *OVHCloudProvider) Cleanup() error {
+func (provider *OVHCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically
 // update cloud provider state. In particular the list of node groups returned
 // by NodeGroups() can change as a result of CloudProvider.Refresh().
-func (provider *OVHCloudProvider) Refresh() error {
+func (provider *OVHCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Info("Listing node pools to refresh NodeGroups")
 
 	// Check if OpenStack keystone token need to be revoke and re-create

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider_test.go
@@ -109,7 +109,7 @@ func newTestProvider(t *testing.T) *OVHCloudProvider {
 		resourceLimiter: cloudprovider.NewResourceLimiter(minLimits, maxLimits),
 	}
 
-	err = provider.Refresh()
+	err = provider.Refresh(context.Background())
 	assert.NoError(t, err)
 
 	return provider
@@ -135,14 +135,14 @@ func TestOVHCloudProvider_NodeGroups(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check default node groups length", func(t *testing.T) {
-		groups := provider.NodeGroups()
+		groups := provider.NodeGroups(context.Background())
 
 		assert.Equal(t, 2, len(groups))
 	})
 
 	t.Run("check empty node groups length after reset", func(t *testing.T) {
 		provider.manager.NodePools = []sdk.NodePool{}
-		groups := provider.NodeGroups()
+		groups := provider.NodeGroups(context.Background())
 
 		assert.Equal(t, 0, len(groups))
 	})
@@ -180,13 +180,13 @@ func TestOVHCloudProvider_NodeGroupForNode(t *testing.T) {
 			provider.manager.NodeGroupPerProviderID = make(map[string]*NodeGroup)
 		}()
 
-		group, err := provider.NodeGroupForNode(node)
+		group, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.NotNil(t, group)
 
 		assert.Equal(t, ng.Name, group.Id())
-		assert.Equal(t, ng.MinNodes, uint32(group.MinSize()))
-		assert.Equal(t, ng.MaxNodes, uint32(group.MaxSize()))
+		assert.Equal(t, ng.MinNodes, uint32(group.MinSize(context.Background())))
+		assert.Equal(t, ng.MaxNodes, uint32(group.MaxSize(context.Background())))
 	})
 
 	t.Run("find node group with label on node", func(t *testing.T) {
@@ -202,13 +202,13 @@ func TestOVHCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		group, err := provider.NodeGroupForNode(node)
+		group, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.NotNil(t, group)
 
 		assert.Equal(t, "pool-1", group.Id())
-		assert.Equal(t, 1, group.MinSize())
-		assert.Equal(t, 5, group.MaxSize())
+		assert.Equal(t, 1, group.MinSize(context.Background()))
+		assert.Equal(t, 5, group.MaxSize(context.Background()))
 	})
 
 	t.Run("find node group by listing nodes", func(t *testing.T) {
@@ -244,13 +244,13 @@ func TestOVHCloudProvider_NodeGroupForNode(t *testing.T) {
 			provider.manager.NodeGroupPerProviderID = make(map[string]*NodeGroup)
 		}()
 
-		group, err := provider.NodeGroupForNode(node)
+		group, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.NotNil(t, group)
 
 		assert.Equal(t, "pool-1", group.Id())
-		assert.Equal(t, 1, group.MinSize())
-		assert.Equal(t, 5, group.MaxSize())
+		assert.Equal(t, 1, group.MinSize(context.Background()))
+		assert.Equal(t, 5, group.MaxSize(context.Background()))
 	})
 
 	t.Run("fail to find node group with empty providerID", func(t *testing.T) {
@@ -260,7 +260,7 @@ func TestOVHCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		group, err := provider.NodeGroupForNode(node)
+		group, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.Nil(t, group)
 	})
@@ -286,7 +286,7 @@ func TestOVHCloudProvider_NodeGroupForNode(t *testing.T) {
 			[]sdk.Node{}, nil,
 		)
 
-		group, err := provider.NodeGroupForNode(node)
+		group, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.Nil(t, group)
 	})
@@ -310,7 +310,7 @@ func TestOVHCloudProvider_NodeGroupForNode(t *testing.T) {
 			[]sdk.Node{}, nil,
 		).Once()
 
-		group, err := provider.NodeGroupForNode(node)
+		group, err := provider.NodeGroupForNode(context.Background(), node)
 		assert.NoError(t, err)
 		assert.Nil(t, group)
 	})
@@ -320,7 +320,7 @@ func TestOVHCloudProvider_Pricing(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("not implemented", func(t *testing.T) {
-		_, err := provider.Pricing()
+		_, err := provider.Pricing(context.Background())
 		assert.Error(t, err)
 	})
 }
@@ -329,7 +329,7 @@ func TestOVHCloudProvider_GetAvailableMachineTypes(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check available machine types", func(t *testing.T) {
-		flavors, err := provider.GetAvailableMachineTypes()
+		flavors, err := provider.GetAvailableMachineTypes(context.Background())
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, len(flavors))
@@ -340,12 +340,12 @@ func TestOVHCloudProvider_NewNodeGroup(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check new node group default values", func(t *testing.T) {
-		group, err := provider.NewNodeGroup("b2-7", nil, nil, nil, nil)
+		group, err := provider.NewNodeGroup(context.Background(), "b2-7", nil, nil, nil, nil)
 		assert.NoError(t, err)
 
 		assert.Contains(t, group.Id(), "b2-7")
-		assert.Equal(t, 0, group.MinSize())
-		assert.Equal(t, 100, group.MaxSize())
+		assert.Equal(t, 0, group.MinSize(context.Background()))
+		assert.Equal(t, 100, group.MaxSize(context.Background()))
 	})
 }
 
@@ -353,7 +353,7 @@ func TestOVHCloudProvider_GetResourceLimiter(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check default resource limiter values", func(t *testing.T) {
-		rl, err := provider.GetResourceLimiter()
+		rl, err := provider.GetResourceLimiter(context.Background())
 		assert.NoError(t, err)
 
 		minCpu := rl.GetMin(cloudprovider.ResourceNameCores)
@@ -373,7 +373,7 @@ func TestOVHCloudProvider_GPULabel(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check gpu label annotation", func(t *testing.T) {
-		label := provider.GPULabel()
+		label := provider.GPULabel(context.Background())
 
 		assert.Equal(t, GPULabel, label)
 	})
@@ -383,7 +383,7 @@ func TestOVHCloudProvider_GetAvailableGPUTypes(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check available gpu machine types", func(t *testing.T) {
-		flavors := provider.GetAvailableGPUTypes()
+		flavors := provider.GetAvailableGPUTypes(context.Background())
 
 		assert.Equal(t, 1, len(flavors))
 		assert.Equal(t, struct{}{}, flavors["t1-45"])
@@ -394,7 +394,7 @@ func TestOVHCloudProvider_Cleanup(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check return nil", func(t *testing.T) {
-		err := provider.Cleanup()
+		err := provider.Cleanup(context.Background())
 		assert.NoError(t, err)
 	})
 }
@@ -404,14 +404,14 @@ func TestOVHCloudProvider_Refresh(t *testing.T) {
 
 	t.Run("check refresh reset node groups correctly", func(t *testing.T) {
 		provider.manager.NodePools = []sdk.NodePool{}
-		groups := provider.NodeGroups()
+		groups := provider.NodeGroups(context.Background())
 
 		assert.Equal(t, 0, len(groups))
 
-		err := provider.Refresh()
+		err := provider.Refresh(context.Background())
 		assert.NoError(t, err)
 
-		groups = provider.NodeGroups()
+		groups = provider.NodeGroups(context.Background())
 		assert.Equal(t, 2, len(groups))
 	})
 }

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
@@ -76,22 +76,22 @@ func (ng *nodeGroup) Id() string {
 }
 
 // MinSize returns minimum size of the node group.
-func (ng *nodeGroup) MinSize() int {
+func (ng *nodeGroup) MinSize(ctx context.Context) int {
 	return ng.minSize
 }
 
 // MaxSize returns maximum size of the node group.
-func (ng *nodeGroup) MaxSize() int {
+func (ng *nodeGroup) MaxSize(ctx context.Context) int {
 	return ng.maxSize
 }
 
 // Debug returns a debug string for the node group.
-func (ng *nodeGroup) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", ng.Id(), ng.MinSize(), ng.MaxSize())
+func (ng *nodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", ng.Id(), ng.MinSize(context.TODO()), ng.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (ng *nodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *nodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	nodes, err := ng.nodes()
 	if err != nil {
 		return nil, err
@@ -106,10 +106,10 @@ func (ng *nodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 }
 
 // DeleteNodes deletes the specified nodes from the node group.
-func (ng *nodeGroup) DeleteNodes(toDelete []*corev1.Node) error {
-	if ng.replicas-len(toDelete) < ng.MinSize() {
+func (ng *nodeGroup) DeleteNodes(ctx context.Context, toDelete []*corev1.Node) error {
+	if ng.replicas-len(toDelete) < ng.MinSize(context.TODO()) {
 		return fmt.Errorf("node group size would be below minimum size - desired: %d, min: %d",
-			ng.replicas-len(toDelete), ng.MinSize())
+			ng.replicas-len(toDelete), ng.MinSize(context.TODO()))
 	}
 
 	for _, del := range toDelete {
@@ -135,7 +135,7 @@ func (ng *nodeGroup) DeleteNodes(toDelete []*corev1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (ng *nodeGroup) ForceDeleteNodes(nodes []*corev1.Node) error {
+func (ng *nodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*corev1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -155,39 +155,39 @@ func (ng *nodeGroup) findNodeByProviderID(providerID string) (*node, error) {
 }
 
 // IncreaseSize increases NodeGroup size.
-func (ng *nodeGroup) IncreaseSize(delta int) error {
+func (ng *nodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
 
 	newSize := ng.replicas + delta
-	if newSize > ng.MaxSize() {
-		return fmt.Errorf("size increase too large, desired: %d max: %d", newSize, ng.MaxSize())
+	if newSize > ng.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large, desired: %d max: %d", newSize, ng.MaxSize(context.TODO()))
 	}
 
 	return ng.setSize(newSize)
 }
 
 // AtomicIncreaseSize is not implemented.
-func (ng *nodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *nodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
-func (ng *nodeGroup) TargetSize() (int, error) {
+func (ng *nodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return ng.replicas, nil
 }
 
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
-func (ng *nodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *nodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
 
-	nodes, err := ng.Nodes()
+	nodes, err := ng.Nodes(context.TODO())
 	if err != nil {
 		return fmt.Errorf("failed to get node group nodes: %w", err)
 	}
@@ -201,7 +201,7 @@ func (ng *nodeGroup) DecreaseTargetSize(delta int) error {
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (ng *nodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *nodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   fmt.Sprintf("%s-%s-%d", ng.provider.config.ClusterName, ng.Id(), rand.Int63()),
@@ -226,28 +226,28 @@ func (ng *nodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 }
 
 // Exist checks if the node group really exists on the cloud provider side.
-func (ng *nodeGroup) Exist() bool {
+func (ng *nodeGroup) Exist(ctx context.Context) bool {
 	return ng.Id() != ""
 }
 
 // Create creates the node group on the cloud provider side.
-func (ng *nodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *nodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
-func (ng *nodeGroup) Delete() error {
+func (ng *nodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (ng *nodeGroup) Autoprovisioned() bool {
+func (ng *nodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (ng *nodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *nodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rancher
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -121,7 +122,7 @@ func TestNodeGroupNodes(t *testing.T) {
 
 			tc.nodeGroup.provider = provider
 
-			nodes, err := tc.nodeGroup.Nodes()
+			nodes, err := tc.nodeGroup.Nodes(context.Background())
 			if err != nil {
 				if tc.expectedErrContains == "" || !strings.Contains(err.Error(), tc.expectedErrContains) {
 					t.Fatalf("expected err to contain %q, got %q", tc.expectedErrContains, err)
@@ -214,20 +215,20 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 
 			tc.nodeGroup.provider = provider
 
-			if err := provider.Refresh(); err != nil {
+			if err := provider.Refresh(context.Background()); err != nil {
 				t.Fatal(err)
 			}
 
 			// store delta before deleting nodes
 			delta := tc.nodeGroup.replicas - tc.expectedTargetSize
 
-			if err := tc.nodeGroup.DeleteNodes(tc.toDelete); err != nil {
+			if err := tc.nodeGroup.DeleteNodes(context.Background(), tc.toDelete); err != nil {
 				if tc.expectedErrContains == "" || !strings.Contains(err.Error(), tc.expectedErrContains) {
 					t.Fatalf("expected err to contain %q, got %q", tc.expectedErrContains, err)
 				}
 			}
 
-			targetSize, err := tc.nodeGroup.TargetSize()
+			targetSize, err := tc.nodeGroup.TargetSize(context.Background())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -305,7 +306,7 @@ func TestIncreaseTargetSize(t *testing.T) {
 			}
 
 			tc.nodeGroup.provider = provider
-			if err := tc.nodeGroup.IncreaseSize(tc.delta); err != nil {
+			if err := tc.nodeGroup.IncreaseSize(context.Background(), tc.delta); err != nil {
 				if tc.expectedErrContains == "" || !strings.Contains(err.Error(), tc.expectedErrContains) {
 					t.Fatalf("expected err to contain %q, got %q", tc.expectedErrContains, err)
 				}
@@ -363,7 +364,7 @@ func TestDecreaseTargetSize(t *testing.T) {
 			}
 
 			tc.nodeGroup.provider = provider
-			if err := tc.nodeGroup.DecreaseTargetSize(tc.delta); err != nil {
+			if err := tc.nodeGroup.DecreaseTargetSize(context.Background(), tc.delta); err != nil {
 				if tc.expectedErrContains == "" || !strings.Contains(err.Error(), tc.expectedErrContains) {
 					t.Fatalf("expected err to contain %q, got %q", tc.expectedErrContains, err)
 				}
@@ -391,7 +392,7 @@ func TestTemplateNodeInfo(t *testing.T) {
 		},
 	}
 
-	nodeInfo, err := ng.TemplateNodeInfo()
+	nodeInfo, err := ng.TemplateNodeInfo(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
@@ -129,24 +129,24 @@ func (provider *RancherCloudProvider) Name() string {
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (provider *RancherCloudProvider) GPULabel() string {
+func (provider *RancherCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports
-func (provider *RancherCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (provider *RancherCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	// TODO: implement GPU support
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (provider *RancherCloudProvider) GetNodeGpuConfig(node *corev1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(provider, node)
+func (provider *RancherCloudProvider) GetNodeGpuConfig(ctx context.Context, node *corev1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), provider, node)
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (provider *RancherCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (provider *RancherCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodeGroups := make([]cloudprovider.NodeGroup, len(provider.nodeGroups))
 	for i, ng := range provider.nodeGroups {
 		nodeGroups[i] = ng
@@ -155,12 +155,12 @@ func (provider *RancherCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (provider *RancherCloudProvider) Pricing() (cloudprovider.PricingModel, autoscalererrors.AutoscalerError) {
+func (provider *RancherCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, autoscalererrors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (provider *RancherCloudProvider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup, error) {
+func (provider *RancherCloudProvider) NodeGroupForNode(ctx context.Context, node *corev1.Node) (cloudprovider.NodeGroup, error) {
 	machineName, ok := node.Annotations[machineNodeAnnotationKey]
 	if !ok {
 		klog.V(4).Infof("skipping NodeGroupForNode %q as the annotation %q is missing", node.Name, machineNodeAnnotationKey)
@@ -192,31 +192,31 @@ func (provider *RancherCloudProvider) NodeGroupForNode(node *corev1.Node) (cloud
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (provider *RancherCloudProvider) HasInstance(node *corev1.Node) (bool, error) {
+func (provider *RancherCloudProvider) HasInstance(ctx context.Context, node *corev1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (provider *RancherCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (provider *RancherCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, cloudprovider.ErrNotImplemented
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided.
-func (provider *RancherCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (provider *RancherCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []corev1.Taint,
 	extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (provider *RancherCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (provider *RancherCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return provider.resourceLimiter, nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (provider *RancherCloudProvider) Refresh() error {
+func (provider *RancherCloudProvider) Refresh(ctx context.Context) error {
 	nodeGroups, err := provider.scalableNodeGroups()
 	if err != nil {
 		return fmt.Errorf("unable to get node groups from cluster: %w", err)
@@ -227,7 +227,7 @@ func (provider *RancherCloudProvider) Refresh() error {
 }
 
 // Cleanup cleans up all resources before the cloud provider is removed
-func (provider *RancherCloudProvider) Cleanup() error {
+func (provider *RancherCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
@@ -250,7 +250,7 @@ func (provider *RancherCloudProvider) scalableNodeGroups() ([]*nodeGroup, error)
 			return nil, fmt.Errorf("error getting node group from machine pool: %w", err)
 		}
 
-		klog.V(4).Infof("scalable node group found: %s", nodeGroup.Debug())
+		klog.V(4).Infof("scalable node group found: %s", nodeGroup.Debug(context.TODO()))
 
 		result = append(result, nodeGroup)
 	}

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rancher
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -109,14 +110,14 @@ func TestNodeGroups(t *testing.T) {
 				config: config,
 			}
 
-			if err := provider.Refresh(); err != nil {
+			if err := provider.Refresh(context.Background()); err != nil {
 				if tc.expectedErrContains == "" || !strings.Contains(err.Error(), tc.expectedErrContains) {
 					t.Fatalf("expected err to contain %q, got %q", tc.expectedErrContains, err)
 				}
 			}
 
-			if len(provider.NodeGroups()) != tc.expectedGroups {
-				t.Fatalf("expected %d groups, got %d", tc.expectedGroups, len(provider.NodeGroups()))
+			if len(provider.NodeGroups(context.Background())) != tc.expectedGroups {
+				t.Fatalf("expected %d groups, got %d", tc.expectedGroups, len(provider.NodeGroups(context.Background())))
 			}
 		})
 	}
@@ -128,7 +129,7 @@ func TestNodeGroupForNode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := provider.Refresh(); err != nil {
+	if err := provider.Refresh(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -178,7 +179,7 @@ func TestNodeGroupForNode(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ng, err := provider.NodeGroupForNode(tc.node)
+			ng, err := provider.NodeGroupForNode(context.Background(), tc.node)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
@@ -129,7 +129,7 @@ func newScalewayCloudProvider(configFile io.Reader, defaultUserAgent string, rl 
 	}
 
 	// Perform initial refresh to populate node groups cache
-	if err := provider.Refresh(); err != nil {
+	if err := provider.Refresh(context.TODO()); err != nil {
 		klog.Errorf("Failed to perform initial refresh: %v", err)
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (*scalewayCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (scw *scalewayCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (scw *scalewayCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	klog.V(4).Info("NodeGroups,ClusterID=", scw.clusterID)
 
 	return scw.providerNodeGroups
@@ -178,7 +178,7 @@ func (scw *scalewayCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (scw *scalewayCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (scw *scalewayCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	klog.V(4).Infof("NodeGroupForNode,NodeSpecProviderID=%s", node.Spec.ProviderID)
 
 	for _, ng := range scw.nodeGroups {
@@ -192,27 +192,27 @@ func (scw *scalewayCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovi
 
 // HasInstance returns whether the node has corresponding instance in cloud provider,
 // true if the node has an instance, false if it no longer exists
-func (scw *scalewayCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (scw *scalewayCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return node.Spec.ProviderID != "", nil
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (scw *scalewayCloudProvider) Pricing() (cloudprovider.PricingModel, ca_errors.AutoscalerError) {
+func (scw *scalewayCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, ca_errors.AutoscalerError) {
 	klog.V(4).Info("Pricing,called")
 	return scw, nil
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (scw *scalewayCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (scw *scalewayCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (scw *scalewayCloudProvider) NewNodeGroup(
+func (scw *scalewayCloudProvider) NewNodeGroup(ctx context.Context,
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
@@ -224,39 +224,39 @@ func (scw *scalewayCloudProvider) NewNodeGroup(
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (scw *scalewayCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (scw *scalewayCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	klog.V(4).Info("GetResourceLimiter,called")
 	return scw.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (scw *scalewayCloudProvider) GPULabel() string {
+func (scw *scalewayCloudProvider) GPULabel(ctx context.Context) string {
 	klog.V(6).Info("GPULabel,called")
 	return GPULabel
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (scw *scalewayCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (scw *scalewayCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	klog.V(4).Info("GetAvailableGPUTypes,called")
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (scw *scalewayCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+func (scw *scalewayCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
 	klog.V(6).Info("GetNodeGpuConfig,called")
-	return gpu.GetNodeGPUFromCloudProvider(scw, node)
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), scw, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (scw *scalewayCloudProvider) Cleanup() error {
+func (scw *scalewayCloudProvider) Cleanup(ctx context.Context) error {
 	klog.V(4).Info("Cleanup,called")
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (scw *scalewayCloudProvider) Refresh() error {
+func (scw *scalewayCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Info("Refresh,ClusterID=", scw.clusterID)
 
 	// Only skip refresh if lastRefresh is non-zero and interval has not elapsed
@@ -331,7 +331,7 @@ func (scw *scalewayCloudProvider) Refresh() error {
 
 // NodePrice returns a price of running the given node for a given period of time.
 // All prices returned by the structure should be in the same currency.
-func (scw *scalewayCloudProvider) NodePrice(node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
+func (scw *scalewayCloudProvider) NodePrice(ctx context.Context, node *apiv1.Node, startTime time.Time, endTime time.Time) (float64, error) {
 	poolID, ok := node.Labels[PoolLabel]
 	if !ok {
 		return 0.0, fmt.Errorf("node %s does not have pool label %s", node.Name, PoolLabel)
@@ -350,6 +350,6 @@ func (scw *scalewayCloudProvider) NodePrice(node *apiv1.Node, startTime time.Tim
 
 // PodPrice returns a theoretical minimum price of running a pod for a given
 // period of time on a perfectly matching machine.
-func (scw *scalewayCloudProvider) PodPrice(pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
+func (scw *scalewayCloudProvider) PodPrice(ctx context.Context, pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
 	return 0.0, nil
 }

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider_test.go
@@ -145,7 +145,7 @@ func TestScalewayCloudProvider_Refresh(t *testing.T) {
 			nodeGroups:      make(map[string]*NodeGroup),
 		}
 
-		err := provider.Refresh()
+		err := provider.Refresh(context.Background())
 		require.NoError(t, err)
 
 		// Verify node groups (only autoscaling pools)
@@ -188,12 +188,12 @@ func TestScalewayCloudProvider_Refresh(t *testing.T) {
 			nodeGroups:      make(map[string]*NodeGroup),
 		}
 
-		err := provider.Refresh()
+		err := provider.Refresh(context.Background())
 		require.NoError(t, err)
 		assert.NotZero(t, provider.lastRefresh)
 
 		// Second refresh immediately - should be skipped
-		err = provider.Refresh()
+		err = provider.Refresh(context.Background())
 		require.NoError(t, err)
 
 		// Only one call to each method
@@ -224,14 +224,14 @@ func TestScalewayCloudProvider_Refresh(t *testing.T) {
 			nodeGroups:      make(map[string]*NodeGroup),
 		}
 
-		err := provider.Refresh()
+		err := provider.Refresh(context.Background())
 		require.NoError(t, err)
 
 		// Wait for interval to elapse
 		time.Sleep(2 * time.Millisecond)
 
 		// Second refresh should execute
-		err = provider.Refresh()
+		err = provider.Refresh(context.Background())
 		require.NoError(t, err)
 
 		client.AssertExpectations(t)
@@ -253,7 +253,7 @@ func TestScalewayCloudProvider_Refresh(t *testing.T) {
 			nodeGroups:      make(map[string]*NodeGroup),
 		}
 
-		err := provider.Refresh()
+		err := provider.Refresh(context.Background())
 		assert.Error(t, err)
 		assert.Equal(t, err, provider.lastRefreshError)
 
@@ -282,7 +282,7 @@ func TestScalewayCloudProvider_Refresh(t *testing.T) {
 			nodeGroups:      make(map[string]*NodeGroup),
 		}
 
-		err := provider.Refresh()
+		err := provider.Refresh(context.Background())
 		assert.Error(t, err)
 		assert.Equal(t, err, provider.lastRefreshError)
 
@@ -313,7 +313,7 @@ func TestScalewayCloudProvider_Refresh(t *testing.T) {
 			nodeGroups:      make(map[string]*NodeGroup),
 		}
 
-		err := provider.Refresh()
+		err := provider.Refresh(context.Background())
 		require.NoError(t, err)
 
 		// Only pool-1 should have nodes
@@ -351,7 +351,7 @@ func TestScalewayCloudProvider_NodeGroups(t *testing.T) {
 		provider.nodeGroups["pool-2"],
 	}
 
-	nodeGroups := provider.NodeGroups()
+	nodeGroups := provider.NodeGroups(context.Background())
 	assert.Len(t, nodeGroups, 2)
 }
 
@@ -381,7 +381,7 @@ func TestScalewayCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		ng, err := provider.NodeGroupForNode(k8sNode)
+		ng, err := provider.NodeGroupForNode(context.Background(), k8sNode)
 		require.NoError(t, err)
 		require.NotNil(t, ng)
 		assert.Equal(t, "pool-1", ng.Id())
@@ -409,7 +409,7 @@ func TestScalewayCloudProvider_NodeGroupForNode(t *testing.T) {
 			},
 		}
 
-		ng, err := provider.NodeGroupForNode(k8sNode)
+		ng, err := provider.NodeGroupForNode(context.Background(), k8sNode)
 		require.NoError(t, err)
 		assert.Nil(t, ng)
 	})
@@ -425,7 +425,7 @@ func TestScalewayCloudProvider_HasInstance(t *testing.T) {
 			},
 		}
 
-		hasInstance, err := provider.HasInstance(node)
+		hasInstance, err := provider.HasInstance(context.Background(), node)
 		require.NoError(t, err)
 		assert.True(t, hasInstance)
 	})
@@ -437,7 +437,7 @@ func TestScalewayCloudProvider_HasInstance(t *testing.T) {
 			},
 		}
 
-		hasInstance, err := provider.HasInstance(node)
+		hasInstance, err := provider.HasInstance(context.Background(), node)
 		require.NoError(t, err)
 		assert.False(t, hasInstance)
 	})
@@ -446,7 +446,7 @@ func TestScalewayCloudProvider_HasInstance(t *testing.T) {
 func TestScalewayCloudProvider_Pricing(t *testing.T) {
 	provider := &scalewayCloudProvider{}
 
-	pricingModel, err := provider.Pricing()
+	pricingModel, err := provider.Pricing(context.Background())
 	require.NoError(t, err)
 	assert.NotNil(t, pricingModel)
 	assert.Equal(t, provider, pricingModel)
@@ -455,7 +455,7 @@ func TestScalewayCloudProvider_Pricing(t *testing.T) {
 func TestScalewayCloudProvider_GetAvailableMachineTypes(t *testing.T) {
 	provider := &scalewayCloudProvider{}
 
-	machineTypes, err := provider.GetAvailableMachineTypes()
+	machineTypes, err := provider.GetAvailableMachineTypes(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, machineTypes)
 }
@@ -463,7 +463,7 @@ func TestScalewayCloudProvider_GetAvailableMachineTypes(t *testing.T) {
 func TestScalewayCloudProvider_NewNodeGroup(t *testing.T) {
 	provider := &scalewayCloudProvider{}
 
-	ng, err := provider.NewNodeGroup("DEV1-M", nil, nil, nil, nil)
+	ng, err := provider.NewNodeGroup(context.Background(), "DEV1-M", nil, nil, nil, nil)
 	assert.Error(t, err)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 	assert.Nil(t, ng)
@@ -475,7 +475,7 @@ func TestScalewayCloudProvider_GetResourceLimiter(t *testing.T) {
 		resourceLimiter: limiter,
 	}
 
-	result, err := provider.GetResourceLimiter()
+	result, err := provider.GetResourceLimiter(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, limiter, result)
 }
@@ -483,14 +483,14 @@ func TestScalewayCloudProvider_GetResourceLimiter(t *testing.T) {
 func TestScalewayCloudProvider_GPULabel(t *testing.T) {
 	provider := &scalewayCloudProvider{}
 
-	label := provider.GPULabel()
+	label := provider.GPULabel(context.Background())
 	assert.Equal(t, "k8s.scw.cloud/gpu", label)
 }
 
 func TestScalewayCloudProvider_GetAvailableGPUTypes(t *testing.T) {
 	provider := &scalewayCloudProvider{}
 
-	gpuTypes := provider.GetAvailableGPUTypes()
+	gpuTypes := provider.GetAvailableGPUTypes(context.Background())
 	assert.Nil(t, gpuTypes)
 }
 
@@ -530,7 +530,7 @@ func TestScalewayCloudProvider_NodePrice(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(2*time.Hour + 30*time.Minute)
 
-		price, err := provider.NodePrice(k8sNode, startTime, endTime)
+		price, err := provider.NodePrice(context.Background(), k8sNode, startTime, endTime)
 		require.NoError(t, err)
 		// 2.5 hours rounds up to 3 hours at $0.10/hour = $0.30
 		assert.InDelta(t, 0.30, price, 0.001)
@@ -557,7 +557,7 @@ func TestScalewayCloudProvider_NodePrice(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(1 * time.Hour)
 
-		price, err := provider.NodePrice(k8sNode, startTime, endTime)
+		price, err := provider.NodePrice(context.Background(), k8sNode, startTime, endTime)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "does not have pool label")
 		assert.Equal(t, 0.0, price)
@@ -586,7 +586,7 @@ func TestScalewayCloudProvider_NodePrice(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(1 * time.Hour)
 
-		price, err := provider.NodePrice(k8sNode, startTime, endTime)
+		price, err := provider.NodePrice(context.Background(), k8sNode, startTime, endTime)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 		assert.Equal(t, 0.0, price)
@@ -605,7 +605,7 @@ func TestScalewayCloudProvider_PodPrice(t *testing.T) {
 	startTime := time.Now()
 	endTime := startTime.Add(1 * time.Hour)
 
-	price, err := provider.PodPrice(pod, startTime, endTime)
+	price, err := provider.PodPrice(context.Background(), pod, startTime, endTime)
 	require.NoError(t, err)
 	assert.Equal(t, 0.0, price)
 }
@@ -613,6 +613,6 @@ func TestScalewayCloudProvider_PodPrice(t *testing.T) {
 func TestScalewayCloudProvider_Cleanup(t *testing.T) {
 	provider := &scalewayCloudProvider{}
 
-	err := provider.Cleanup()
+	err := provider.Cleanup(context.Background())
 	assert.NoError(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -41,13 +41,13 @@ type NodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (ng *NodeGroup) MaxSize() int {
+func (ng *NodeGroup) MaxSize(ctx context.Context) int {
 	klog.V(6).Info("MaxSize,called")
 	return ng.pool.MaxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (ng *NodeGroup) MinSize() int {
+func (ng *NodeGroup) MinSize(ctx context.Context) int {
 	klog.V(6).Info("MinSize,called")
 	return ng.pool.MinSize
 }
@@ -56,7 +56,7 @@ func (ng *NodeGroup) MinSize() int {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (ng *NodeGroup) TargetSize() (int, error) {
+func (ng *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	klog.V(6).Info("TargetSize,called")
 	return ng.pool.Size, nil
 }
@@ -64,7 +64,7 @@ func (ng *NodeGroup) TargetSize() (int, error) {
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (ng *NodeGroup) IncreaseSize(delta int) error {
+func (ng *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("IncreaseSize,ClusterID=%s,delta=%d", ng.pool.ClusterID, delta)
 
 	if delta <= 0 {
@@ -77,8 +77,8 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 		return fmt.Errorf("size cannot be negative. current: %d delta: %d", ng.pool.Size, delta)
 	}
 
-	if targetSize > ng.MaxSize() {
-		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d", ng.pool.Size, targetSize, ng.MaxSize())
+	if targetSize > ng.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d", ng.pool.Size, targetSize, ng.MaxSize(context.TODO()))
 	}
 
 	updatedPool, err := ng.UpdatePool(context.Background(), ng.pool.ID, targetSize)
@@ -97,15 +97,15 @@ func (ng *NodeGroup) IncreaseSize(delta int) error {
 // for atomically requesting multiple instances. If implemented, CA will take advantage of the method while scaling up
 // BestEffortAtomicScaleUp ProvisioningClass, guaranteeing that all instances required for such a
 // ProvisioningRequest are provisioned atomically.
-func (ng *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (ng *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
-	ctx := context.Background()
+func (ng *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
+	ctx2 := context.Background()
 	klog.V(4).Infof("DeleteNodes: %d nodes to reclaim", len(nodes))
 	for _, n := range nodes {
 		node, ok := ng.nodes[n.Spec.ProviderID]
@@ -114,7 +114,7 @@ func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 			continue
 		}
 
-		deletedNode, err := ng.DeleteNode(ctx, node.ID)
+		deletedNode, err := ng.DeleteNode(ctx2, node.ID)
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 // constraints like minimal size validation etc. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated.
-func (ng *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (ng *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -139,7 +139,7 @@ func (ng *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (ng *NodeGroup) DecreaseTargetSize(delta int) error {
+func (ng *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("DecreaseTargetSize,ClusterID=%s,delta=%d", ng.pool.ClusterID, delta)
 
 	if delta >= 0 {
@@ -152,12 +152,12 @@ func (ng *NodeGroup) DecreaseTargetSize(delta int) error {
 		return fmt.Errorf("size cannot be negative. current: %d delta: %d", ng.pool.Size, delta)
 	}
 
-	if targetSize < ng.MinSize() {
-		return fmt.Errorf("size decrease is too large. current: %d desired: %d min: %d", ng.pool.Size, targetSize, ng.MinSize())
+	if targetSize < ng.MinSize(context.TODO()) {
+		return fmt.Errorf("size decrease is too large. current: %d desired: %d min: %d", ng.pool.Size, targetSize, ng.MinSize(context.TODO()))
 	}
 
-	ctx := context.Background()
-	updatedNode, err := ng.UpdatePool(ctx, ng.pool.ID, targetSize)
+	ctx2 := context.Background()
+	updatedNode, err := ng.UpdatePool(ctx2, ng.pool.ID, targetSize)
 	if err != nil {
 		return err
 	}
@@ -174,16 +174,16 @@ func (ng *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (ng *NodeGroup) Debug() string {
+func (ng *NodeGroup) Debug(ctx context.Context) string {
 	klog.V(4).Info("Debug,called")
-	return fmt.Sprintf("id:%s,status:%s,version:%s,autoscaling:%t,size:%d,min_size:%d,max_size:%d", ng.Id(), ng.pool.Status, ng.pool.Version, ng.pool.Autoscaling, ng.pool.Size, ng.MinSize(), ng.MaxSize())
+	return fmt.Sprintf("id:%s,status:%s,version:%s,autoscaling:%t,size:%d,min_size:%d,max_size:%d", ng.Id(), ng.pool.Status, ng.pool.Version, ng.pool.Autoscaling, ng.pool.Size, ng.MinSize(context.TODO()), ng.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (ng *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (ng *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	klog.V(4).Infof("Nodes,PoolID=%s", ng.pool.ID)
 
 	nodes := make([]cloudprovider.Instance, 0, len(ng.nodes))
@@ -203,7 +203,7 @@ func (ng *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (ng *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (ng *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	klog.V(4).Infof("TemplateNodeInfo,PoolID=%s", ng.pool.ID)
 	node := apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -234,33 +234,33 @@ func (ng *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (ng *NodeGroup) Exist() bool {
+func (ng *NodeGroup) Exist(ctx context.Context) bool {
 	klog.V(4).Infof("Exist,PoolID=%s", ng.pool.ID)
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (ng *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (ng *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (ng *NodeGroup) Delete() error {
+func (ng *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (ng *NodeGroup) Autoprovisioned() bool {
+func (ng *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 // Implementation optional. Callers MUST handle `cloudprovider.ErrNotImplemented`.
-func (ng *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (ng *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -105,7 +105,10 @@ func (ng *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
 func (ng *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
-	ctx2 := context.Background()
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
 	klog.V(4).Infof("DeleteNodes: %d nodes to reclaim", len(nodes))
 	for _, n := range nodes {
 		node, ok := ng.nodes[n.Spec.ProviderID]
@@ -114,7 +117,7 @@ func (ng *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error
 			continue
 		}
 
-		deletedNode, err := ng.DeleteNode(ctx2, node.ID)
+		deletedNode, err := ng.DeleteNode(emptyCtx, node.ID)
 		if err != nil {
 			return err
 		}
@@ -156,8 +159,11 @@ func (ng *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 		return fmt.Errorf("size decrease is too large. current: %d desired: %d min: %d", ng.pool.Size, targetSize, ng.MinSize(context.TODO()))
 	}
 
-	ctx2 := context.Background()
-	updatedNode, err := ng.UpdatePool(ctx2, ng.pool.ID, targetSize)
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
+	updatedNode, err := ng.UpdatePool(emptyCtx, ng.pool.ID, targetSize)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaleway
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestNodeGroup_MaxSize(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, 10, ng.MaxSize())
+	assert.Equal(t, 10, ng.MaxSize(context.Background()))
 }
 
 func TestNodeGroup_MinSize(t *testing.T) {
@@ -46,7 +47,7 @@ func TestNodeGroup_MinSize(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, 2, ng.MinSize())
+	assert.Equal(t, 2, ng.MinSize(context.Background()))
 }
 
 func TestNodeGroup_TargetSize(t *testing.T) {
@@ -56,7 +57,7 @@ func TestNodeGroup_TargetSize(t *testing.T) {
 		},
 	}
 
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 5, size)
 }
@@ -85,7 +86,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			nodes:  make(map[string]*scalewaygo.Node),
 		}
 
-		err := ng.IncreaseSize(2)
+		err := ng.IncreaseSize(context.Background(), 2)
 		require.NoError(t, err)
 		assert.Equal(t, 5, ng.pool.Size)
 		assert.Equal(t, scalewaygo.PoolStatusScaling, ng.pool.Status)
@@ -102,7 +103,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			},
 		}
 
-		err := ng.IncreaseSize(0)
+		err := ng.IncreaseSize(context.Background(), 0)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "delta must be strictly positive")
 	})
@@ -116,7 +117,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			},
 		}
 
-		err := ng.IncreaseSize(-1)
+		err := ng.IncreaseSize(context.Background(), -1)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "delta must be strictly positive")
 	})
@@ -130,7 +131,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			},
 		}
 
-		err := ng.IncreaseSize(5)
+		err := ng.IncreaseSize(context.Background(), 5)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "size increase is too large")
 	})
@@ -145,7 +146,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		}
 
 		// Starting from negative size (corrupted state)
-		err := ng.IncreaseSize(2)
+		err := ng.IncreaseSize(context.Background(), 2)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "size cannot be negative")
 	})
@@ -171,7 +172,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 			nodes:  make(map[string]*scalewaygo.Node),
 		}
 
-		err := ng.IncreaseSize(2)
+		err := ng.IncreaseSize(context.Background(), 2)
 		assert.Error(t, err)
 
 		client.AssertExpectations(t)
@@ -202,7 +203,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 			nodes:  make(map[string]*scalewaygo.Node),
 		}
 
-		err := ng.DecreaseTargetSize(-2)
+		err := ng.DecreaseTargetSize(context.Background(), -2)
 		require.NoError(t, err)
 		assert.Equal(t, 3, ng.pool.Size)
 		assert.Equal(t, scalewaygo.PoolStatusScaling, ng.pool.Status)
@@ -219,7 +220,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 			},
 		}
 
-		err := ng.DecreaseTargetSize(0)
+		err := ng.DecreaseTargetSize(context.Background(), 0)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "delta must be strictly negative")
 	})
@@ -233,7 +234,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 			},
 		}
 
-		err := ng.DecreaseTargetSize(1)
+		err := ng.DecreaseTargetSize(context.Background(), 1)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "delta must be strictly negative")
 	})
@@ -248,7 +249,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		}
 
 		// 5 + (-3) = 2, which is below min (3) but not negative
-		err := ng.DecreaseTargetSize(-3)
+		err := ng.DecreaseTargetSize(context.Background(), -3)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "size decrease is too large")
 	})
@@ -264,7 +265,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 
 		// Attempting to decrease by more than current size would result in negative
 		// 2 + (-5) = -3
-		err := ng.DecreaseTargetSize(-5)
+		err := ng.DecreaseTargetSize(context.Background(), -5)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "size cannot be negative")
 	})
@@ -290,7 +291,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 			nodes:  make(map[string]*scalewaygo.Node),
 		}
 
-		err := ng.DecreaseTargetSize(-2)
+		err := ng.DecreaseTargetSize(context.Background(), -2)
 		assert.Error(t, err)
 
 		client.AssertExpectations(t)
@@ -328,7 +329,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			{Spec: apiv1.NodeSpec{ProviderID: "scaleway://fr-par-1/instance-2"}},
 		}
 
-		err := ng.DeleteNodes(k8sNodes)
+		err := ng.DeleteNodes(context.Background(), k8sNodes)
 		require.NoError(t, err)
 		assert.Equal(t, 3, ng.pool.Size)
 		assert.Equal(t, scalewaygo.NodeStatusDeleting, ng.nodes["scaleway://fr-par-1/instance-1"].Status)
@@ -353,7 +354,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			{Spec: apiv1.NodeSpec{ProviderID: "scaleway://fr-par-1/instance-nonexistent"}},
 		}
 
-		err := ng.DeleteNodes(k8sNodes)
+		err := ng.DeleteNodes(context.Background(), k8sNodes)
 		// Should not error, just log and continue
 		require.NoError(t, err)
 		assert.Equal(t, 3, ng.pool.Size) // Size unchanged
@@ -385,7 +386,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			{Spec: apiv1.NodeSpec{ProviderID: "scaleway://fr-par-1/instance-1"}},
 		}
 
-		err := ng.DeleteNodes(k8sNodes)
+		err := ng.DeleteNodes(context.Background(), k8sNodes)
 		assert.Error(t, err)
 
 		client.AssertExpectations(t)
@@ -395,14 +396,14 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 func TestNodeGroup_ForceDeleteNodes(t *testing.T) {
 	ng := &NodeGroup{}
 
-	err := ng.ForceDeleteNodes([]*apiv1.Node{})
+	err := ng.ForceDeleteNodes(context.Background(), []*apiv1.Node{})
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
 func TestNodeGroup_AtomicIncreaseSize(t *testing.T) {
 	ng := &NodeGroup{}
 
-	err := ng.AtomicIncreaseSize(1)
+	err := ng.AtomicIncreaseSize(context.Background(), 1)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
@@ -429,7 +430,7 @@ func TestNodeGroup_Debug(t *testing.T) {
 		},
 	}
 
-	debug := ng.Debug()
+	debug := ng.Debug(context.Background())
 	assert.Contains(t, debug, "pool-123")
 	assert.Contains(t, debug, "ready")
 	assert.Contains(t, debug, "1.27.0")
@@ -456,7 +457,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 			},
 		}
 
-		instances, err := ng.Nodes()
+		instances, err := ng.Nodes(context.Background())
 		require.NoError(t, err)
 		assert.Len(t, instances, 3)
 
@@ -480,7 +481,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 			nodes: make(map[string]*scalewaygo.Node),
 		}
 
-		instances, err := ng.Nodes()
+		instances, err := ng.Nodes(context.Background())
 		require.NoError(t, err)
 		assert.Empty(t, instances)
 	})
@@ -514,7 +515,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 		},
 	}
 
-	nodeInfo, err := ng.TemplateNodeInfo()
+	nodeInfo, err := ng.TemplateNodeInfo(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, nodeInfo)
 
@@ -568,13 +569,13 @@ func TestNodeGroup_Exist(t *testing.T) {
 	}
 
 	// Always returns true in current implementation
-	assert.True(t, ng.Exist())
+	assert.True(t, ng.Exist(context.Background()))
 }
 
 func TestNodeGroup_Create(t *testing.T) {
 	ng := &NodeGroup{}
 
-	newNg, err := ng.Create()
+	newNg, err := ng.Create(context.Background())
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 	assert.Nil(t, newNg)
 }
@@ -582,21 +583,21 @@ func TestNodeGroup_Create(t *testing.T) {
 func TestNodeGroup_Delete(t *testing.T) {
 	ng := &NodeGroup{}
 
-	err := ng.Delete()
+	err := ng.Delete(context.Background())
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 }
 
 func TestNodeGroup_Autoprovisioned(t *testing.T) {
 	ng := &NodeGroup{}
 
-	assert.False(t, ng.Autoprovisioned())
+	assert.False(t, ng.Autoprovisioned(context.Background()))
 }
 
 func TestNodeGroup_GetOptions(t *testing.T) {
 	ng := &NodeGroup{}
 
 	defaults := config.NodeGroupAutoscalingOptions{}
-	opts, err := ng.GetOptions(defaults)
+	opts, err := ng.GetOptions(context.Background(), defaults)
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 	assert.Nil(t, opts)
 }

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tencentcloud
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -94,24 +95,24 @@ func (asg *tcAsg) SetScalingType(scalingType string) {
 }
 
 // MaxSize returns maximum size of the node group.
-func (asg *tcAsg) MaxSize() int {
+func (asg *tcAsg) MaxSize(ctx context.Context) int {
 	return asg.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (asg *tcAsg) MinSize() int {
+func (asg *tcAsg) MinSize(ctx context.Context) int {
 	return asg.minSize
 }
 
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kuberentes.
-func (asg *tcAsg) TargetSize() (int, error) {
+func (asg *tcAsg) TargetSize(ctx context.Context) (int, error) {
 	size, err := asg.tencentcloudManager.GetAsgSize(asg)
 	return int(size), err
 }
 
 // IncreaseSize increases Asg size
-func (asg *tcAsg) IncreaseSize(delta int) error {
+func (asg *tcAsg) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -119,14 +120,14 @@ func (asg *tcAsg) IncreaseSize(delta int) error {
 	if err != nil {
 		return err
 	}
-	if int(size)+delta > asg.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, asg.MaxSize())
+	if int(size)+delta > asg.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, asg.MaxSize(context.TODO()))
 	}
 	return asg.tencentcloudManager.SetAsgSize(asg, size+int64(delta))
 }
 
 // AtomicIncreaseSize is not implemented.
-func (asg *tcAsg) AtomicIncreaseSize(delta int) error {
+func (asg *tcAsg) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -135,7 +136,7 @@ func (asg *tcAsg) AtomicIncreaseSize(delta int) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes if the size
 // when there is an option to just decrease the target.
-func (asg *tcAsg) DecreaseTargetSize(delta int) error {
+func (asg *tcAsg) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease size must be negative")
 	}
@@ -143,8 +144,8 @@ func (asg *tcAsg) DecreaseTargetSize(delta int) error {
 	if err != nil {
 		return err
 	}
-	if int(size)+delta < asg.MinSize() {
-		return fmt.Errorf("size increase too small - desired:%d min:%d", int(size)+delta, asg.MaxSize())
+	if int(size)+delta < asg.MinSize(context.TODO()) {
+		return fmt.Errorf("size increase too small - desired:%d min:%d", int(size)+delta, asg.MaxSize(context.TODO()))
 	}
 	nodes, err := asg.tencentcloudManager.GetAsgNodes(asg)
 	if err != nil {
@@ -181,34 +182,34 @@ func (asg *tcAsg) Belongs(node *apiv1.Node) (bool, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one.
-func (asg *tcAsg) Exist() bool {
+func (asg *tcAsg) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side.
-func (asg *tcAsg) Create() (cloudprovider.NodeGroup, error) {
+func (asg *tcAsg) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrAlreadyExist
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
-func (asg *tcAsg) Delete() error {
+func (asg *tcAsg) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned.
-func (asg *tcAsg) Autoprovisioned() bool {
+func (asg *tcAsg) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // DeleteNodes deletes the nodes from the group.
-func (asg *tcAsg) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *tcAsg) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	size, err := asg.tencentcloudManager.GetAsgSize(asg)
 	if err != nil {
 		return err
 	}
 
-	if int(size) <= asg.MinSize() {
+	if int(size) <= asg.MinSize(context.TODO()) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
@@ -232,7 +233,7 @@ func (asg *tcAsg) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (asg *tcAsg) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (asg *tcAsg) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -242,17 +243,17 @@ func (asg *tcAsg) Id() string {
 }
 
 // Debug returns a debug string for the Asg.
-func (asg *tcAsg) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(), asg.MaxSize())
+func (asg *tcAsg) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(context.TODO()), asg.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
-func (asg *tcAsg) Nodes() ([]cloudprovider.Instance, error) {
+func (asg *tcAsg) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	return asg.tencentcloudManager.GetAsgNodes(asg)
 }
 
 // TemplateNodeInfo returns a node template for this node group.
-func (asg *tcAsg) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (asg *tcAsg) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	node, err := asg.tencentcloudManager.GetAsgTemplateNode(asg)
 	if err != nil {
 		return nil, err
@@ -265,6 +266,6 @@ func (asg *tcAsg) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (asg *tcAsg) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (asg *tcAsg) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, nil
 }

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tencentcloud
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -80,7 +81,7 @@ func buildStaticallyDiscoveringProvider(tencentcloudManager TencentcloudManager,
 }
 
 // Cleanup ...
-func (tencentcloud *tencentCloudProvider) Cleanup() error {
+func (tencentcloud *tencentCloudProvider) Cleanup(ctx context.Context) error {
 	tencentcloud.tencentcloudManager.Cleanup()
 	return nil
 }
@@ -91,7 +92,7 @@ func (tencentcloud *tencentCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (tencentcloud *tencentCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (tencentcloud *tencentCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	asgs := tencentcloud.tencentcloudManager.GetAsgs()
 	result := make([]cloudprovider.NodeGroup, 0, len(asgs))
 	for _, asg := range asgs {
@@ -101,7 +102,7 @@ func (tencentcloud *tencentCloudProvider) NodeGroups() []cloudprovider.NodeGroup
 }
 
 // NodeGroupForNode returns the node group for the given node.
-func (tencentcloud *tencentCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (tencentcloud *tencentCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	if node.Spec.ProviderID == "" {
 		return nil, nil
 	}
@@ -123,45 +124,45 @@ func (tencentcloud *tencentCloudProvider) NodeGroupForNode(node *apiv1.Node) (cl
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (tencentcloud *tencentCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (tencentcloud *tencentCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (tencentcloud *tencentCloudProvider) GPULabel() string {
+func (tencentcloud *tencentCloudProvider) GPULabel(ctx context.Context) string {
 	return GPULabel
 }
 
 // GetAvailableGPUTypes returns all available GPU types cloud provider supports.
-func (tencentcloud *tencentCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (tencentcloud *tencentCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return availableGPUTypes
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (tencentcloud *tencentCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(tencentcloud, node)
+func (tencentcloud *tencentCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), tencentcloud, node)
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (tencentcloud *tencentCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (tencentcloud *tencentCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
-func (tencentcloud *tencentCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (tencentcloud *tencentCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
-func (tencentcloud *tencentCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string,
+func (tencentcloud *tencentCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string,
 	taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (tencentcloud *tencentCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (tencentcloud *tencentCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	resourceLimiter, err := tencentcloud.tencentcloudManager.GetResourceLimiter()
 	if err != nil {
 		return nil, err
@@ -174,7 +175,7 @@ func (tencentcloud *tencentCloudProvider) GetResourceLimiter() (*cloudprovider.R
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (tencentcloud *tencentCloudProvider) Refresh() error {
+func (tencentcloud *tencentCloudProvider) Refresh(ctx context.Context) error {
 
 	klog.V(4).Infof("Refresh loop")
 

--- a/cluster-autoscaler/cloudprovider/utho/utho_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/utho/utho_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utho
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -65,7 +66,7 @@ func (u *uthoCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (u *uthoCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (u *uthoCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodeGroups := make([]cloudprovider.NodeGroup, len(u.manager.nodeGroups))
 	for i, ng := range u.manager.nodeGroups {
 		nodeGroups[i] = ng
@@ -76,7 +77,7 @@ func (u *uthoCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (u *uthoCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (u *uthoCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	rawID := node.Spec.ProviderID
 	if rawID == "" {
 		if lbl, exists := node.Labels["node_id"]; exists {
@@ -93,7 +94,7 @@ func (u *uthoCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.No
 
 	for _, group := range u.manager.nodeGroups {
 		klog.V(5).Infof("iterating over node group %q", group.Id())
-		nodes, err := group.Nodes()
+		nodes, err := group.Nodes(context.TODO())
 		if err != nil {
 			return nil, fmt.Errorf("failed to list nodes for group %q: %w", group.Id(), err)
 		}
@@ -114,19 +115,19 @@ func (u *uthoCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.No
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (u *uthoCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (u *uthoCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (u *uthoCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (u *uthoCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (u *uthoCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (u *uthoCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
@@ -134,7 +135,7 @@ func (u *uthoCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // provided. The node group is not automatically created on the cloud provider
 // side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (u *uthoCloudProvider) NewNodeGroup(
+func (u *uthoCloudProvider) NewNodeGroup(ctx context.Context,
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
@@ -145,34 +146,34 @@ func (u *uthoCloudProvider) NewNodeGroup(
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (u *uthoCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (u *uthoCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return u.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (u *uthoCloudProvider) GPULabel() string {
+func (u *uthoCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (u *uthoCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (u *uthoCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (u *uthoCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(u, node)
+func (u *uthoCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), u, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (u *uthoCloudProvider) Cleanup() error {
+func (u *uthoCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (u *uthoCloudProvider) Refresh() error {
+func (u *uthoCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Info("Refreshing node group cache")
 	return u.manager.Refresh()
 }

--- a/cluster-autoscaler/cloudprovider/utho/utho_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/utho/utho_cloud_provider_test.go
@@ -72,10 +72,10 @@ func TestUthoCloudProvider_NewNodeGroup_Success(t *testing.T) {
 	manager.client = client
 	provider := newUthoCloudProvider(manager, &cloudprovider.ResourceLimiter{})
 
-	err = provider.Refresh()
+	err = provider.Refresh(context.Background())
 	assert.NoError(t, err)
 
-	nodes := provider.NodeGroups()
+	nodes := provider.NodeGroups(context.Background())
 	assert.Equal(t, 2, len(nodes), "number of nodes do not match")
 }
 
@@ -118,11 +118,11 @@ func TestUthoCloudProvider_NodeGroupForNode_Success(t *testing.T) {
 	manager.client = client
 	provider := newUthoCloudProvider(manager, &cloudprovider.ResourceLimiter{})
 
-	err = provider.Refresh()
+	err = provider.Refresh(context.Background())
 	assert.NoError(t, err)
 
 	node := &apiv1.Node{Spec: apiv1.NodeSpec{ProviderID: toProviderID("1234")}}
-	nodeGroup, err := provider.NodeGroupForNode(node)
+	nodeGroup, err := provider.NodeGroupForNode(context.Background(), node)
 	require.NoError(t, err)
 
 	require.NotNil(t, nodeGroup)
@@ -154,10 +154,10 @@ func TestUthoCloudProvider_Refresh_EmptyNodePools(t *testing.T) {
 	manager.client = client
 	provider := newUthoCloudProvider(manager, &cloudprovider.ResourceLimiter{})
 
-	err = provider.Refresh()
+	err = provider.Refresh(context.Background())
 	assert.NoError(t, err)
 
-	nodes := provider.NodeGroups()
+	nodes := provider.NodeGroups(context.Background())
 	assert.Equal(t, 0, len(nodes), "expected no node groups")
 
 }
@@ -176,7 +176,7 @@ func TestUthoCloudProvider_Refresh_ErrorFromAPI(t *testing.T) {
 	manager.client = client
 	provider := newUthoCloudProvider(manager, &cloudprovider.ResourceLimiter{})
 
-	err = provider.Refresh()
+	err = provider.Refresh(context.Background())
 	assert.Error(t, err, "expected an error from ListNodePools")
 
 }

--- a/cluster-autoscaler/cloudprovider/utho/utho_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/utho/utho_manager_test.go
@@ -114,7 +114,7 @@ func TestManager_Refresh(t *testing.T) {
 
 		// Verify first node group
 		assert.Equal(t, 1, manager.nodeGroups[0].minSize)
-		assert.Equal(t, 3, manager.nodeGroups[0].MaxSize())
+		assert.Equal(t, 3, manager.nodeGroups[0].MaxSize(context.Background()))
 
 		// Verify second node group
 		assert.Equal(t, 2, manager.nodeGroups[1].minSize)
@@ -206,7 +206,7 @@ func TestNodeGroup_Nodes_EmptyWorkers(t *testing.T) {
 		Workers: []utho.WorkerNode{},
 	})
 
-	nodes, err := nodeGroup.Nodes()
+	nodes, err := nodeGroup.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Empty(t, nodes, "nodes should be empty when no workers exist")
 }
@@ -220,7 +220,7 @@ func TestNodeGroup_Nodes_NilNodePool(t *testing.T) {
 		nodePool:  nil,
 	}
 
-	nodes, err := nodeGroup.Nodes()
+	nodes, err := nodeGroup.Nodes(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, nodes)
 	assert.Contains(t, err.Error(), "node pool instance is not created")

--- a/cluster-autoscaler/cloudprovider/utho/utho_node_group.go
+++ b/cluster-autoscaler/cloudprovider/utho/utho_node_group.go
@@ -100,15 +100,18 @@ func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 		NodePoolId: n.id,
 		Count:      strconv.Itoa(targetSize),
 	}
-	ctx2 := context.Background()
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
 	klog.V(4).Infof("IncreaseSize: calling UpdateNodePool with targetSize=%d for node group %s", targetSize, n.id)
-	_, err := n.client.UpdateNodePool(ctx2, param)
+	_, err := n.client.UpdateNodePool(emptyCtx, param)
 	if err != nil {
 		klog.Errorf("IncreaseSize: UpdateNodePool API error for node group %s: %v", n.id, err)
 		return err
 	}
 
-	nodePool, err := n.client.ReadNodePool(ctx, n.clusterID, n.id)
+	nodePool, err := n.client.ReadNodePool(emptyCtx, n.clusterID, n.id)
 	if err != nil {
 		klog.Errorf("IncreaseSize: ReadNodePool API error for node group %s: %v", n.id, err)
 		return fmt.Errorf("failed to read node pool after update for node group %s: %w", n.id, err)
@@ -139,7 +142,10 @@ func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	klog.V(4).Infof("DeleteNodes: requested deletion of %d nodes from pool %s", len(nodes), n.id)
 
-	ctx2 := context.Background()
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
 
 	for _, node := range nodes {
 		// Find the node ID label
@@ -164,7 +170,7 @@ func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error 
 		klog.V(4).Infof("DeleteNodes: calling DeleteNode(cluster=%d, pool=%s, node=%s)",
 			n.clusterID, n.id, nodeID)
 
-		if _, err := n.client.DeleteNode(ctx2, param); err != nil {
+		if _, err := n.client.DeleteNode(emptyCtx, param); err != nil {
 			klog.Errorf("DeleteNodes: API error for cluster %d pool %s node %s: %v",
 				n.clusterID, n.id, nodeID, err)
 			return fmt.Errorf("deleting node failed for cluster %d node pool %q node %q: %w",
@@ -214,9 +220,12 @@ func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 		Label:      uthoLabel,
 		Size:       strconv.Itoa(targetSize),
 	}
-	ctx2 := context.Background()
+	// The ctx parameter was added to the NodeGroup interface methods, and all in-tree NodeGroup implementations were mechanically adapted as part of that (PR#10164).
+	// This particular method had already been using a Context object internally - its usage was kept as-is, it was just renamed to `emptyCtx`.
+	// This should likely be refactored away, and the method should likely just propagate the `ctx` parameter instead.
+	emptyCtx := context.Background()
 	klog.V(4).Infof("DecreaseTargetSize: calling UpdateNodePool with targetSize=%d for node group %s", targetSize, n.id)
-	updatedNodePool, err := n.client.UpdateNodePool(ctx2, req)
+	updatedNodePool, err := n.client.UpdateNodePool(emptyCtx, req)
 	if err != nil {
 		klog.Errorf("DecreaseTargetSize: UpdateNodePool API error for node group %s: %v", n.id, err)
 		return err

--- a/cluster-autoscaler/cloudprovider/utho/utho_node_group.go
+++ b/cluster-autoscaler/cloudprovider/utho/utho_node_group.go
@@ -57,12 +57,12 @@ type NodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *NodeGroup) MaxSize() int {
+func (n *NodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *NodeGroup) MinSize() int {
+func (n *NodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
@@ -71,14 +71,14 @@ func (n *NodeGroup) MinSize() int {
 // be equal to Size() once everything stabilizes (new nodes finish startup and
 // registration or removed nodes are deleted completely). Implementation
 // required.
-func (n *NodeGroup) TargetSize() (int, error) {
+func (n *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return n.nodePool.Count, nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (n *NodeGroup) IncreaseSize(delta int) error {
+func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("IncreaseSize: requested delta=%d for node group %s", delta, n.id)
 
 	if delta <= 0 {
@@ -88,11 +88,11 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 
 	targetSize := n.nodePool.Count + delta
 
-	if targetSize > n.MaxSize() {
+	if targetSize > n.MaxSize(context.TODO()) {
 		klog.Errorf("IncreaseSize: size increase too large for node group %s. current: %d, desired: %d, max: %d",
-			n.id, n.nodePool.Count, targetSize, n.MaxSize())
+			n.id, n.nodePool.Count, targetSize, n.MaxSize(context.TODO()))
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			n.nodePool.Count, targetSize, n.MaxSize())
+			n.nodePool.Count, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	param := utho.UpdateKubernetesAutoscaleNodepool{
@@ -100,9 +100,9 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 		NodePoolId: n.id,
 		Count:      strconv.Itoa(targetSize),
 	}
-	ctx := context.Background()
+	ctx2 := context.Background()
 	klog.V(4).Infof("IncreaseSize: calling UpdateNodePool with targetSize=%d for node group %s", targetSize, n.id)
-	_, err := n.client.UpdateNodePool(ctx, param)
+	_, err := n.client.UpdateNodePool(ctx2, param)
 	if err != nil {
 		klog.Errorf("IncreaseSize: UpdateNodePool API error for node group %s: %v", n.id, err)
 		return err
@@ -128,7 +128,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -136,10 +136,10 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	klog.V(4).Infof("DeleteNodes: requested deletion of %d nodes from pool %s", len(nodes), n.id)
 
-	ctx := context.Background()
+	ctx2 := context.Background()
 
 	for _, node := range nodes {
 		// Find the node ID label
@@ -164,7 +164,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		klog.V(4).Infof("DeleteNodes: calling DeleteNode(cluster=%d, pool=%s, node=%s)",
 			n.clusterID, n.id, nodeID)
 
-		if _, err := n.client.DeleteNode(ctx, param); err != nil {
+		if _, err := n.client.DeleteNode(ctx2, param); err != nil {
 			klog.Errorf("DeleteNodes: API error for cluster %d pool %s node %s: %v",
 				n.clusterID, n.id, nodeID, err)
 			return fmt.Errorf("deleting node failed for cluster %d node pool %q node %q: %w",
@@ -182,7 +182,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -191,7 +191,7 @@ func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (n *NodeGroup) DecreaseTargetSize(delta int) error {
+func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	klog.V(4).Infof("DecreaseTargetSize: requested delta=%d for node group %s", delta, n.id)
 
 	if delta >= 0 {
@@ -200,11 +200,11 @@ func (n *NodeGroup) DecreaseTargetSize(delta int) error {
 	}
 
 	targetSize := n.nodePool.Count + delta
-	if targetSize < n.MinSize() {
+	if targetSize < n.MinSize(context.TODO()) {
 		klog.Errorf("DecreaseTargetSize: size decrease too small for node group %s. current: %d, desired: %d, min: %d",
-			n.Id(), n.nodePool.Count, targetSize, n.MinSize())
+			n.Id(), n.nodePool.Count, targetSize, n.MinSize(context.TODO()))
 		return fmt.Errorf("node group %s: size decrease is too small. current size: %d, desired size: %d, minimum size: %d",
-			n.Id(), n.nodePool.Count, targetSize, n.MinSize())
+			n.Id(), n.nodePool.Count, targetSize, n.MinSize(context.TODO()))
 	}
 
 	req := utho.UpdateKubernetesAutoscaleNodepool{
@@ -214,9 +214,9 @@ func (n *NodeGroup) DecreaseTargetSize(delta int) error {
 		Label:      uthoLabel,
 		Size:       strconv.Itoa(targetSize),
 	}
-	ctx := context.Background()
+	ctx2 := context.Background()
 	klog.V(4).Infof("DecreaseTargetSize: calling UpdateNodePool with targetSize=%d for node group %s", targetSize, n.id)
-	updatedNodePool, err := n.client.UpdateNodePool(ctx, req)
+	updatedNodePool, err := n.client.UpdateNodePool(ctx2, req)
 	if err != nil {
 		klog.Errorf("DecreaseTargetSize: UpdateNodePool API error for node group %s: %v", n.id, err)
 		return err
@@ -241,14 +241,14 @@ func (n *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroup) Debug() string {
-	return fmt.Sprintf("node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *NodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.  It is
 // required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
-func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	klog.V(5).Infof("Checking nodes for node group %s", n.Id())
 
 	if n.nodePool == nil {
@@ -286,7 +286,7 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // all of the labels, capacity and allocatable information as well as all pods
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
-func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	klog.V(4).Infof("TemplateNodeInfo: start for node-group %s", n.id)
 
 	if n.nodePool == nil {
@@ -342,31 +342,31 @@ func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 // Exist checks if the node group really exists on the cloud provider side.
 // Allows to tell the theoretical node group from the real one. Implementation
 // required.
-func (n *NodeGroup) Exist() bool {
+func (n *NodeGroup) Exist(ctx context.Context) bool {
 	return n.nodePool != nil
 }
 
 // Create creates the node group on the cloud provider side. Implementation
 // optional.
-func (n *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.  This will be
 // executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroup) Delete() error {
+func (n *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroup) Autoprovisioned() bool {
+func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/utho/utho_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/utho/utho_node_group_test.go
@@ -38,7 +38,7 @@ func TestNodeGroup_Debug(t *testing.T) {
 		MaxNodes: 10,
 	})
 
-	d := ng.Debug()
+	d := ng.Debug(context.Background())
 	exp := "node group ID: pool-123 (min:1 max:10)"
 	assert.Equal(t, exp, d, "debug string do not match")
 }
@@ -51,7 +51,7 @@ func TestNodeGroup_TargetSize(t *testing.T) {
 		Count: numberOfNodes,
 	})
 
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, numberOfNodes, size, "target size is not correct")
 }
@@ -62,7 +62,7 @@ func TestNodeGroup_TargetSize_WithZeroCount(t *testing.T) {
 		Count: 0,
 	})
 
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 0, size, "target size should be zero")
 }
@@ -94,7 +94,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 				MaxNodes: 3,
 			}, nil).Once()
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.NoError(t, err)
 		client.AssertExpectations(t)
 	})
@@ -106,7 +106,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		ng := testNodeGroup(client, &utho.NodepoolDetails{
 			Count: numberOfNodes,
 		})
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
@@ -122,7 +122,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
 	})
 
@@ -136,9 +136,9 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		})
 
 		exp := fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			nodes, nodes+delta, ng.MaxSize())
+			nodes, nodes+delta, ng.MaxSize(context.Background()))
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase is too large")
 	})
 }
@@ -165,7 +165,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 				Size:       strconv.Itoa(newQuant),
 			}).Return(&utho.UpdateKubernetesAutoscaleNodepoolResponse{Count: newQuant}, nil).Once()
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.NoError(t, err, "expected no error when decreasing target size")
 		assert.Equal(t, newQuant, ng.nodePool.Count, "node pool count should be updated")
 		client.AssertExpectations(t)
@@ -179,7 +179,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		})
 
 		delta := 1
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be negative, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease must be negative")
@@ -196,8 +196,8 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		})
 
 		exp := fmt.Errorf("node group %s: size decrease is too small. current size: %d, desired size: %d, minimum size: %d",
-			"pool-123", numberOfNodes, numberOfNodes+delta, ng.MinSize())
-		err := ng.DecreaseTargetSize(delta)
+			"pool-123", numberOfNodes, numberOfNodes+delta, ng.MinSize(context.Background()))
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease is too small")
 	})
 }
@@ -224,7 +224,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 		},
 	}
 
-	nodes, err := ng.Nodes()
+	nodes, err := ng.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, instances, nodes, "nodes do not match")
 }
@@ -247,7 +247,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			NodeId:    "123",
 		}).Return(&utho.DeleteResponse{}, nil).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.NoError(t, err)
 		client.AssertExpectations(t)
 	})
@@ -269,7 +269,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 			NodeId:    "123",
 		}).Return(&utho.DeleteResponse{}, errors.New("delete error")).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.Error(t, err)
 		errMsg := err.Error()
 		assert.Contains(t, errMsg, "deleting node failed for cluster", "error should indicate node deletion failure")
@@ -292,7 +292,7 @@ func TestNodeGroup_DeleteNodes_WithMissingLabel(t *testing.T) {
 	nodes := []*apiv1.Node{
 		{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}},
 	}
-	err := ng.DeleteNodes(nodes)
+	err := ng.DeleteNodes(context.Background(), nodes)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "node ID label is missing")
 }
@@ -301,7 +301,7 @@ func TestNodeGroup_Exist(t *testing.T) {
 	client := &uthoClientMock{}
 	nodeGroup := testNodeGroup(client, &utho.NodepoolDetails{MinNodes: 1, MaxNodes: 2})
 
-	assert.Equal(t, true, nodeGroup.Exist(), "nodegroup should exist")
+	assert.Equal(t, true, nodeGroup.Exist(context.Background()), "nodegroup should exist")
 
 }
 
@@ -322,7 +322,7 @@ func TestNodeGroup_IncreaseSize_WithUpdateFailure(t *testing.T) {
 				Count:      "3",
 			}).Return((*utho.UpdateKubernetesAutoscaleNodepoolResponse)(nil), expectedErr).Once()
 
-		err := nodeGroup.IncreaseSize(1)
+		err := nodeGroup.IncreaseSize(context.Background(), 1)
 		assert.Error(t, err)
 		assert.Equal(t, expectedErr, err)
 		client.AssertExpectations(t)
@@ -350,7 +350,7 @@ func TestNodeGroup_IncreaseSize_WithUpdateFailure(t *testing.T) {
 				MaxNodes: 5,
 			}, nil).Once()
 
-		err := nodeGroup.IncreaseSize(1)
+		err := nodeGroup.IncreaseSize(context.Background(), 1)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "couldn't increase size")
 		client.AssertExpectations(t)
@@ -397,7 +397,7 @@ func TestNodeGroup_DeleteNodes_MultipleNodes(t *testing.T) {
 			NodeId:    "456",
 		}).Return(&utho.DeleteResponse{}, nil).Once()
 
-		err := nodeGroup.DeleteNodes(nodes)
+		err := nodeGroup.DeleteNodes(context.Background(), nodes)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, nodeGroup.nodePool.Count) // Should decrease by 2
 		client.AssertExpectations(t)
@@ -413,7 +413,7 @@ func TestNodeGroup_DecreaseTargetSize_WithValidation(t *testing.T) {
 			MaxNodes: 5,
 		})
 
-		err := nodeGroup.DecreaseTargetSize(-2)
+		err := nodeGroup.DecreaseTargetSize(context.Background(), -2)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "size decrease is too small")
 	})
@@ -435,7 +435,7 @@ func TestNodeGroup_DecreaseTargetSize_WithValidation(t *testing.T) {
 				Size:       "4",
 			}).Return(&utho.UpdateKubernetesAutoscaleNodepoolResponse{Count: 4}, nil).Once()
 
-		err := nodeGroup.DecreaseTargetSize(-1)
+		err := nodeGroup.DecreaseTargetSize(context.Background(), -1)
 		assert.NoError(t, err)
 		assert.Equal(t, 4, nodeGroup.nodePool.Count)
 		client.AssertExpectations(t)
@@ -451,7 +451,7 @@ func TestNodeGroup_Nodes_WithInvalidWorkers(t *testing.T) {
 		},
 	})
 
-	nodes, err := nodeGroup.Nodes()
+	nodes, err := nodeGroup.Nodes(context.Background())
 	assert.NoError(t, err)
 	for _, instance := range nodes {
 		assert.Contains(t, instance.Id, uthoProviderIDPrefix, "provider ID should contain prefix")
@@ -465,8 +465,8 @@ func TestNodeGroup_MinSize_Validation(t *testing.T) {
 		MaxNodes: 5,
 	})
 
-	assert.Equal(t, 2, ng.MinSize())
-	assert.Less(t, ng.MinSize(), ng.MaxSize(), "min size should be less than max size")
+	assert.Equal(t, 2, ng.MinSize(context.Background()))
+	assert.Less(t, ng.MinSize(context.Background()), ng.MaxSize(context.Background()), "min size should be less than max size")
 }
 
 func TestNodeGroup_DeleteNodes_WorkerStatus(t *testing.T) {
@@ -490,7 +490,7 @@ func TestNodeGroup_DeleteNodes_WorkerStatus(t *testing.T) {
 			NodeId:    "123",
 		}).Return(&utho.DeleteResponse{}, nil).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.NoError(t, err)
 		client.AssertExpectations(t)
 	})
@@ -505,7 +505,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 			},
 		})
 
-		nodeInfo, err := nodeGroup.TemplateNodeInfo()
+		nodeInfo, err := nodeGroup.TemplateNodeInfo(context.Background())
 		assert.NoError(t, err)
 		assert.NotNil(t, nodeInfo)
 
@@ -522,7 +522,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 			Workers: []utho.WorkerNode{},
 		})
 
-		nodeInfo, err := nodeGroup.TemplateNodeInfo()
+		nodeInfo, err := nodeGroup.TemplateNodeInfo(context.Background())
 		assert.Error(t, err)
 		assert.Nil(t, nodeInfo)
 		assert.Contains(t, err.Error(), "node pool pool-123 has no example worker")
@@ -532,7 +532,7 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 		client := &uthoClientMock{}
 		nodeGroup := testNodeGroup(client, nil)
 
-		nodeInfo, err := nodeGroup.TemplateNodeInfo()
+		nodeInfo, err := nodeGroup.TemplateNodeInfo(context.Background())
 		assert.Error(t, err)
 		assert.Nil(t, nodeInfo)
 		assert.Contains(t, err.Error(), fmt.Sprintf("node pool %s has no example worker to derive resources", nodeGroup.id))

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine_auto_scaling_group.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volcengine
 
 import (
+	"context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -35,12 +36,12 @@ type AutoScalingGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (asg *AutoScalingGroup) MaxSize() int {
+func (asg *AutoScalingGroup) MaxSize(ctx context.Context) int {
 	return asg.maxInstanceNumber
 }
 
 // MinSize returns minimum size of the node group.
-func (asg *AutoScalingGroup) MinSize() int {
+func (asg *AutoScalingGroup) MinSize(ctx context.Context) int {
 	return asg.minInstanceNumber
 }
 
@@ -48,14 +49,14 @@ func (asg *AutoScalingGroup) MinSize() int {
 // number of nodes in Kubernetes is different at the moment but should be equal
 // to Size() once everything stabilizes (new nodes finish startup and registration or
 // removed nodes are deleted completely). Implementation required.
-func (asg *AutoScalingGroup) TargetSize() (int, error) {
+func (asg *AutoScalingGroup) TargetSize(ctx context.Context) (int, error) {
 	return asg.manager.GetAsgDesireCapacity(asg.asgId)
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated. Implementation required.
-func (asg *AutoScalingGroup) IncreaseSize(delta int) error {
+func (asg *AutoScalingGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
@@ -63,27 +64,27 @@ func (asg *AutoScalingGroup) IncreaseSize(delta int) error {
 	if err != nil {
 		return err
 	}
-	if size+delta > asg.MaxSize() {
-		return fmt.Errorf("size increase is too large - desired:%d max:%d", size+delta, asg.MaxSize())
+	if size+delta > asg.MaxSize(context.TODO()) {
+		return fmt.Errorf("size increase is too large - desired:%d max:%d", size+delta, asg.MaxSize(context.TODO()))
 	}
 	return asg.manager.SetAsgTargetSize(asg.asgId, size+delta)
 }
 
 // AtomicIncreaseSize is not implemented.
-func (asg *AutoScalingGroup) AtomicIncreaseSize(delta int) error {
+func (asg *AutoScalingGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // DeleteNodes deletes nodes from this node group. Error is returned either on
 // failure or if the given node doesn't belong to this node group. This function
 // should wait until node group size is updated. Implementation required.
-func (asg *AutoScalingGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (asg *AutoScalingGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	size, err := asg.manager.GetAsgDesireCapacity(asg.asgId)
 	if err != nil {
 		klog.Errorf("Failed to get desire capacity for %s: %v", asg.asgId, err)
 		return err
 	}
-	if size <= asg.MinSize() {
+	if size <= asg.MinSize(context.TODO()) {
 		klog.Errorf("Failed to delete nodes from %s: min size reached", asg.asgId)
 		return fmt.Errorf("asg min size reached")
 	}
@@ -107,7 +108,7 @@ func (asg *AutoScalingGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (asg *AutoScalingGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (asg *AutoScalingGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -131,7 +132,7 @@ func (asg *AutoScalingGroup) belongs(node *apiv1.Node) (bool, error) {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target. Implementation required.
-func (asg *AutoScalingGroup) DecreaseTargetSize(delta int) error {
+func (asg *AutoScalingGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease size must be negative")
 	}
@@ -158,15 +159,15 @@ func (asg *AutoScalingGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (asg *AutoScalingGroup) Debug() string {
-	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(), asg.MaxSize())
+func (asg *AutoScalingGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("%s (%d:%d)", asg.Id(), asg.MinSize(context.TODO()), asg.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
 // It is required that Instance objects returned by this method have Id field set.
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
-func (asg *AutoScalingGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (asg *AutoScalingGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	nodes, err := asg.manager.GetAsgNodes(asg.asgId)
 	if err != nil {
 		return nil, err
@@ -180,7 +181,7 @@ func (asg *AutoScalingGroup) Nodes() ([]cloudprovider.Instance, error) {
 // NodeInfo is expected to have a fully populated Node object, with all of the labels,
 // capacity and allocatable information as well as all pods that are started on
 // the node by default, using manifest (most likely only kube-proxy). Implementation optional.
-func (asg *AutoScalingGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (asg *AutoScalingGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	template, err := asg.manager.getAsgTemplate(asg.asgId)
 	if err != nil {
 		return nil, err
@@ -195,31 +196,31 @@ func (asg *AutoScalingGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 
 // Exist checks if the node group really exists on the cloud provider side. Allows to tell the
 // theoretical node group from the real one. Implementation required.
-func (asg *AutoScalingGroup) Exist() bool {
+func (asg *AutoScalingGroup) Exist(ctx context.Context) bool {
 	return true
 }
 
 // Create creates the node group on the cloud provider side. Implementation optional.
-func (asg *AutoScalingGroup) Create() (cloudprovider.NodeGroup, error) {
+func (asg *AutoScalingGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.
 // This will be executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (asg *AutoScalingGroup) Delete() error {
+func (asg *AutoScalingGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An autoprovisioned group
 // was created by CA and can be deleted when scaled to 0.
-func (asg *AutoScalingGroup) Autoprovisioned() bool {
+func (asg *AutoScalingGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 // Implementation optional.
-func (asg *AutoScalingGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (asg *AutoScalingGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volcengine
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -58,7 +59,7 @@ func (v *volcengineCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (v *volcengineCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (v *volcengineCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	result := make([]cloudprovider.NodeGroup, 0, len(v.scalingGroups))
 	for _, ng := range v.scalingGroups {
 		result = append(result, ng)
@@ -69,7 +70,7 @@ func (v *volcengineCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (v *volcengineCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (v *volcengineCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	instanceId, err := ecsInstanceFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		return nil, err
@@ -90,59 +91,59 @@ func (v *volcengineCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovi
 
 // HasInstance returns whether the node has corresponding instance in cloud provider,
 // true if the node has an instance, false if it no longer exists
-func (v *volcengineCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (v *volcengineCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (v *volcengineCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (v *volcengineCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (v *volcengineCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (v *volcengineCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // NewNodeGroup builds a theoretical node group based on the node definition provided. The node group is not automatically
 // created on the cloud provider side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (v *volcengineCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (v *volcengineCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (v *volcengineCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (v *volcengineCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return v.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (v *volcengineCloudProvider) GPULabel() string {
+func (v *volcengineCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (v *volcengineCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (v *volcengineCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return map[string]struct{}{}
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (v *volcengineCloudProvider) Cleanup() error {
+func (v *volcengineCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (v *volcengineCloudProvider) Refresh() error {
+func (v *volcengineCloudProvider) Refresh(ctx context.Context) error {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (v *volcengineCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(v, node)
+func (v *volcengineCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), v, node)
 }
 
 func (v *volcengineCloudProvider) addNodeGroup(spec string) error {

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vultr
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -64,7 +65,7 @@ func (v *vultrCloudProvider) Name() string {
 }
 
 // NodeGroups returns all node groups configured for this cloud provider.
-func (v *vultrCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+func (v *vultrCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.NodeGroup {
 	nodeGroups := make([]cloudprovider.NodeGroup, len(v.manager.nodeGroups))
 	for i, ng := range v.manager.nodeGroups {
 		nodeGroups[i] = ng
@@ -75,12 +76,12 @@ func (v *vultrCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // NodeGroupForNode returns the node group for the given node, nil if the node
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
-func (v *vultrCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (v *vultrCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	providerID := node.Spec.ProviderID
 
 	// we want to find the pool for a specific node
 	for _, group := range v.manager.nodeGroups {
-		nodes, err := group.Nodes()
+		nodes, err := group.Nodes(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -98,19 +99,19 @@ func (v *vultrCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
-func (v *vultrCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+func (v *vultrCloudProvider) HasInstance(ctx context.Context, node *apiv1.Node) (bool, error) {
 	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
 // Implementation optional.
-func (v *vultrCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (v *vultrCloudProvider) Pricing(ctx context.Context) (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
 // Implementation optional.
-func (v *vultrCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+func (v *vultrCloudProvider) GetAvailableMachineTypes(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
@@ -118,39 +119,39 @@ func (v *vultrCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // provided. The node group is not automatically created on the cloud provider
 // side. The node group is not returned by NodeGroups() until it is created.
 // Implementation optional.
-func (v *vultrCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+func (v *vultrCloudProvider) NewNodeGroup(ctx context.Context, machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
-func (v *vultrCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (v *vultrCloudProvider) GetResourceLimiter(ctx context.Context) (*cloudprovider.ResourceLimiter, error) {
 	return v.resourceLimiter, nil
 }
 
 // GPULabel returns the label added to nodes with GPU resource.
-func (v *vultrCloudProvider) GPULabel() string {
+func (v *vultrCloudProvider) GPULabel(ctx context.Context) string {
 	return ""
 }
 
 // GetAvailableGPUTypes return all available GPU types cloud provider supports.
-func (v *vultrCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+func (v *vultrCloudProvider) GetAvailableGPUTypes(ctx context.Context) map[string]struct{} {
 	return nil
 }
 
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
-func (v *vultrCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
-	return gpu.GetNodeGPUFromCloudProvider(v, node)
+func (v *vultrCloudProvider) GetNodeGpuConfig(ctx context.Context, node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(context.TODO(), v, node)
 }
 
 // Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
-func (v *vultrCloudProvider) Cleanup() error {
+func (v *vultrCloudProvider) Cleanup(ctx context.Context) error {
 	return nil
 }
 
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
-func (v *vultrCloudProvider) Refresh() error {
+func (v *vultrCloudProvider) Refresh(ctx context.Context) error {
 	klog.V(4).Info("Refreshing node group cache")
 	return v.manager.Refresh()
 }

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider_test.go
@@ -107,10 +107,10 @@ func TestVultrCloudProvider_NewNodeGroup(t *testing.T) {
 	rl := &cloudprovider.ResourceLimiter{}
 
 	provider := newVultrCloudProvider(manager, rl)
-	err = provider.Refresh()
+	err = provider.Refresh(context.Background())
 	assert.NoError(t, err)
 
-	nodes := provider.NodeGroups()
+	nodes := provider.NodeGroups(context.Background())
 	assert.Equal(t, len(nodes), 2, "number of nodes do not match")
 
 }
@@ -165,12 +165,12 @@ func TestVultrCloudProvider_NodeGroupForNode(t *testing.T) {
 	rl := &cloudprovider.ResourceLimiter{}
 
 	provider := newVultrCloudProvider(manager, rl)
-	err = provider.Refresh()
+	err = provider.Refresh(context.Background())
 	assert.NoError(t, err)
 
 	node := &apiv1.Node{Spec: apiv1.NodeSpec{ProviderID: toProviderID("np-1234")}}
 
-	nodeGroup, err := provider.NodeGroupForNode(node)
+	nodeGroup, err := provider.NodeGroupForNode(context.Background(), node)
 	require.NoError(t, err)
 
 	require.NotNil(t, nodeGroup)

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_manager_test.go
@@ -94,7 +94,7 @@ func TestManager_Refresh(t *testing.T) {
 	assert.Equal(t, len(manager.nodeGroups), 2, "number of nodepools do not match")
 
 	assert.Equal(t, manager.nodeGroups[0].minSize, 1, "minimum node for first group does not match")
-	assert.Equal(t, manager.nodeGroups[0].MaxSize(), 2, "minimum node for first group does not match")
+	assert.Equal(t, manager.nodeGroups[0].MaxSize(context.Background()), 2, "minimum node for first group does not match")
 	//
 	assert.Equal(t, manager.nodeGroups[1].minSize, 5, "minimum node for first group does not match")
 	assert.Equal(t, manager.nodeGroups[1].maxSize, 8, "minimum node for first group does not match")

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
@@ -47,12 +47,12 @@ type NodeGroup struct {
 }
 
 // MaxSize returns maximum size of the node group.
-func (n *NodeGroup) MaxSize() int {
+func (n *NodeGroup) MaxSize(ctx context.Context) int {
 	return n.maxSize
 }
 
 // MinSize returns minimum size of the node group.
-func (n *NodeGroup) MinSize() int {
+func (n *NodeGroup) MinSize(ctx context.Context) int {
 	return n.minSize
 }
 
@@ -61,22 +61,22 @@ func (n *NodeGroup) MinSize() int {
 // be equal to Size() once everything stabilizes (new nodes finish startup and
 // registration or removed nodes are deleted completely). Implementation
 // required.
-func (n *NodeGroup) TargetSize() (int, error) {
+func (n *NodeGroup) TargetSize(ctx context.Context) (int, error) {
 	return n.nodePool.NodeQuantity, nil
 }
 
 // IncreaseSize increases the size of the node group. To delete a node you need
 // to explicitly name it and use DeleteNode. This function should wait until
 // node group size is updated.
-func (n *NodeGroup) IncreaseSize(delta int) error {
+func (n *NodeGroup) IncreaseSize(ctx context.Context, delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("delta must be positive, have: %d", delta)
 	}
 
 	targetSize := n.nodePool.NodeQuantity + delta
-	if targetSize > n.MaxSize() {
+	if targetSize > n.MaxSize(context.TODO()) {
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			n.nodePool.NodeQuantity, targetSize, n.MaxSize())
+			n.nodePool.NodeQuantity, targetSize, n.MaxSize(context.TODO()))
 	}
 
 	req := &govultr.NodePoolReqUpdate{NodeQuantity: targetSize}
@@ -97,7 +97,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 }
 
 // AtomicIncreaseSize is not implemented.
-func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
+func (n *NodeGroup) AtomicIncreaseSize(ctx context.Context, delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -105,7 +105,7 @@ func (n *NodeGroup) AtomicIncreaseSize(delta int) error {
 // of the node group with that). Error is returned either on failure or if the
 // given node doesn't belong to this node group. This function should wait
 // until node group size is updated. Implementation required.
-func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	for _, node := range nodes {
 		nodeID, ok := node.Labels[nodeIDLabel]
 		providerID := node.Spec.ProviderID
@@ -130,7 +130,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (n *NodeGroup) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 
@@ -139,15 +139,15 @@ func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 // request for new nodes that have not been yet fulfilled. Delta should be negative.
 // It is assumed that cloud provider will not delete the existing nodes when there
 // is an option to just decrease the target.
-func (n *NodeGroup) DecreaseTargetSize(delta int) error {
+func (n *NodeGroup) DecreaseTargetSize(ctx context.Context, delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("delta must be negative, have: %d", delta)
 	}
 
 	targetSize := n.nodePool.NodeQuantity + delta
-	if targetSize < n.MinSize() {
+	if targetSize < n.MinSize(context.TODO()) {
 		return fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
-			n.nodePool.NodeQuantity, targetSize, n.MinSize())
+			n.nodePool.NodeQuantity, targetSize, n.MinSize(context.TODO()))
 	}
 
 	req := &govultr.NodePoolReqUpdate{NodeQuantity: targetSize}
@@ -172,14 +172,14 @@ func (n *NodeGroup) Id() string {
 }
 
 // Debug returns a string containing all information regarding this node group.
-func (n *NodeGroup) Debug() string {
-	return fmt.Sprintf("node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(), n.MaxSize())
+func (n *NodeGroup) Debug(ctx context.Context) string {
+	return fmt.Sprintf("node group ID: %s (min:%d max:%d)", n.Id(), n.MinSize(context.TODO()), n.MaxSize(context.TODO()))
 }
 
 // Nodes returns a list of all nodes that belong to this node group.  It is
 // required that Instance objects returned by this method have ID field set.
 // Other fields are optional.
-func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+func (n *NodeGroup) Nodes(ctx context.Context) ([]cloudprovider.Instance, error) {
 	if n.nodePool == nil {
 		return nil, errors.New("node pool instance is not created")
 	}
@@ -205,38 +205,38 @@ func (n *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 // all of the labels, capacity and allocatable information as well as all pods
 // that are started on the node by default, using manifest (most likely only
 // kube-proxy). Implementation optional.
-func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+func (n *NodeGroup) TemplateNodeInfo(ctx context.Context) (*framework.NodeInfo, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Exist checks if the node group really exists on the cloud provider side.
 // Allows to tell the theoretical node group from the real one. Implementation
 // required.
-func (n *NodeGroup) Exist() bool {
+func (n *NodeGroup) Exist(ctx context.Context) bool {
 	return n.nodePool != nil
 }
 
 // Create creates the node group on the cloud provider side. Implementation
 // optional.
-func (n *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+func (n *NodeGroup) Create(ctx context.Context) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
 // Delete deletes the node group on the cloud provider side.  This will be
 // executed only for autoprovisioned node groups, once their size drops to 0.
 // Implementation optional.
-func (n *NodeGroup) Delete() error {
+func (n *NodeGroup) Delete(ctx context.Context) error {
 	return cloudprovider.ErrNotImplemented
 }
 
 // Autoprovisioned returns true if the node group is autoprovisioned. An
 // autoprovisioned group was created by CA and can be deleted when scaled to 0.
-func (n *NodeGroup) Autoprovisioned() bool {
+func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 	return false
 }
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_node_group_test.go
@@ -37,7 +37,7 @@ func TestNodeGroup_Debug(t *testing.T) {
 		MaxNodes:     10,
 	})
 
-	d := ng.Debug()
+	d := ng.Debug(context.Background())
 	exp := "node group ID: a (min:1 max:10)"
 	assert.Equal(t, exp, d, "debug string do not match")
 }
@@ -50,7 +50,7 @@ func TestNodeGroup_TargetSize(t *testing.T) {
 		NodeQuantity: nodes,
 	})
 
-	size, err := ng.TargetSize()
+	size, err := ng.TargetSize(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, nodes, size, "target size is not correct")
 }
@@ -67,7 +67,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		client.On("UpdateNodePool", context.Background(), ng.clusterID, ng.id,
 			&govultr.NodePoolReqUpdate{NodeQuantity: newQaunt}).Return(&govultr.NodePool{NodeQuantity: newQaunt}, nil).Once()
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -78,7 +78,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		ng := testData(client, &govultr.NodePool{
 			NodeQuantity: numberOfNodes,
 		})
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
@@ -94,7 +94,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 
 		exp := fmt.Errorf("delta must be positive, have: %d", delta)
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase must be positive")
 	})
 
@@ -108,9 +108,9 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 		})
 
 		exp := fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			nodes, nodes+delta, ng.MaxSize())
+			nodes, nodes+delta, ng.MaxSize(context.Background()))
 
-		err := ng.IncreaseSize(delta)
+		err := ng.IncreaseSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size increase is too large")
 	})
 }
@@ -127,7 +127,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		client.On("UpdateNodePool", context.Background(), ng.clusterID, ng.id,
 			&govultr.NodePoolReqUpdate{NodeQuantity: newQaunt}).Return(&govultr.NodePool{NodeQuantity: newQaunt}, nil).Once()
 
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.NoError(t, err)
 	})
 
@@ -139,7 +139,7 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		})
 
 		delta := 1
-		err := ng.DecreaseTargetSize(delta)
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 
 		exp := fmt.Errorf("delta must be negative, have: %d", delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease must be negative")
@@ -156,8 +156,8 @@ func TestNodeGroup_DecreaseTargetSize(t *testing.T) {
 		})
 
 		exp := fmt.Errorf("size decrease is too small. current: %d desired: %d min: %d",
-			numberOfNodes, numberOfNodes+delta, ng.MinSize())
-		err := ng.DecreaseTargetSize(delta)
+			numberOfNodes, numberOfNodes+delta, ng.MinSize(context.Background()))
+		err := ng.DecreaseTargetSize(context.Background(), delta)
 		assert.EqualError(t, err, exp.Error(), "size decrease is too small")
 	})
 }
@@ -184,7 +184,7 @@ func TestNodeGroup_Nodes(t *testing.T) {
 		},
 	}
 
-	nodes, err := ng.Nodes()
+	nodes, err := ng.Nodes(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, instances, nodes, "nodes do not match")
 }
@@ -203,7 +203,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 
 		client.On("DeleteNodePoolInstance", ctx, ng.clusterID, ng.id, "a").Return(nil).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.NoError(t, err)
 	})
 
@@ -218,7 +218,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 
 		client.On("DeleteNodePoolInstance", ctx, ng.clusterID, ng.id, "a").Return(errors.New("error")).Once()
 
-		err := ng.DeleteNodes(nodes)
+		err := ng.DeleteNodes(context.Background(), nodes)
 		assert.Error(t, err)
 	})
 }
@@ -227,7 +227,7 @@ func TestNodeGroup_Exist(t *testing.T) {
 	client := &vultrClientMock{}
 	nodeGroup := testData(client, &govultr.NodePool{MinNodes: 1, MaxNodes: 2})
 
-	assert.Equal(t, true, nodeGroup.Exist(), "nodegroup should exist")
+	assert.Equal(t, true, nodeGroup.Exist(context.Background()), "nodegroup should exist")
 
 }
 

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -60,7 +60,7 @@ require (
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 	sigs.k8s.io/cloud-provider-azure v1.36.2
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.3
-	sigs.k8s.io/cluster-autoscaler v0.0.0-20260821162314-33c3f97bf274
+	sigs.k8s.io/cluster-autoscaler v0.0.0-20260824153901-9360ab35ce24
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -651,8 +651,8 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.3 h1:0bvLkGdzonXJD/KjmhUQkm1
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.3/go.mod h1:o396fhu+YRYWM4HYueSNw/UcABjtD+HAPILrifi+WJA=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.15.2 h1:be6PmylCocI/CZTamSn9uQpchsXcb4SCaH9jl3KDxkQ=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.15.2/go.mod h1:bFd+YoGg9on0uMr5Y4HjFiBovY1y6GbmokVl35+zQAA=
-sigs.k8s.io/cluster-autoscaler v0.0.0-20260821162314-33c3f97bf274 h1:J0Xilho8vqJdrd4CA6vbX+8DzP5vmj8UnAtiZ09NC5s=
-sigs.k8s.io/cluster-autoscaler v0.0.0-20260821162314-33c3f97bf274/go.mod h1:2aCcQLPtjrcNYLZ0dep7WWkBr/kb6xH8J+oDntiYtxQ=
+sigs.k8s.io/cluster-autoscaler v0.0.0-20260824153901-9360ab35ce24 h1:0nMKtacrl03nQ3oj7tPGWhlx0NUzYBFOtj8uX+VeNuA=
+sigs.k8s.io/cluster-autoscaler v0.0.0-20260824153901-9360ab35ce24/go.mod h1:2aCcQLPtjrcNYLZ0dep7WWkBr/kb6xH8J+oDntiYtxQ=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -132,6 +132,7 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 	}
 
 	err = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		iteration := 0
 		// Autoscale ad infinitum.
 		if autoscalingOpts.FrequentLoopsEnabled {
 			// We need to have two timestamps because the scaleUp activity alternates between processing ProvisioningRequests,
@@ -147,8 +148,9 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 				default:
 					trigger.Wait(previousRun)
 					previousRun, lastRun = lastRun, time.Now()
-					loop.RunAutoscalerOnce(ctx, autoscaler, healthCheck, lastRun)
+					loop.RunAutoscalerOnce(ctx, autoscaler, healthCheck, lastRun, iteration)
 				}
+				iteration++
 			}
 		} else {
 			for {
@@ -158,8 +160,9 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 					// iteration in progress will be interrupted and cleaned up there.
 					return nil
 				case <-time.After(autoscalingOpts.ScanInterval):
-					loop.RunAutoscalerOnce(ctx, autoscaler, healthCheck, time.Now())
+					loop.RunAutoscalerOnce(ctx, autoscaler, healthCheck, time.Now(), iteration)
 				}
+				iteration++
 			}
 		}
 	}))


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Update implementations finalizes kubernetes-sigs/cluster-autoscaler/pull/24 in kubernets-sigs/cluster-autocaler repository by adjusting the implementations of CloudProvider, NodeGroup and PricingModel to accept go context.
Additionally, migrate gce cloud providers to contextual logging.

Changes to cloud providers other than GCE are intentionally minimal. We don't propagate contexts in arguments, and instead inject context.TODO() where needed. Migrating  all cloud providers is out of scope of this change, and by leaving context.TODO() we want to signalize that the migration is not done.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Changes to most cloud providers are purely mechanical. In GCE, we fully propagate context in methods, and migrate  logs to use structural logging.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Enhancements

* Cloud provider integrations now support context-aware scaling, node discovery, pricing, GPU information, refresh, cleanup, and lifecycle operations.
* GCE operations consistently propagate request context through cloud API activity, caching, logging, and long-running operations.
* Autoscaling iterations are tracked consistently across frequent and interval-based execution modes.

## Tests

* Updated provider and autoscaling test coverage to validate context-aware operations across supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->