### PR TITLE
VPA: test multi VPA behavior in VPA updater

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
@@ -19,6 +19,7 @@ package vpa
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -126,8 +127,8 @@ func TestGetMatchingVpa(t *testing.T) {
 			name: "two vpas, one in off mode",
 			pod:  podBuilder.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
-				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeOff).WithName("off-vpa").WithTargetRef(targetRef).Get(),
-				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).WithName("recreate-vpa").WithTargetRef(targetRef).Get(),
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeOff).WithName("off-vpa").WithCreationTimestamp(time.Now().Add(-time.Hour)).WithTargetRef(targetRef).Get(),
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).WithName("recreate-vpa").WithCreationTimestamp(time.Now()).WithTargetRef(targetRef).Get(),
 			},
 			labelSelector:   "app = test",
 			expectedFound:   true,

--- a/vertical-pod-autoscaler/pkg/recommender/model/types_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 )
 
 type ResourcesAsResourceListTestCase struct {
@@ -137,12 +139,7 @@ func TestResourcesAsResourceList(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := ResourcesAsResourceList(tc.resources, tc.humanize, tc.roundCPU, tc.roundMemory)
-			if !result[corev1.ResourceCPU].Equal(tc.resourceList[corev1.ResourceCPU]) {
-				t.Errorf("expected %v, got %v", tc.resourceList[corev1.ResourceCPU], result[corev1.ResourceCPU])
-			}
-			if !result[corev1.ResourceMemory].Equal(tc.resourceList[corev1.ResourceMemory]) {
-				t.Errorf("expected %v, got %v", tc.resourceList[corev1.ResourceMemory], result[corev1.ResourceMemory])
-			}
+			test.AssertResourceListEqual(t, "resources", tc.resourceList, result)
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -413,9 +413,9 @@ func TestRunOnce_MultipleVPAs(t *testing.T) {
 			WithMemRequest(resource.MustParse("100M")).
 			WithCPULimit(resource.MustParse("1")).
 			WithMemLimit(resource.MustParse("100M")).Get()).
+		WithLabels(podLabels).
 		WithCreator(&rs.ObjectMeta, &rs.TypeMeta).
 		Get()
-	pod.Labels = podLabels
 
 	targetRef := &autoscalingv1.CrossVersionObjectReference{
 		Kind:       rs.Kind,

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -24,31 +24,41 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/time/rate"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/set"
 
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
 	target_mock "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/mock"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/inplace"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/priority"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/restriction"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/utils"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
 func parseLabelSelector(selector string) labels.Selector {
@@ -369,6 +379,146 @@ func testRunOnceBase(
 	updater.RunOnce(context.Background())
 	eviction.AssertNumberOfCalls(t, "Evict", expectedEvictionCount)
 	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", expectedInPlacedCount)
+}
+
+// TestRunOnce_MultipleVPAs tests that if multiple VPAs target the same Pod and only one of them is 'active' (does NOT have `spec.updateMode: Off`):
+// - the applied recommendation is always the one from the 'active' VPA
+// - the 'active' VPA is always selected as the 'controlling' VPA for the Pod
+func TestRunOnce_MultipleVPAs(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlace, true)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	podLabels := map[string]string{"app": "test"}
+	selector := parseLabelSelector("app = test")
+	containerName := "test"
+	replicas := int32(1)
+	rs := appsv1.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ReplicaSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs",
+			Namespace: "default",
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	pod := test.Pod().WithName("test-pod").
+		AddContainer(test.Container().WithName(containerName).
+			WithCPURequest(resource.MustParse("1")).
+			WithMemRequest(resource.MustParse("100M")).
+			WithCPULimit(resource.MustParse("1")).
+			WithMemLimit(resource.MustParse("100M")).Get()).
+		WithCreator(&rs.ObjectMeta, &rs.TypeMeta).
+		Get()
+	pod.Labels = podLabels
+
+	targetRef := &autoscalingv1.CrossVersionObjectReference{
+		Kind:       rs.Kind,
+		Name:       rs.Name,
+		APIVersion: rs.APIVersion,
+	}
+
+	// If multiple VPAs match a Pod, a 'controlling' VPA is selected using VPA
+	// timestamps.
+	// The selector should be given a list that does NOT include any VPAs with
+	// `updateMode: Off` and no startup boost, so the test here would catch if
+	// that logic changed.
+	now := time.Now()
+	vpaInPlace := test.VerticalPodAutoscaler().
+		WithName("vpa-in-place").
+		WithNamespace("default").
+		WithCreationTimestamp(now).
+		WithContainer(containerName).
+		WithUpdateMode(vpa_types.UpdateModeInPlace).
+		WithTarget("3", "300M").
+		WithTargetRef(targetRef).
+		Get()
+
+	vpaOff1 := test.VerticalPodAutoscaler().
+		WithName("vpa-off-1").
+		WithNamespace("default").
+		WithCreationTimestamp(now.Add(-time.Hour)). // older than the InPlace VPA
+		WithContainer(containerName).
+		WithUpdateMode(vpa_types.UpdateModeOff).
+		WithTarget("9", "900M").
+		WithTargetRef(targetRef).
+		Get()
+
+	vpaOff2 := test.VerticalPodAutoscaler().
+		WithName("vpa-off-2").
+		WithNamespace("default").
+		WithCreationTimestamp(now). // timestamp matches the InPlace VPA
+		WithContainer(containerName).
+		WithUpdateMode(vpa_types.UpdateModeOff).
+		WithTarget("5", "500M").
+		WithTargetRef(targetRef).
+		Get()
+
+	vpaOff3 := test.VerticalPodAutoscaler().
+		WithName("vpa-off-3").
+		WithNamespace("default").
+		WithCreationTimestamp(now.Add(time.Hour)). // newer than the InPlace VPA
+		WithContainer(containerName).
+		WithUpdateMode(vpa_types.UpdateModeOff).
+		WithTarget("7", "700M").
+		WithTargetRef(targetRef).
+		Get()
+
+	kubeClient := fake.NewSimpleClientset(pod)
+
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	require.NoError(t, informerFactory.Apps().V1().ReplicaSets().Informer().GetStore().Add(&rs))
+
+	limitRangeCalculator := limitrange.NewNoopLimitsCalculator()
+	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
+	calculators := []patch.Calculator{inplace.NewResourceInPlaceUpdatesCalculator(recommendationProvider)}
+	restrictionFactory := restriction.NewPodsRestrictionFactory(kubeClient, informerFactory, 0, 0, calculators, false)
+
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaInPlace, vpaOff1, vpaOff2, vpaOff3}, nil).Once()
+
+	podLister := &test.PodListerMock{}
+	podLister.On("List").Return([]*corev1.Pod{pod}, nil)
+
+	mockSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaInPlace)).Return(selector, nil)
+
+	u := &updater{
+		vpaLister:                    vpaLister,
+		podLister:                    podLister,
+		restrictionFactory:           restrictionFactory,
+		evictionRateLimiter:          rate.NewLimiter(rate.Inf, 0),
+		inPlaceRateLimiter:           rate.NewLimiter(rate.Inf, 0),
+		evictionAdmission:            priority.NewDefaultPodEvictionAdmission(),
+		recommendationProcessor:      &test.FakeRecommendationProcessor{},
+		selectorFetcher:              mockSelectorFetcher,
+		controllerFetcher:            controllerfetcher.FakeControllerFetcher{},
+		useAdmissionControllerStatus: true,
+		statusValidator:              newFakeValidator(true),
+		priorityProcessor:            priority.NewProcessor(),
+		eventRecorder:                record.NewFakeRecorder(10),
+	}
+
+	u.RunOnce(context.Background())
+
+	updatedPod, err := kubeClient.CoreV1().Pods("default").Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Test that the Pod got patched with the recommendation from the VPA with `updateMode: InPlace`.
+	wantResources := vpaInPlace.Status.Recommendation.ContainerRecommendations[0].Target
+
+	gotRequests := updatedPod.Spec.Containers[0].Resources.Requests
+	assert.True(t, apiequality.Semantic.DeepEqual(wantResources, gotRequests),
+		"Container's requests should be patched with the recommendation from `%s` (%v), got %v", vpaInPlace.Name, wantResources, gotRequests)
+
+	gotLimits := updatedPod.Spec.Containers[0].Resources.Limits
+	assert.True(t, apiequality.Semantic.DeepEqual(wantResources, gotLimits),
+		"Container's limits should be patched with the recommendation from `%s` (%v), got %v", vpaInPlace.Name, wantResources, gotLimits)
 }
 
 func TestRunOnceNotingToProcess(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -30,7 +30,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -513,12 +512,10 @@ func TestRunOnce_MultipleVPAs(t *testing.T) {
 	wantResources := vpaInPlace.Status.Recommendation.ContainerRecommendations[0].Target
 
 	gotRequests := updatedPod.Spec.Containers[0].Resources.Requests
-	assert.True(t, apiequality.Semantic.DeepEqual(wantResources, gotRequests),
-		"Container's requests should be patched with the recommendation from `%s` (%v), got %v", vpaInPlace.Name, wantResources, gotRequests)
+	test.AssertResourceListEqual(t, "requests", wantResources, gotRequests)
 
 	gotLimits := updatedPod.Spec.Containers[0].Resources.Limits
-	assert.True(t, apiequality.Semantic.DeepEqual(wantResources, gotLimits),
-		"Container's limits should be patched with the recommendation from `%s` (%v), got %v", vpaInPlace.Name, wantResources, gotLimits)
+	test.AssertResourceListEqual(t, "limits", wantResources, gotLimits)
 }
 
 func TestRunOnceNotingToProcess(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost_test.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 )
 
 func TestGetOriginalResourcesAnnotationValue(t *testing.T) {
@@ -103,10 +105,8 @@ func TestGetOriginalResourcesAnnotationValue(t *testing.T) {
 			var got OriginalResources
 			err = json.Unmarshal([]byte(val), &got)
 			assert.NoError(t, err)
-			assert.True(t, tc.expected.Requests.Cpu().Equal(*got.Requests.Cpu()), "CPU requests do not match")
-			assert.True(t, tc.expected.Requests.Memory().Equal(*got.Requests.Memory()), "Memory requests do not match")
-			assert.True(t, tc.expected.Limits.Cpu().Equal(*got.Limits.Cpu()), "CPU limits do not match")
-			assert.True(t, tc.expected.Limits.Memory().Equal(*got.Limits.Memory()), "Memory limits do not match")
+			test.AssertResourceListEqual(t, "requests", tc.expected.Requests, got.Requests)
+			test.AssertResourceListEqual(t, "limits", tc.expected.Limits, got.Limits)
 		})
 	}
 }
