### PR TITLE
AWS: fix int32 overflow computing memory from InstanceRequirements

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -372,7 +372,7 @@ func (m *AwsManager) updateCapacityWithRequirementsOverrides(capacity *apiv1.Res
 	}
 
 	if instanceRequirements.MemoryMiB != nil && instanceRequirements.MemoryMiB.Min != nil {
-		(*capacity)[apiv1.ResourceMemory] = *resource.NewQuantity(int64(*instanceRequirements.MemoryMiB.Min*1024*1024), resource.DecimalSI)
+		(*capacity)[apiv1.ResourceMemory] = *resource.NewQuantity(int64(*instanceRequirements.MemoryMiB.Min)*1024*1024, resource.DecimalSI)
 	}
 
 	for _, manufacturer := range instanceRequirements.AcceleratorManufacturers {

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -513,8 +513,8 @@ func TestBuildNodeFromTemplate(t *testing.T) {
 				Max: aws.Int32(8),
 			},
 			MemoryMiB: &ec2types.MemoryMiB{
-				Min: aws.Int32(4),
-				Max: aws.Int32(8),
+				Min: aws.Int32(8192),
+				Max: aws.Int32(16384),
 			},
 			AcceleratorTypes:         []ec2types.AcceleratorType{ec2types.AcceleratorTypeGpu},
 			AcceleratorManufacturers: []ec2types.AcceleratorManufacturer{ec2types.AcceleratorManufacturerNvidia},
@@ -530,7 +530,7 @@ func TestBuildNodeFromTemplate(t *testing.T) {
 
 	assert.NoError(t, observedErr)
 	observedMemoryRequirement := observedNode.Status.Capacity[apiv1.ResourceMemory]
-	assert.Equal(t, int64(4*1024*1024), observedMemoryRequirement.Value())
+	assert.Equal(t, int64(8192*1024*1024), observedMemoryRequirement.Value())
 	observedVCpuRequirement := observedNode.Status.Capacity[apiv1.ResourceCPU]
 	assert.Equal(t, int64(4), observedVCpuRequirement.Value())
 	observedGpuRequirement := observedNode.Status.Capacity[gpu.ResourceNvidiaGPU]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For an ASG that uses attribute-based `InstanceRequirements` (MixedInstancesPolicy, no
explicit instance-type overrides), `updateCapacityWithRequirementsOverrides` in
`cloudprovider/aws/aws_manager.go` computed the synthetic template node's memory
capacity as `int64(*instanceRequirements.MemoryMiB.Min*1024*1024)`.

Since the AWS SDK v2 migration, `MemoryMiB.Min` is `*int32` (it was `*int64` in SDK
v1). The `int64()` cast wraps the whole product, so `*Min * 1024 * 1024` is evaluated
in `int32` *before* the cast is applied. For any `Min` of 2048 MiB (2 GiB) or more this
overflows `int32` and wraps — e.g. 8192 MiB wraps to 0. The template node then
advertises ~0 memory capacity, every pending pod fails the `NodeResourcesFit`
predicate with "Insufficient memory", and the node group never scales up from zero.

This PR moves the `int64()` cast to the `Min` operand so the multiplication happens
in `int64`, matching the pre-SDK-v2-migration behavior.

It also updates the existing `TestBuildNodeFromTemplate` unit test, which exercised
this code path with `MemoryMiB.Min = 4` — too small to trigger the overflow, so it
did not catch the regression. The test now uses `Min = 8192`, which reproduces the
exact wraparound.

#### Which issue(s) this PR fixes:
Fixes #10167

#### Special notes for your reviewer:

Validation performed locally (no live cluster available in this environment):
- With only the test change applied and the fix reverted, the updated test fails:
  `go test ./cloudprovider/aws/... -run 'TestBuildNodeFromTemplate$' -v` reports
  `expected: 8589934592, actual: 0`, reproducing the exact overflow described in the
  issue.
- With the fix applied, `go test -race ./cloudprovider/aws/... -vet=all` (mirroring
  this repo's `make test-ci` invocation) passes.
- `gofmt -s -l` on both changed files reports no issues.
- Checked for the same `int64(X * const * const)` cast-after-multiply pattern
  elsewhere in `aws_manager.go`: `VCpuCount.Min` and `AcceleratorCount.Min` are cast
  directly with no multiplication (no overflow risk), and the other in-file use of
  `*1024*1024` operates on `MemoryMb`, which is already `int64`. No other instance of
  this bug exists in this file.
- `master` CI is currently green (checked via `gh run list --branch master`).

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug in the AWS cloud provider where scale-from-zero for ASGs using
attribute-based `InstanceRequirements` (MixedInstancesPolicy, no instance type
overrides) with `MemoryMiB.Min` >= 2048 computed a memory capacity of 0 for the
synthetic template node due to an int32 overflow, causing pods to fail scheduling
with "Insufficient memory" and the node group to never scale up.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reported EC2 instance memory capacity so values are accurately converted to bytes.
  * Fixed node template memory calculations for instances with memory requirements such as 8192 MiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->