### PR TITLE
Don't halt cluster-wide autoscaling when one node group TargetSize() fails

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -421,7 +421,10 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, currentTime ti
 	csr.updateNodeGroupMetrics()
 	targetSizes, err := getTargetSizes(csr.cloudProvider)
 	if err != nil {
-		return err
+		klog.Warningf("Failed to get target sizes for some node groups: %v", err)
+		if len(targetSizes) == 0 {
+			return err
+		}
 	}
 	metrics.UpdateNodeGroupTargetSize(targetSizes)
 
@@ -476,16 +479,22 @@ func (csr *ClusterStateRegistry) Recalculate() {
 }
 
 // getTargetSizes gets target sizes of node groups.
+// If TargetSize() fails for a node group, that group is skipped so healthy
+// groups can still be autoscaled. The returned error is a join of per-group
+// failures; the map contains sizes for groups that succeeded.
 func getTargetSizes(cp cloudprovider.CloudProvider) (map[string]int, error) {
 	result := make(map[string]int)
+	var errs []error
 	for _, ng := range cp.NodeGroups() {
 		size, err := ng.TargetSize()
 		if err != nil {
-			return map[string]int{}, err
+			klog.Warningf("Failed to get target size for node group %s: %v", ng.Id(), err)
+			errs = append(errs, fmt.Errorf("node group %s: %w", ng.Id(), err))
+			continue
 		}
 		result[ng.Id()] = size
 	}
-	return result, nil
+	return result, errors.Join(errs...)
 }
 
 // IsClusterHealthy returns true if the cluster health is within the acceptable limits

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -2345,3 +2345,52 @@ func newTestClusterStateRegistry(cloudProvider cloudprovider.CloudProvider, logR
 	nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute})
 	return NewNotifiedClusterStateRegistry(cloudProvider, logRecorder, newBackoff(), nodeGroupConfigProcessor, &emptyTemplateNodeInfoRegistry{}, opts...)
 }
+
+func failingTargetSizeNodeGroup(id string, targetSizeErr error) *mockprovider.NodeGroup {
+	ng := &mockprovider.NodeGroup{}
+	ng.On("Id").Return(id)
+	ng.On("TargetSize").Return(0, targetSizeErr)
+	ng.On("Nodes").Return([]cloudprovider.Instance{}, nil)
+	ng.On("Autoprovisioned").Return(false)
+	ng.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
+	return ng
+}
+
+func TestGetTargetSizesContinuesOnPartialFailure(t *testing.T) {
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("healthy", 1, 10, 5)
+	provider.InsertNodeGroup(failingTargetSizeNodeGroup("broken", fmt.Errorf("could not find vmss: broken")))
+
+	sizes, err := getTargetSizes(provider)
+	assert.ErrorContains(t, err, "node group broken")
+	assert.Equal(t, map[string]int{"healthy": 5}, sizes)
+}
+
+func TestGetTargetSizesAllFail(t *testing.T) {
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.InsertNodeGroup(failingTargetSizeNodeGroup("broken", fmt.Errorf("could not find vmss: broken")))
+
+	sizes, err := getTargetSizes(provider)
+	assert.ErrorContains(t, err, "node group broken")
+	assert.Empty(t, sizes)
+}
+
+func TestUpdateNodesContinuesWhenOneNodeGroupTargetSizeFails(t *testing.T) {
+	now := time.Now()
+	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 1, 10, 5)
+	provider.AddNode("ng1", ng1_1)
+	provider.InsertNodeGroup(failingTargetSizeNodeGroup("broken", fmt.Errorf("could not find vmss: broken")))
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder)
+
+	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, now)
+	assert.NoError(t, err)
+	_, targetSize := clusterstate.GetAutoscaledNodesCount()
+	assert.Equal(t, 5, targetSize)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area cluster-autoscaler

#### What this PR does / why we need it:

`getTargetSizes` currently returns an empty map on the first `TargetSize()` error, and `UpdateNodes` treats that as fatal. One broken node group then blocks scale-up and scale-down for every other node group until it is removed.

This was hit in production on Azure/AKS when an AgentPool had no backing VMSS (`could not find vmss: ...` on every reconcile) and froze the whole cluster for ~17.5 hours. The same path is provider-agnostic.

This PR:
- skips node groups whose `TargetSize()` fails, returning partial results
- logs the per-group error
- lets `UpdateNodes` continue when at least one node group succeeded
- still fails `UpdateNodes` if every node group fails (nothing useful to scale)

This matches the rest of CA (`Recalculate`, `ScaleUpToNodeGroupMinSize`, and other direct `TargetSize()` callers already log-and-continue).

Related Azure-only draft: #10166. This change is the provider-agnostic fix for #10132.

#### Which issue(s) this PR fixes:

Fixes #10132

#### Special notes for your reviewer:

The snippet in #10132 still returned `errors.Join(...)`, which `UpdateNodes` would have treated as fatal and discarded the partial map. This PR also changes `UpdateNodes` to continue when the map is non-empty.

Happy to cherry-pick to `cluster-autoscaler-release-1.30` through `1.36` — the failing function is byte-identical across those branches.

#### Does this PR introduce a user-facing change?

```release-note
Fix cluster-autoscaler stalling all scale-up/down when a single node group's TargetSize() returns an error. Healthy node groups now continue to autoscale.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

Made with [Cursor](https://cursor.com)