### PR TITLE
CA: use 1.36.1 by default in helm chart

### DIFF
--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.35.0
+appVersion: 1.36.1
 description: Scales Kubernetes worker nodes within autoscaling groups.
 engine: gotpl
 home: https://github.com/kubernetes/autoscaler
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.59.0
+version: 9.60.0

--- a/cluster-autoscaler/charts/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/charts/cluster-autoscaler/README.md
@@ -503,7 +503,7 @@ vpa:
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
 | image.repository | string | `"registry.k8s.io/autoscaling/cluster-autoscaler"` | Image repository |
-| image.tag | string | `"v1.35.0"` | Image tag |
+| image.tag | string | `"v1.36.1"` | Image tag |
 | initContainers | list | `[]` | Any additional init containers. |
 | kubeTargetVersionOverride | string | `""` | Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands. |
 | kwokConfigMapName | string | `"kwok-provider-config"` | configmap for configuring kwok provider |

--- a/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
@@ -303,7 +303,7 @@ image:
   # image.repository -- Image repository
   repository: registry.k8s.io/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
-  tag: v1.35.0
+  tag: v1.36.1
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it
Updates the cluster-autoscaler Helm chart to use the latest released version (v1.36.1) as the default image tag. The chart was still referencing v1.35.0, which could lead users to deploy an older version when using chart defaults.

### Changes
- `Chart.yaml`: appVersion 1.35.0 → 1.36.1
- `Chart.yaml`: chart version 9.59.0 → 9.60.0
- `values.yaml`: image.tag v1.35.0 → v1.36.1
- `README.md`: regenerated via helm-docs

## Which issue(s) this PR fixes
Fixes #9866

## Special notes for your reviewer
The `cluster-autoscaler-1.36.1` release was published on 2026-07-23 and the corresponding image is available in the registry, but the Helm chart was never updated to reference it.

/area cluster-autoscaler
/sig autoscaling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Cluster Autoscaler Helm chart to application version 1.36.1.
  * Updated the default container image to version 1.36.1.
  * Incremented the chart version to 9.60.0.
  * Updated the chart documentation to reflect the new default image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->