@@ -175,10 +175,8 @@ func TestGetOriginalResourcesFromAnnotation(t *testing.T) {
 				assert.Nil(t, got)
 			} else {
 				assert.NotNil(t, got)
-				assert.True(t, tc.expected.Requests.Cpu().Equal(*got.Requests.Cpu()), "CPU requests do not match")
-				assert.True(t, tc.expected.Requests.Memory().Equal(*got.Requests.Memory()), "Memory requests do not match")
-				assert.True(t, tc.expected.Limits.Cpu().Equal(*got.Limits.Cpu()), "CPU limits do not match")
-				assert.True(t, tc.expected.Limits.Memory().Equal(*got.Limits.Memory()), "Memory limits do not match")
+				test.AssertResourceListEqual(t, "requests", tc.expected.Requests, got.Requests)
+				test.AssertResourceListEqual(t, "limits", tc.expected.Limits, got.Limits)
 			}
 		})
 	}

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"errors"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/mock"
@@ -74,6 +75,27 @@ func Resources(cpu, mem string) corev1.ResourceList {
 		result[corev1.ResourceMemory] = memVal
 	}
 	return result
+}
+
+// AssertResourceListEqual asserts that two resource lists are equal.
+func AssertResourceListEqual(t testing.TB, listName string, want, got corev1.ResourceList) {
+	t.Helper()
+	t.Log("Asserting", listName)
+	for resourceName, wantQuantity := range want {
+		gotQuantity, ok := got[resourceName]
+		if !ok {
+			t.Errorf("%s: expected %s to be %s, but it is missing", listName, resourceName, wantQuantity.String())
+			continue
+		}
+		if !wantQuantity.Equal(gotQuantity) {
+			t.Errorf("%s: expected %s to be %s, got %s", listName, resourceName, wantQuantity.String(), gotQuantity.String())
+		}
+	}
+	for resourceName, gotQuantity := range got {
+		if _, ok := want[resourceName]; !ok {
+			t.Errorf("%s: unexpected %s with value %s", listName, resourceName, gotQuantity.String())
+		}
+	}
 }
 
 // RecommenderAPIMock is a mock of RecommenderAPI

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -80,7 +80,6 @@ func Resources(cpu, mem string) corev1.ResourceList {
 // AssertResourceListEqual asserts that two resource lists are equal.
 func AssertResourceListEqual(t testing.TB, listName string, want, got corev1.ResourceList) {
 	t.Helper()
-	t.Log("Asserting", listName)
 	for resourceName, wantQuantity := range want {
 		gotQuantity, ok := got[resourceName]
 		if !ok {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -243,7 +243,7 @@ func TestRecommendationCappedToMinMaxPolicy(t *testing.T) {
 
 	res, annotations, err := NewCappingRecommendationProcessor(&fakeLimitRangeCalculator{}).Apply(vpa, pod)
 	assert.Nil(t, err)
-	assert.Equal(t, corev1.ResourceList{
+	test.AssertResourceListEqual(t, "target", corev1.ResourceList{
 		corev1.ResourceCPU:    *resource.NewScaledQuantity(40, 1),
 		corev1.ResourceMemory: *resource.NewScaledQuantity(4500, 1),
 	}, res.ContainerRecommendations[0].Target)
@@ -252,12 +252,12 @@ func TestRecommendationCappedToMinMaxPolicy(t *testing.T) {
 	assert.Contains(t, annotations["ctr-name"], "cpu capped to minAllowed")
 	assert.Contains(t, annotations["ctr-name"], "memory capped to maxAllowed")
 
-	assert.Equal(t, corev1.ResourceList{
+	test.AssertResourceListEqual(t, "lower bound", corev1.ResourceList{
 		corev1.ResourceCPU:    *resource.NewScaledQuantity(40, 1),
 		corev1.ResourceMemory: *resource.NewScaledQuantity(4300, 1),
 	}, res.ContainerRecommendations[0].LowerBound)
 
-	assert.Equal(t, corev1.ResourceList{
+	test.AssertResourceListEqual(t, "upper bound", corev1.ResourceList{
 		corev1.ResourceCPU:    *resource.NewScaledQuantity(45, 1),
 		corev1.ResourceMemory: *resource.NewScaledQuantity(4500, 1),
 	}, res.ContainerRecommendations[0].UpperBound)

--- a/vertical-pod-autoscaler/test/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/actuation.go
@@ -153,27 +153,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Checking that container resources were actually updated")
-		gomega.Eventually(func() error {
-			updatedPodList, err := GetHamsterPods(f)
-			if err != nil {
-				return err
-			}
-			for _, pod := range updatedPodList.Items {
-				for _, container := range pod.Status.ContainerStatuses {
-					cpuRequest := container.Resources.Requests[apiv1.ResourceCPU]
-					memoryRequest := container.Resources.Requests[apiv1.ResourceMemory]
-					if cpuRequest.Cmp(ParseQuantityOrDie(targetCPU)) != 0 {
-						framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetCPU, cpuRequest.String())
-						return fmt.Errorf("%s CPU request not updated", container.Name)
-					}
-					if memoryRequest.Cmp(ParseQuantityOrDie(targetMemory)) != 0 {
-						framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetMemory, memoryRequest.String())
-						return fmt.Errorf("%s Memory request not updated", container.Name)
-					}
-				}
-			}
-			return nil
-		}, VpaInPlaceTimeout*3, 15*time.Second).Should(gomega.Succeed())
+		CheckHamsterPodsResourcesUpdated(f, targetCPU, targetMemory)
 	})
 
 	ginkgo.It("falls back to evicting pods when in-place update is Infeasible when update mode is InPlaceOrRecreate", func() {

--- a/vertical-pod-autoscaler/test/e2e/v1/admission_controller.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/admission_controller.go
@@ -418,6 +418,59 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
 		AnnotatePod(f, podName, "someAnnotation", "someValue")
 	})
 
+	ginkgo.It("applies recommendation from a VPA with `UpdateMode: Initial` when a VPA with `UpdateMode: Off` also matches the target", func() {
+		d := NewHamsterDeploymentWithResources(f, ParseQuantityOrDie("100m") /*cpu*/, ParseQuantityOrDie("100Mi") /*memory*/)
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+
+		ginkgo.By("Setting up VPA CRD with updateMode: Off")
+		// VPA creation order and names are so that if there was some future
+		// change that changes the multi-VPA behaviour, it is more likely to get
+		// caught.
+		// https://github.com/kubernetes/autoscaler/blob/8624d41d09317cc6d716b8b3e4d73dd7424a4f1c/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L189
+		offVpaCRD := test.VerticalPodAutoscaler().
+			WithName("1-hamster-vpa-off").
+			WithNamespace(f.Namespace.Name).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithUpdateMode(vpa_types.UpdateModeOff).
+			WithContainer(containerName).
+			AppendRecommendation(
+				test.Recommendation().
+					WithContainer(containerName).
+					WithTarget("500m", "500Mi").
+					WithLowerBound("500m", "500Mi").
+					WithUpperBound("500m", "500Mi").
+					GetContainerResources()).
+			Get()
+
+		utils.InstallVPA(f, offVpaCRD)
+
+		ginkgo.By("Setting up a VPA CRD with updateMode: Initial")
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("2-hamster-vpa").
+			WithNamespace(f.Namespace.Name).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithUpdateMode(vpa_types.UpdateModeInitial).
+			WithContainer(containerName).
+			AppendRecommendation(
+				test.Recommendation().
+					WithContainer(containerName).
+					WithTarget("250m", "200Mi").
+					WithLowerBound("250m", "200Mi").
+					WithUpperBound("250m", "200Mi").
+					GetContainerResources()).
+			Get()
+
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Setting up a hamster deployment")
+		podList := utils.StartDeploymentPods(f, d)
+
+		for _, pod := range podList.Items {
+			gomega.Expect(pod.Spec.Containers[0].Resources.Requests[apiv1.ResourceCPU]).To(gomega.Equal(ParseQuantityOrDie("250m")))
+			gomega.Expect(pod.Spec.Containers[0].Resources.Requests[apiv1.ResourceMemory]).To(gomega.Equal(ParseQuantityOrDie("200Mi")))
+		}
+	})
+
 	ginkgo.It("keeps limits equal to request", func() {
 		d := NewHamsterDeploymentWithGuaranteedResources(f, ParseQuantityOrDie("100m") /*cpu*/, ParseQuantityOrDie("100Mi") /*memory*/)
 

--- a/vertical-pod-autoscaler/test/e2e/v1/admission_controller.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/admission_controller.go
@@ -420,47 +420,12 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
 
 	ginkgo.It("applies recommendation from a VPA with `UpdateMode: Initial` when a VPA with `UpdateMode: Off` also matches the target", func() {
 		d := NewHamsterDeploymentWithResources(f, ParseQuantityOrDie("100m") /*cpu*/, ParseQuantityOrDie("100Mi") /*memory*/)
-		containerName := utils.GetHamsterContainerNameByIndex(0)
 
 		ginkgo.By("Setting up VPA CRD with updateMode: Off")
-		// VPA creation order and names are so that if there was some future
-		// change that changes the multi-VPA behaviour, it is more likely to get
-		// caught.
-		// https://github.com/kubernetes/autoscaler/blob/8624d41d09317cc6d716b8b3e4d73dd7424a4f1c/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L189
-		offVpaCRD := test.VerticalPodAutoscaler().
-			WithName("1-hamster-vpa-off").
-			WithNamespace(f.Namespace.Name).
-			WithTargetRef(utils.HamsterTargetRef).
-			WithUpdateMode(vpa_types.UpdateModeOff).
-			WithContainer(containerName).
-			AppendRecommendation(
-				test.Recommendation().
-					WithContainer(containerName).
-					WithTarget("500m", "500Mi").
-					WithLowerBound("500m", "500Mi").
-					WithUpperBound("500m", "500Mi").
-					GetContainerResources()).
-			Get()
-
-		utils.InstallVPA(f, offVpaCRD)
+		installHamsterVPA(f, "1-hamster-vpa-off", vpa_types.UpdateModeOff, "500m", "500Mi")
 
 		ginkgo.By("Setting up a VPA CRD with updateMode: Initial")
-		vpaCRD := test.VerticalPodAutoscaler().
-			WithName("2-hamster-vpa").
-			WithNamespace(f.Namespace.Name).
-			WithTargetRef(utils.HamsterTargetRef).
-			WithUpdateMode(vpa_types.UpdateModeInitial).
-			WithContainer(containerName).
-			AppendRecommendation(
-				test.Recommendation().
-					WithContainer(containerName).
-					WithTarget("250m", "200Mi").
-					WithLowerBound("250m", "200Mi").
-					WithUpperBound("250m", "200Mi").
-					GetContainerResources()).
-			Get()
-
-		utils.InstallVPA(f, vpaCRD)
+		installHamsterVPA(f, "2-hamster-vpa", vpa_types.UpdateModeInitial, "250m", "200Mi")
 
 		ginkgo.By("Setting up a hamster deployment")
 		podList := utils.StartDeploymentPods(f, d)

--- a/vertical-pod-autoscaler/test/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/common.go
@@ -537,3 +537,29 @@ func WaitForPodsUpdatedWithoutEviction(f *framework.Framework, initialPods *apiv
 	framework.Logf("finished waiting for at least one pod to be updated without eviction")
 	return err
 }
+
+// CheckHamsterPodsResourcesUpdated waits until every hamster container's CPU and
+// memory requests (as reported in the pod status) match the given targets.
+func CheckHamsterPodsResourcesUpdated(f *framework.Framework, targetCPU, targetMemory string) {
+	gomega.Eventually(func() error {
+		updatedPodList, err := GetHamsterPods(f)
+		if err != nil {
+			return err
+		}
+		for _, pod := range updatedPodList.Items {
+			for _, container := range pod.Status.ContainerStatuses {
+				cpuRequest := container.Resources.Requests[apiv1.ResourceCPU]
+				memoryRequest := container.Resources.Requests[apiv1.ResourceMemory]
+				if cpuRequest.Cmp(ParseQuantityOrDie(targetCPU)) != 0 {
+					framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetCPU, cpuRequest.String())
+					return fmt.Errorf("%s CPU request not updated", container.Name)
+				}
+				if memoryRequest.Cmp(ParseQuantityOrDie(targetMemory)) != 0 {
+					framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetMemory, memoryRequest.String())
+					return fmt.Errorf("%s Memory request not updated", container.Name)
+				}
+			}
+		}
+		return nil
+	}, VpaInPlaceTimeout*3, 15*time.Second).Should(gomega.Succeed())
+}

--- a/vertical-pod-autoscaler/test/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/common.go
@@ -550,11 +550,11 @@ func CheckHamsterPodsResourcesUpdated(f *framework.Framework, targetCPU, targetM
 			for _, container := range pod.Status.ContainerStatuses {
 				cpuRequest := container.Resources.Requests[apiv1.ResourceCPU]
 				memoryRequest := container.Resources.Requests[apiv1.ResourceMemory]
-				if cpuRequest.Cmp(ParseQuantityOrDie(targetCPU)) != 0 {
+				if !cpuRequest.Equal(ParseQuantityOrDie(targetCPU)) {
 					framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetCPU, cpuRequest.String())
 					return fmt.Errorf("%s CPU request not updated", container.Name)
 				}
-				if memoryRequest.Cmp(ParseQuantityOrDie(targetMemory)) != 0 {
+				if !memoryRequest.Equal(ParseQuantityOrDie(targetMemory)) {
 					framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetMemory, memoryRequest.String())
 					return fmt.Errorf("%s Memory request not updated", container.Name)
 				}

--- a/vertical-pod-autoscaler/test/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/common.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/test/e2e/utils"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -562,4 +563,27 @@ func CheckHamsterPodsResourcesUpdated(f *framework.Framework, targetCPU, targetM
 		}
 		return nil
 	}, VpaInPlaceTimeout*3, 15*time.Second).Should(gomega.Succeed())
+}
+
+// installHamsterVPA installs a VPA targeting the hamster deployment with the
+// given name and update mode, and a flat recommendation (target, lower and upper
+// bound all equal) for the first hamster container.
+func installHamsterVPA(f *framework.Framework, name string, updateMode vpa_types.UpdateMode, targetCPU, targetMemory string) *vpa_types.VerticalPodAutoscaler {
+	containerName := utils.GetHamsterContainerNameByIndex(0)
+	vpaCRD := test.VerticalPodAutoscaler().
+		WithName(name).
+		WithNamespace(f.Namespace.Name).
+		WithTargetRef(utils.HamsterTargetRef).
+		WithUpdateMode(updateMode).
+		WithContainer(containerName).
+		AppendRecommendation(
+			test.Recommendation().
+				WithContainer(containerName).
+				WithTarget(targetCPU, targetMemory).
+				WithLowerBound(targetCPU, targetMemory).
+				WithUpperBound(targetCPU, targetMemory).
+				GetContainerResources()).
+		Get()
+	utils.InstallVPA(f, vpaCRD)
+	return vpaCRD
 }

--- a/vertical-pod-autoscaler/test/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/updater.go
@@ -339,6 +339,109 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		err = WaitForPodsUpdatedWithoutEviction(f, podsAfterFirstUpdate)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	// Sets up a lease object updated periodically to signal - requires WithSerial()
+	framework.It("updates pods with recommendation from a VPA with `UpdateMode: InPlace` when a VPA with `UpdateMode: Off` also matches the pod", framework.WithSerial(), framework.WithFeatureGate(features.InPlace), func() {
+		const statusUpdateInterval = 10 * time.Second
+
+		ginkgo.By("Setting up the Admission Controller status")
+		stopCh := make(chan struct{})
+		statusUpdater := status.NewUpdater(
+			f.ClientSet,
+			status.AdmissionControllerStatusName,
+			utils.VpaNamespace,
+			statusUpdateInterval,
+			"e2e test",
+		)
+		defer func() {
+			ginkgo.By("Deleting the Admission Controller status")
+			close(stopCh)
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
+				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		statusUpdater.Run(stopCh)
+
+		controller := &autoscaling.CrossVersionObjectReference{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "hamster-deployment",
+		}
+		ginkgo.By(fmt.Sprintf("Setting up a hamster %v", controller.Kind))
+		setupHamsterController(f, controller.Kind, "100m", "100Mi", utils.DefaultHamsterReplicas)
+		podList, err := GetHamsterPods(f)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		initialPods := podList.DeepCopy()
+
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		targetCPU := "200m"
+		targetMemory := "200Mi"
+
+		// VPA creation order and names are so that if there was some future
+		// change that changes the multi-VPA behaviour, it is more likely to get
+		// caught.
+		// https://github.com/kubernetes/autoscaler/blob/8624d41d09317cc6d716b8b3e4d73dd7424a4f1c/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L189
+		ginkgo.By("Setting up a VPA CRD with UpdateMode: Off")
+		offVpaCRD := test.VerticalPodAutoscaler().
+			WithName("1-hamster-vpa-off").
+			WithNamespace(f.Namespace.Name).
+			WithTargetRef(controller).
+			WithUpdateMode(vpa_types.UpdateModeOff).
+			WithContainer(containerName).
+			AppendRecommendation(
+				test.Recommendation().
+					WithContainer(containerName).
+					WithTarget("500m", "500Mi").
+					WithLowerBound("500m", "500Mi").
+					WithUpperBound("500m", "500Mi").
+					GetContainerResources()).
+			Get()
+		utils.InstallVPA(f, offVpaCRD)
+		ginkgo.By("Setting up a VPA CRD with UpdateMode: Initial")
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("2-hamster-vpa").
+			WithNamespace(f.Namespace.Name).
+			WithTargetRef(controller).
+			WithUpdateMode(vpa_types.UpdateModeInPlace).
+			WithContainer(containerName).
+			AppendRecommendation(
+				test.Recommendation().
+					WithContainer(containerName).
+					WithTarget(targetCPU, targetMemory).
+					WithLowerBound(targetCPU, targetMemory).
+					WithUpperBound(targetCPU, targetMemory).
+					GetContainerResources()).
+			Get()
+
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Checking that resources were modified due to in-place update, not due to evictions")
+		err = WaitForPodsUpdatedWithoutEviction(f, initialPods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking that container resources were updated with the recommendation from the active VPA")
+		gomega.Eventually(func() error {
+			updatedPodList, err := GetHamsterPods(f)
+			if err != nil {
+				return err
+			}
+			for _, pod := range updatedPodList.Items {
+				for _, container := range pod.Status.ContainerStatuses {
+					cpuRequest := container.Resources.Requests[apiv1.ResourceCPU]
+					memoryRequest := container.Resources.Requests[apiv1.ResourceMemory]
+					if cpuRequest.Cmp(ParseQuantityOrDie(targetCPU)) != 0 {
+						framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetCPU, cpuRequest.String())
+						return fmt.Errorf("%s CPU request not updated", container.Name)
+					}
+					if memoryRequest.Cmp(ParseQuantityOrDie(targetMemory)) != 0 {
+						framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetMemory, memoryRequest.String())
+						return fmt.Errorf("%s Memory request not updated", container.Name)
+					}
+				}
+			}
+			return nil
+		}, VpaInPlaceTimeout*3, 15*time.Second).Should(gomega.Succeed())
+	})
 })
 
 func setupPodsForUpscalingEviction(f *framework.Framework, updateMode vpa_types.UpdateMode) *apiv1.PodList {

--- a/vertical-pod-autoscaler/test/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/updater.go
@@ -341,7 +341,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 	})
 
 	// Sets up a lease object updated periodically to signal - requires WithSerial()
-	framework.It("updates pods with recommendation from a VPA with `UpdateMode: InPlace` when a VPA with `UpdateMode: Off` also matches the pod", framework.WithSerial(), framework.WithFeatureGate(features.InPlace), func() {
+	framework.It("updates pods with recommendation from a VPA with `UpdateMode: InPlaceOrRecreate` when a VPA with `UpdateMode: Off` also matches the pod", framework.WithSerial(), func() {
 		const statusUpdateInterval = 10 * time.Second
 
 		ginkgo.By("Setting up the Admission Controller status")
@@ -362,85 +362,30 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		}()
 		statusUpdater.Run(stopCh)
 
-		controller := &autoscaling.CrossVersionObjectReference{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-			Name:       "hamster-deployment",
-		}
-		ginkgo.By(fmt.Sprintf("Setting up a hamster %v", controller.Kind))
-		setupHamsterController(f, controller.Kind, "100m", "100Mi", utils.DefaultHamsterReplicas)
+		ginkgo.By("Setting up a hamster deployment")
+		setupHamsterController(f, utils.HamsterTargetRef.Kind, "100m", "100Mi", utils.DefaultHamsterReplicas)
 		podList, err := GetHamsterPods(f)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		initialPods := podList.DeepCopy()
 
-		containerName := utils.GetHamsterContainerNameByIndex(0)
 		targetCPU := "200m"
 		targetMemory := "200Mi"
 
-		// VPA creation order and names are so that if there was some future
-		// change that changes the multi-VPA behaviour, it is more likely to get
-		// caught.
+		// VPA creation order and names are chosen so that a future change to the
+		// multi-VPA selection logic is more likely to be caught:
 		// https://github.com/kubernetes/autoscaler/blob/8624d41d09317cc6d716b8b3e4d73dd7424a4f1c/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L189
 		ginkgo.By("Setting up a VPA CRD with UpdateMode: Off")
-		offVpaCRD := test.VerticalPodAutoscaler().
-			WithName("1-hamster-vpa-off").
-			WithNamespace(f.Namespace.Name).
-			WithTargetRef(controller).
-			WithUpdateMode(vpa_types.UpdateModeOff).
-			WithContainer(containerName).
-			AppendRecommendation(
-				test.Recommendation().
-					WithContainer(containerName).
-					WithTarget("500m", "500Mi").
-					WithLowerBound("500m", "500Mi").
-					WithUpperBound("500m", "500Mi").
-					GetContainerResources()).
-			Get()
-		utils.InstallVPA(f, offVpaCRD)
-		ginkgo.By("Setting up a VPA CRD with UpdateMode: Initial")
-		vpaCRD := test.VerticalPodAutoscaler().
-			WithName("2-hamster-vpa").
-			WithNamespace(f.Namespace.Name).
-			WithTargetRef(controller).
-			WithUpdateMode(vpa_types.UpdateModeInPlace).
-			WithContainer(containerName).
-			AppendRecommendation(
-				test.Recommendation().
-					WithContainer(containerName).
-					WithTarget(targetCPU, targetMemory).
-					WithLowerBound(targetCPU, targetMemory).
-					WithUpperBound(targetCPU, targetMemory).
-					GetContainerResources()).
-			Get()
+		installHamsterVPA(f, "1-hamster-vpa-off", vpa_types.UpdateModeOff, "500m", "500Mi")
 
-		utils.InstallVPA(f, vpaCRD)
+		ginkgo.By("Setting up a VPA CRD with UpdateMode: InPlaceOrRecreate")
+		installHamsterVPA(f, "2-hamster-vpa", vpa_types.UpdateModeInPlaceOrRecreate, targetCPU, targetMemory)
 
 		ginkgo.By("Checking that resources were modified due to in-place update, not due to evictions")
 		err = WaitForPodsUpdatedWithoutEviction(f, initialPods)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Checking that container resources were updated with the recommendation from the active VPA")
-		gomega.Eventually(func() error {
-			updatedPodList, err := GetHamsterPods(f)
-			if err != nil {
-				return err
-			}
-			for _, pod := range updatedPodList.Items {
-				for _, container := range pod.Status.ContainerStatuses {
-					cpuRequest := container.Resources.Requests[apiv1.ResourceCPU]
-					memoryRequest := container.Resources.Requests[apiv1.ResourceMemory]
-					if cpuRequest.Cmp(ParseQuantityOrDie(targetCPU)) != 0 {
-						framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetCPU, cpuRequest.String())
-						return fmt.Errorf("%s CPU request not updated", container.Name)
-					}
-					if memoryRequest.Cmp(ParseQuantityOrDie(targetMemory)) != 0 {
-						framework.Logf("%v/%v has not been updated to %v yet: currently=%v", pod.Name, container.Name, targetMemory, memoryRequest.String())
-						return fmt.Errorf("%s Memory request not updated", container.Name)
-					}
-				}
-			}
-			return nil
-		}, VpaInPlaceTimeout*3, 15*time.Second).Should(gomega.Succeed())
+		CheckHamsterPodsResourcesUpdated(f, targetCPU, targetMemory)
 	})
 })
 
@@ -604,6 +549,29 @@ func setupPodsForEviction(f *framework.Framework, hamsterCPU, hamsterMemory stri
 	utils.InstallVPA(f, vpaCRD)
 
 	return podList
+}
+
+// installHamsterVPA installs a VPA targeting the hamster deployment with the
+// given name and update mode, and a flat recommendation (target, lower and upper
+// bound all equal) for the first hamster container.
+func installHamsterVPA(f *framework.Framework, name string, updateMode vpa_types.UpdateMode, targetCPU, targetMemory string) *vpa_types.VerticalPodAutoscaler {
+	containerName := utils.GetHamsterContainerNameByIndex(0)
+	vpaCRD := test.VerticalPodAutoscaler().
+		WithName(name).
+		WithNamespace(f.Namespace.Name).
+		WithTargetRef(utils.HamsterTargetRef).
+		WithUpdateMode(updateMode).
+		WithContainer(containerName).
+		AppendRecommendation(
+			test.Recommendation().
+				WithContainer(containerName).
+				WithTarget(targetCPU, targetMemory).
+				WithLowerBound(targetCPU, targetMemory).
+				WithUpperBound(targetCPU, targetMemory).
+				GetContainerResources()).
+		Get()
+	utils.InstallVPA(f, vpaCRD)
+	return vpaCRD
 }
 
 func setupPodsForUpscalingInPlace(f *framework.Framework, updateMode vpa_types.UpdateMode) *apiv1.PodList {

--- a/vertical-pod-autoscaler/test/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/updater.go
@@ -371,9 +371,6 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		targetCPU := "200m"
 		targetMemory := "200Mi"
 
-		// VPA creation order and names are chosen so that a future change to the
-		// multi-VPA selection logic is more likely to be caught:
-		// https://github.com/kubernetes/autoscaler/blob/8624d41d09317cc6d716b8b3e4d73dd7424a4f1c/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L189
 		ginkgo.By("Setting up a VPA CRD with UpdateMode: Off")
 		installHamsterVPA(f, "1-hamster-vpa-off", vpa_types.UpdateModeOff, "500m", "500Mi")
 
@@ -549,29 +546,6 @@ func setupPodsForEviction(f *framework.Framework, hamsterCPU, hamsterMemory stri
 	utils.InstallVPA(f, vpaCRD)
 
 	return podList
-}
-
-// installHamsterVPA installs a VPA targeting the hamster deployment with the
-// given name and update mode, and a flat recommendation (target, lower and upper
-// bound all equal) for the first hamster container.
-func installHamsterVPA(f *framework.Framework, name string, updateMode vpa_types.UpdateMode, targetCPU, targetMemory string) *vpa_types.VerticalPodAutoscaler {
-	containerName := utils.GetHamsterContainerNameByIndex(0)
-	vpaCRD := test.VerticalPodAutoscaler().
-		WithName(name).
-		WithNamespace(f.Namespace.Name).
-		WithTargetRef(utils.HamsterTargetRef).
-		WithUpdateMode(updateMode).
-		WithContainer(containerName).
-		AppendRecommendation(
-			test.Recommendation().
-				WithContainer(containerName).
-				WithTarget(targetCPU, targetMemory).
-				WithLowerBound(targetCPU, targetMemory).
-				WithUpperBound(targetCPU, targetMemory).
-				GetContainerResources()).
-		Get()
-	utils.InstallVPA(f, vpaCRD)
-	return vpaCRD
 }
 
 func setupPodsForUpscalingInPlace(f *framework.Framework, updateMode vpa_types.UpdateMode) *apiv1.PodList {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds a VPA updater test for a scenario where multiple VPAs target the same Pod, one VPA has `updateMode: InPlace`, all other VPAs have `updateMode: Off`. (See #10158  for use case).
In this scenario:
- the patch that the VPA updater applies should always be from the recommendation of the VPA with `updateMode: InPlace`
- the VPA updater should not skip the VPA with `updateMode: InPlace` even if some of the `updateMode: Off` VPAs are with earlier timestamps

Also adds a timestamp to a similar to admissions controller test to ensure that more of the 'controlling' VPA logic in [api.Stronger](https://github.com/kubernetes/autoscaler/blob/55c37cd5eb550756c5ccc5a89e9068d77797e575/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L189) gets exercised.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Updates #10158 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area vertical-pod-autoscaler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for scenarios where multiple autoscalers target the same Pod.
  * Verified that the active in-place autoscaler is selected over autoscalers in off mode.
  * Confirmed that recommendations are applied to CPU and memory requests and limits during in-place updates.
  * Improved validation of autoscaler selection when operating modes and creation times differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->