### PR TITLE
fix: add missing labels to vpa updater cluster roles in the helm chart

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-clusterrole.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-clusterrole.yaml
@@ -19,6 +19,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}-actor
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -63,6 +65,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}-evictioner
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - "apps"
@@ -82,6 +86,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}-target-reader
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - '*'
@@ -123,6 +129,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}-status-reader
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - "coordination.k8s.io"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Labels are inconsistently added to the VPA Updater ClusterRoles within the helm chart. This PR adds the same labels to all of these ClusterRoles.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added updater labels to relevant autoscaler access-control resources for improved identification and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->