### PR TITLE
fix: Azure autoscaling when VMSS is missing

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -48,7 +48,7 @@ var (
 //   - limit repetitive Azure API calls.
 //
 // It backs efficient responds to
-//   - cloudprovider.NodeGroups() (= registeredNodeGroups)
+//   - cloudprovider.NodeGroups() (the cloud-backed subset of registeredNodeGroups)
 //   - cloudprovider.NodeGroupForNode (via azureManager.GetNodeGroupForInstance => FindForInstance,
 //     using instanceToNodeGroup and unownedInstances)
 //
@@ -88,7 +88,10 @@ type azureCache struct {
 	// It is only used/populated if vmType is vmTypeStandard.
 	virtualMachines map[string][]*armcompute.VirtualMachine
 
-	// registeredNodeGroups represents all known NodeGroups.
+	// registeredNodeGroups is the provider's configured node-group inventory. A group is
+	// registered from an explicit node-group spec or from tag-based autodiscovery; registration
+	// does not guarantee that its backing Azure resource currently exists. AzureManager.getNodeGroups
+	// filters this inventory before exposing it through cloudprovider.NodeGroups().
 	registeredNodeGroups []cloudprovider.NodeGroup
 
 	// instanceToNodeGroup maintains a mapping from instance Ids to nodegroups.
@@ -453,6 +456,9 @@ func (m *azureCache) GetSKU(ctx context.Context, skuName, location string) (skew
 	return cache.Get(ctx, skuName, skewer.VirtualMachines, location)
 }
 
+// getRegisteredNodeGroups returns the complete configured node-group inventory, including
+// groups whose backing Azure resource is currently absent. Internal reconciliation uses this
+// unfiltered view so hidden groups can still be updated or unregistered.
 func (m *azureCache) getRegisteredNodeGroups() []cloudprovider.NodeGroup {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -262,8 +262,11 @@ func (m *AzureManager) invalidateCache() {
 	klog.V(2).Infof("Invalidated Azure cache")
 }
 
-// Fetch automatically discovered NodeGroups. These NodeGroups should be unregistered if
-// they no longer exist in Azure.
+// fetchAutoNodeGroups reconciles tag-based node-group discovery with the registered inventory.
+// It registers VMSS resources matching autoDiscoverySpecs, updates their configuration, and
+// unregisters groups that no longer match. Explicitly configured groups are retained because
+// their configuration takes precedence over autodiscovery. Reconciliation must inspect all
+// registered groups, including ones filtered from the public NodeGroups view.
 func (m *AzureManager) fetchAutoNodeGroups() error {
 	groups, err := m.getFilteredNodeGroups(m.autoDiscoverySpecs)
 	if err != nil {
@@ -303,6 +306,11 @@ func (m *AzureManager) fetchAutoNodeGroups() error {
 	return nil
 }
 
+// getNodeGroups returns the operational node groups exposed through
+// cloudprovider.CloudProvider.NodeGroups. Unlike getRegisteredNodeGroups, this view excludes
+// ScaleSets without a backing VMSS in the current Azure cache snapshot, preventing core
+// autoscaler callers from querying a configured but unavailable group. Non-ScaleSet groups
+// are unaffected by this VMSS-specific filter.
 func (m *AzureManager) getNodeGroups() []cloudprovider.NodeGroup {
 	registered := m.azureCache.getRegisteredNodeGroups()
 	scaleSets := m.azureCache.getScaleSets()

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -288,7 +288,7 @@ func (m *AzureManager) fetchAutoNodeGroups() error {
 		}
 	}
 
-	for _, nodeGroup := range m.getNodeGroups() {
+	for _, nodeGroup := range m.azureCache.getRegisteredNodeGroups() {
 		nodeGroupID := nodeGroup.Id()
 		if !exists[nodeGroupID] && !m.explicitlyConfigured[nodeGroupID] {
 			m.UnregisterNodeGroup(nodeGroup)
@@ -304,7 +304,22 @@ func (m *AzureManager) fetchAutoNodeGroups() error {
 }
 
 func (m *AzureManager) getNodeGroups() []cloudprovider.NodeGroup {
-	return m.azureCache.getRegisteredNodeGroups()
+	registered := m.azureCache.getRegisteredNodeGroups()
+	scaleSets := m.azureCache.getScaleSets()
+	nodeGroups := make([]cloudprovider.NodeGroup, 0, len(registered))
+
+	for _, nodeGroup := range registered {
+		scaleSet, ok := nodeGroup.(*ScaleSet)
+		if ok {
+			if _, exists := scaleSets[scaleSet.Name]; !exists {
+				klog.V(4).Infof("getNodeGroups: excluding %s: no backing VMSS in cache", scaleSet.Name)
+				continue
+			}
+		}
+		nodeGroups = append(nodeGroups, nodeGroup)
+	}
+
+	return nodeGroups
 }
 
 // RegisterNodeGroup registers an a NodeGroup.

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -1132,14 +1132,56 @@ func TestVMSSNotFound(t *testing.T) {
 	t.Run("should not error when VMSS not found in cache", func(t *testing.T) {
 		manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfg), ngdo, &client)
 		assert.NoError(t, err)
-		// expect one nodegroup to be present
+		// The missing VMSS remains registered for reconciliation but is not exposed
+		// to the autoscaler until a backing VMSS appears.
 		nodeGroups := manager.getNodeGroups()
-		assert.Len(t, nodeGroups, 1)
-		assert.Equal(t, nodeGroups[0].Id(), testASG)
+		assert.Empty(t, nodeGroups)
+		registeredNodeGroups := manager.azureCache.getRegisteredNodeGroups()
+		assert.Len(t, registeredNodeGroups, 1)
+		assert.Equal(t, registeredNodeGroups[0].Id(), testASG)
 		// expect no scale sets to be present
 		scaleSets := manager.azureCache.getScaleSets()
 		assert.Len(t, scaleSets, 0)
 	})
+}
+
+func TestGetNodeGroupsFiltersPhantomScaleSet(t *testing.T) {
+	manager := newTestAzureManager(t)
+	scaleSet := newTestScaleSet(manager, "phantom-vmss")
+	assert.True(t, manager.RegisterNodeGroup(scaleSet))
+
+	assert.Empty(t, manager.getNodeGroups())
+	assert.Len(t, manager.azureCache.getRegisteredNodeGroups(), 1)
+}
+
+func TestGetNodeGroupsIncludesScaleSetWhenVMSSAppears(t *testing.T) {
+	manager := newTestAzureManager(t)
+	name := "new-vmss"
+	scaleSet := newTestScaleSet(manager, name)
+	assert.True(t, manager.RegisterNodeGroup(scaleSet))
+	manager.azureCache.setScaleSet(name, newTestVMSSList(0, name, testLocation, armcompute.OrchestrationModeUniform)[0])
+
+	nodeGroups := manager.getNodeGroups()
+	assert.Len(t, nodeGroups, 1)
+	assert.Equal(t, name, nodeGroups[0].Id())
+}
+
+func TestGetNodeGroupsFiltersPreviouslyObservedScaleSetOnCacheMiss(t *testing.T) {
+	manager := newTestAzureManager(t)
+	scaleSet := newTestScaleSet(manager, "temporarily-missing-vmss")
+	assert.True(t, manager.RegisterNodeGroup(scaleSet))
+
+	assert.Empty(t, manager.getNodeGroups())
+}
+
+func TestGetNodeGroupsDoesNotFilterVMsPool(t *testing.T) {
+	manager := newTestAzureManager(t)
+	vmPool := newTestVMsPool(manager)
+	assert.True(t, manager.RegisterNodeGroup(vmPool))
+
+	nodeGroups := manager.getNodeGroups()
+	assert.Len(t, nodeGroups, 1)
+	assert.Equal(t, vmPool.Id(), nodeGroups[0].Id())
 }
 
 func assertStructsMinimallyEqual(t *testing.T, struct1, struct2 interface{}) bool {

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -1166,10 +1166,20 @@ func TestGetNodeGroupsIncludesScaleSetWhenVMSSAppears(t *testing.T) {
 	assert.Equal(t, name, nodeGroups[0].Id())
 }
 
-func TestGetNodeGroupsFiltersPreviouslyObservedScaleSetOnCacheMiss(t *testing.T) {
+func TestGetNodeGroupsFiltersScaleSetRemovedFromCache(t *testing.T) {
 	manager := newTestAzureManager(t)
-	scaleSet := newTestScaleSet(manager, "temporarily-missing-vmss")
+	name := "removed-vmss"
+	scaleSet := newTestScaleSet(manager, name)
 	assert.True(t, manager.RegisterNodeGroup(scaleSet))
+	manager.azureCache.setScaleSet(name, newTestVMSSList(1, name, testLocation, armcompute.OrchestrationModeUniform)[0])
+
+	nodeGroups := manager.getNodeGroups()
+	assert.Len(t, nodeGroups, 1)
+	assert.Equal(t, name, nodeGroups[0].Id())
+
+	manager.azureCache.mutex.Lock()
+	manager.azureCache.scaleSets = make(map[string]*armcompute.VirtualMachineScaleSet)
+	manager.azureCache.mutex.Unlock()
 
 	assert.Empty(t, manager.getNodeGroups())
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -212,7 +212,7 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 	set, err := scaleSet.getVMSSFromCache()
 	if err != nil {
 		klog.Errorf("failed to get information for VMSS: %s, error: %v", scaleSet.Name, err)
-		return -1, newGetVMSSFailedError(err, true)
+		return scaleSet.curSize, newGetVMSSFailedError(err, true)
 	}
 
 	// // Remove check for returning in-memory size when VMSS is in updating state
@@ -277,6 +277,10 @@ func (scaleSet *ScaleSet) getScaleSetSize() (int64, error) {
 	// First, get the current size of the ScaleSet
 	size, getVMSSError := scaleSet.getCurSize()
 	if getVMSSError != nil {
+		if getVMSSError.notFound && size >= 0 {
+			klog.Warningf("VMSS %s not in cache; returning last-known size %d", scaleSet.Name, size)
+			return size, nil
+		}
 		klog.V(3).Infof("getScaleSetSize: error exists (actual err:%v)", getVMSSError.error)
 		return size, getVMSSError.error
 	}
@@ -964,9 +968,13 @@ func (scaleSet *ScaleSet) Nodes() ([]cloudprovider.Instance, error) {
 	if getVMSSError != nil {
 		klog.Errorf("Failed to get current size for vmss %q: %v", scaleSet.Name, getVMSSError.error)
 		if getVMSSError.notFound {
-			return []cloudprovider.Instance{}, nil // Don't return error if VMSS not found
+			// azureCache.regenerate calls Nodes for every registered node group and
+			// aborts the entire cache refresh on any error. A missing VMSS means this
+			// group currently has no instances, so represent it as an empty group and
+			// allow healthy node groups to refresh. Other errors still propagate below.
+			return []cloudprovider.Instance{}, nil
 		}
-		return nil, getVMSSError.error // We want to return error if other errors occur.
+		return nil, getVMSSError.error
 	}
 
 	scaleSet.instanceMutex.Lock()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -205,6 +205,10 @@ func (scaleSet *ScaleSet) getVMSSFromCache() (*armcompute.VirtualMachineScaleSet
 	return allVMSS[scaleSet.Name], nil
 }
 
+// getCurSize returns the current VMSS capacity together with Azure-specific lookup status.
+// It serializes access to the cached size and refresh timestamp. When the VMSS lookup fails,
+// it returns the last-known size (or -1 if no size was learned) plus GetVMSSFailedError so
+// callers can distinguish not-found from other failures without losing cached state.
 func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 	scaleSet.sizeMutex.Lock()
 	defer scaleSet.sizeMutex.Unlock()
@@ -249,7 +253,7 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 		set, err = scaleSet.manager.azClient.virtualMachineScaleSetsClient.Get(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, nil)
 		if err != nil {
 			klog.Errorf("failed to get information for VMSS: %s, error: %v", scaleSet.Name, err)
-			return -1, newGetVMSSFailedError(err, azerrors.IsNotFoundErr(err))
+			return scaleSet.curSize, newGetVMSSFailedError(err, azerrors.IsNotFoundErr(err))
 		}
 		// Persist the freshly-fetched VMSS (including its ETag) so subsequent
 		// capacity updates send an up-to-date If-Match.
@@ -272,15 +276,14 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 	return scaleSet.curSize, nil
 }
 
-// getScaleSetSize gets Scale Set size.
+// getScaleSetSize returns a VMSS size suitable for mutation decisions. Unlike read-only
+// callers that may interpret the typed result from getCurSize, this strict wrapper propagates
+// every provider error even when a last-known size is available. It also rejects -1 without
+// an accompanying provider error so mutations never proceed with unknown or stale capacity.
 func (scaleSet *ScaleSet) getScaleSetSize() (int64, error) {
 	// First, get the current size of the ScaleSet
 	size, getVMSSError := scaleSet.getCurSize()
 	if getVMSSError != nil {
-		if getVMSSError.notFound && size >= 0 {
-			klog.Warningf("VMSS %s not in cache; returning last-known size %d", scaleSet.Name, size)
-			return size, nil
-		}
 		klog.V(3).Infof("getScaleSetSize: error exists (actual err:%v)", getVMSSError.error)
 		return size, getVMSSError.error
 	}
@@ -319,8 +322,18 @@ func (scaleSet *ScaleSet) setScaleSetSize(size int64, delta int) error {
 // TargetSize returns the current TARGET size of the node group. It is possible that the
 // number is different from the number of nodes registered in Kubernetes.
 func (scaleSet *ScaleSet) TargetSize() (int, error) {
-	size, err := scaleSet.getScaleSetSize()
-	return int(size), err
+	size, getVMSSError := scaleSet.getCurSize()
+	if getVMSSError != nil {
+		if getVMSSError.notFound && size >= 0 {
+			klog.Warningf("VMSS %s not in cache; returning last-known size %d", scaleSet.Name, size)
+			return int(size), nil
+		}
+		return int(size), getVMSSError.error
+	}
+	if size == -1 {
+		return -1, fmt.Errorf("failed to get scale set size for %s: cached size is -1 without provider error", scaleSet.Name)
+	}
+	return int(size), nil
 }
 
 // canIncreaseSize checks if the size increase is possible.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -271,6 +271,50 @@ func TestScaleSetTargetSizeReturnsErrorForCachedNegativeSize(t *testing.T) {
 	assert.Equal(t, -1, size)
 }
 
+func TestGetCurSizeReturnsLastKnownSizeAndErrorOnCacheMiss(t *testing.T) {
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSet(provider.azureManager, "missing-vmss-with-known-size")
+	scaleSet.curSize = 3
+
+	size, err := scaleSet.getCurSize()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, int64(3), size)
+}
+
+func TestTargetSizeReturnsLastKnownSizeOnCacheMiss(t *testing.T) {
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSet(provider.azureManager, "missing-vmss-with-known-size")
+	scaleSet.curSize = 3
+
+	size, err := scaleSet.TargetSize()
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, size)
+}
+
+func TestNodesReturnsEmptyOnCacheMiss(t *testing.T) {
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSet(provider.azureManager, "missing-vmss-with-known-size")
+	scaleSet.curSize = 3
+
+	instances, err := scaleSet.Nodes()
+
+	assert.NoError(t, err)
+	assert.Empty(t, instances)
+}
+
+func TestGetCurSizeReturnsErrorWhenVMSSNeverObserved(t *testing.T) {
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSet(provider.azureManager, "never-observed-vmss")
+	scaleSet.curSize = -1
+
+	size, err := scaleSet.getCurSize()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, int64(-1), size)
+}
+
 func TestScaleSetIncreaseSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -327,6 +371,7 @@ func TestScaleSetIncreaseSize(t *testing.T) {
 		assert.NoError(t, err)
 
 		ss := newTestScaleSet(provider.azureManager, "test-asg-doesnt-exist")
+		ss.curSize = -1
 		err = ss.IncreaseSize(100)
 		expectedErr := fmt.Errorf("could not find vmss: test-asg-doesnt-exist")
 		assert.Equal(t, expectedErr, err)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -282,6 +282,29 @@ func TestGetCurSizeReturnsLastKnownSizeAndErrorOnCacheMiss(t *testing.T) {
 	assert.Equal(t, int64(3), size)
 }
 
+func TestGetCurSizeReturnsLastKnownSizeOnSpotNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := newTestProvider(t)
+	name := "missing-spot-vmss"
+	spotScaleSet := newTestVMSSList(3, name, testLocation, armcompute.OrchestrationModeUniform)[0]
+	priority := armcompute.VirtualMachinePriorityTypesSpot
+	spotScaleSet.Properties.VirtualMachineProfile = &armcompute.VirtualMachineScaleSetVMProfile{Priority: &priority}
+	provider.azureManager.azureCache.setScaleSet(name, spotScaleSet)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), provider.azureManager.config.ResourceGroup, name, nil).
+		Return(nil, &azcore.ResponseError{StatusCode: http.StatusNotFound})
+	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	scaleSet := newTestScaleSet(provider.azureManager, name)
+	scaleSet.curSize = 3
+	size, err := scaleSet.getCurSize()
+
+	assert.Equal(t, int64(3), size)
+	assert.NotNil(t, err)
+	assert.True(t, err.notFound)
+}
+
 func TestTargetSizeReturnsLastKnownSizeOnCacheMiss(t *testing.T) {
 	provider := newTestProvider(t)
 	scaleSet := newTestScaleSet(provider.azureManager, "missing-vmss-with-known-size")
@@ -291,6 +314,27 @@ func TestTargetSizeReturnsLastKnownSizeOnCacheMiss(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, 3, size)
+}
+
+func TestGetScaleSetSizeReturnsErrorOnCacheMiss(t *testing.T) {
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSet(provider.azureManager, "missing-vmss-with-known-size")
+	scaleSet.curSize = 3
+
+	size, err := scaleSet.getScaleSetSize()
+
+	assert.EqualError(t, err, "could not find vmss: missing-vmss-with-known-size")
+	assert.Equal(t, int64(3), size)
+}
+
+func TestDecreaseTargetSizeReturnsErrorOnCacheMiss(t *testing.T) {
+	provider := newTestProvider(t)
+	scaleSet := newTestScaleSet(provider.azureManager, "missing-vmss-with-known-size")
+	scaleSet.curSize = 3
+
+	err := scaleSet.DecreaseTargetSize(-1)
+
+	assert.EqualError(t, err, "could not find vmss: missing-vmss-with-known-size")
 }
 
 func TestNodesReturnsEmptyOnCacheMiss(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/azure/docs/vmss-missing-call-paths.md
+++ b/cluster-autoscaler/cloudprovider/azure/docs/vmss-missing-call-paths.md
@@ -1,0 +1,119 @@
+# Azure Missing-VMSS Call Paths
+
+This note describes how core Cluster Autoscaler callers reach the Azure VMSS helpers and where missing-VMSS errors are handled.
+
+## Related change
+
+**August 2026:** [kubernetes/autoscaler#10166](https://github.com/kubernetes/autoscaler/pull/10166) prevents an Azure node group without a backing VMSS from blocking cluster-wide autoscaling.
+
+## Node-group inventory and refresh
+
+```text
+StaticAutoscaler loop
+  -> CloudProvider.Refresh()
+  -> AzureManager.Refresh()
+  -> AzureManager.forceRefresh()
+     -> fetchAutoNodeGroups()
+        -> getFilteredNodeGroups(autoDiscoverySpecs)
+        -> getFilteredScaleSets()
+           -> current VMSS cache entries matching configured tag selectors
+        -> register/update matching autodiscovered groups
+        -> compare against getRegisteredNodeGroups()
+        -> unregister non-explicit groups that no longer match
+     -> azureCache.regenerate()
+        -> fetchAzureResources()
+           -> VMSS.List() replaces the VMSS cache snapshot
+        -> Nodes() for every registered group
+```
+
+`getRegisteredNodeGroups()` returns the complete provider configuration inventory. Groups enter it through explicit node-group specs or tag-based autodiscovery. Registration does not prove that a backing Azure resource currently exists.
+
+`getNodeGroups()` returns the operational subset exposed by `CloudProvider.NodeGroups()`. It removes registered `ScaleSet` groups that have no VMSS in the current cache snapshot. Internal autodiscovery reconciliation uses the unfiltered registered inventory so a hidden group can still be updated or unregistered.
+
+## Why there are two size helpers
+
+`getCurSize()` is the lower-level Azure-aware helper. It owns synchronization for `curSize` and `lastSizeRefresh`, reads VMSS capacity from the cache (or a direct GET for Spot), and returns two pieces of information:
+
+- the current or last-known size, using `-1` when no valid size has ever been learned;
+- a typed `GetVMSSFailedError` that distinguishes VMSS not-found from other Azure failures.
+
+The size and typed error are intentionally returned together. `Nodes()` needs the not-found classification to represent a missing VMSS as an empty group. Read-only `TargetSize()` can use a non-negative last-known size during a narrow snapshot transition. Neither behavior should apply to mutations.
+
+`getScaleSetSize()` is the strict wrapper for mutation paths. It converts the Azure-specific result into the conventional `(int64, error)` contract, propagates every provider error, and also turns an unexplained `-1` size into an explicit error. `IncreaseSize()`, `AtomicIncreaseSize()`, `DecreaseTargetSize()`, and `DeleteNodes()` use this wrapper so they never act on stale or invalid capacity.
+
+`TargetSize()` and `Nodes()` call `getCurSize()` directly because they deliberately interpret VMSS not-found differently. The separate helpers keep those caller-specific read behaviors out of mutation paths.
+
+## Target-size flow
+
+```text
+StaticAutoscaler.updateClusterState()
+  -> ClusterStateRegistry.UpdateNodes()
+  -> getTargetSizes()
+  -> CloudProvider.NodeGroups()
+  -> AzureManager.getNodeGroups()
+     -> filter ScaleSets absent from the VMSS cache
+  -> TargetSize() for every returned group
+  -> ScaleSet.getCurSize()
+     -> getVMSSFromCache()
+```
+
+`getTargetSizes()` returns an empty map and an error as soon as any `TargetSize()` call fails. `UpdateNodes()` propagates that error, aborting cluster-state update and the autoscaler loop.
+
+`TargetSize()` is read-only. If a VMSS disappears between node-group enumeration and its size lookup, it may use a non-negative last-known size returned with the typed not-found error. This fallback is defensive; normal missing VMSS groups are removed by `getNodeGroups()` first.
+
+## Instance-list flow
+
+```text
+AzureManager.forceRefresh()
+  -> azureCache.regenerate()
+  -> Nodes() for every registered group
+  -> ScaleSet.getCurSize()
+     -> getVMSSFromCache()
+```
+
+`azureCache.regenerate()` returns immediately if any `Nodes()` call returns an error. `ScaleSet.Nodes()` therefore translates VMSS not-found into an empty instance list and nil error. Other errors still propagate.
+
+Core CAS also calls `Nodes()` through its node-instance cache and scale-down processing. Those callers normally see only the groups exposed by `CloudProvider.NodeGroups()`.
+
+## Mutation flows
+
+```text
+IncreaseSize() / AtomicIncreaseSize()
+  -> canIncreaseSize()
+  -> getScaleSetSize()
+  -> getCurSize()
+
+DecreaseTargetSize()
+  -> getScaleSetSize()
+  -> getCurSize()
+
+DeleteNodes()
+  -> getScaleSetSize()
+  -> getCurSize()
+```
+
+`getScaleSetSize()` is strict: it propagates a missing-VMSS error even when `getCurSize()` also returns a last-known size. Mutating operations must not make decisions from stale capacity.
+
+## Call path targeted by [kubernetes/autoscaler#10166](https://github.com/kubernetes/autoscaler/pull/10166)
+
+The reported issue followed the target-size flow:
+
+```text
+phantom pool remains registered
+  -> CloudProvider.NodeGroups() returns it
+  -> ClusterStateRegistry.getTargetSizes()
+  -> phantom TargetSize()
+  -> missing VMSS error
+  -> UpdateNodes() fails
+  -> no scaling decisions for healthy groups
+```
+
+The primary fix filters cache-absent VMSS groups from the public `NodeGroups()` view. The group remains in the registered inventory for configuration reconciliation. The secondary protection lets read-only `TargetSize()` use a known cached size during a narrow snapshot transition, while mutations remain strict.
+
+## Call paths targeted by previous fixes
+
+[PR #7708](https://github.com/kubernetes/autoscaler/pull/7708) (`fix: don't crash when vmss not present or has no nodes`) targeted the instance-list flow. It made `GetOptions()` accept defaults and made `Nodes()` return an empty list for VMSS not-found, preventing Azure manager construction or cache regeneration from failing. It did not filter the group or change the `TargetSize()` path.
+
+[PR #9779](https://github.com/kubernetes/autoscaler/pull/9779) (`fix(azure): VMSS size cache handling after delete failures`) included several related cache fixes. Its target-size change handled an inconsistent result from `getCurSize()`: `(-1, nil)`. It made the size wrapper return an explicit error instead of dereferencing a nil `GetVMSSFailedError`, but did not handle a real VMSS not-found error.
+
+The same [PR #9779](https://github.com/kubernetes/autoscaler/pull/9779) also prevents deletion from publishing a negative cached size and invalidates size state after delete failure. Those changes target delete-related cache correctness; they do not affect node-group filtering or missing-VMSS error routing.


### PR DESCRIPTION
## Summary

Prevent an Azure node group without a backing VMSS from blocking cluster-wide autoscaling.

- exclude registered VMSS node groups that are absent from the current VMSS cache snapshot
- retain unfiltered registrations for node-group reconciliation
- preserve the existing `Nodes()` not-found behavior while allowing `TargetSize()` to use a non-negative last-known size defensively
- add coverage for phantom pools, VMSS recovery, previously observed removals, VMs pools, and caller-specific cache-miss handling

Related to #10132.

## Testing

- `go test ./cloudprovider/azure`
- `go test -race ./cloudprovider/azure -run 'Test(GetCurSizeReturnsLastKnownSizeAndErrorOnCacheMiss|TargetSizeReturnsLastKnownSizeOnCacheMiss|NodesReturnsEmptyOnCacheMiss|GetNodeGroups|VMSSNotFound)$'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing Azure VMSS resources during autoscaler updates.
  - Preserves the last known scale-set size when current Azure data is unavailable.
  - Prevents stale or phantom scale sets from appearing as active autoscaler node groups.
  - Continues safely processing node groups when a scale set is missing, while retaining VM pools.
- **Documentation**
  - Added guidance on Azure VMSS missing-resource behavior and related autoscaler operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->