### PR TITLE
VPA: fix RequestsOnly capping for fractional limits

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -148,3 +148,13 @@ func HasLowerResource(a, b corev1.ResourceList) bool {
 	}
 	return false
 }
+
+// CapResources caps every resource in-place to the corresponding value in maxResources
+func CapResources(resources, maxResources corev1.ResourceList) {
+	for resourceName, resourceValue := range resources {
+		maxValue, ok := maxResources[resourceName]
+		if ok && maxValue.Cmp(resourceValue) < 0 {
+			resources[resourceName] = maxValue.DeepCopy()
+		}
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers_test.go
@@ -479,3 +479,92 @@ func TestRecommendationHasLowerResource(t *testing.T) {
 		})
 	}
 }
+
+func TestCapResources(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		resources    corev1.ResourceList
+		maxResources corev1.ResourceList
+		expected     corev1.ResourceList
+	}{
+		{
+			desc: "resources above the max are capped down to it",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("101m"),
+				corev1.ResourceMemory: resource.MustParse("1025"),
+			},
+			maxResources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100500u"),
+				corev1.ResourceMemory: resource.MustParse("1024500m"),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100500u"),
+				corev1.ResourceMemory: resource.MustParse("1024500m"),
+			},
+		},
+		{
+			desc: "resources below the max are kept",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			maxResources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+		},
+		{
+			desc: "resources equal to the max are kept",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+			maxResources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+		},
+		{
+			desc: "a resource missing from maxResources is left unchanged",
+			resources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("101m"),
+				corev1.ResourceMemory: resource.MustParse("1025"),
+			},
+			maxResources: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("100500u"),
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100500u"),
+				corev1.ResourceMemory: resource.MustParse("1025"),
+			},
+		},
+		{
+			desc:         "no resources stays nil",
+			resources:    nil,
+			maxResources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			expected:     nil,
+		},
+		{
+			desc:         "nil maxResources leaves resources unchanged",
+			resources:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("101m")},
+			maxResources: nil,
+			expected:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("101m")},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			resources := tc.resources.DeepCopy()
+			CapResources(resources, tc.maxResources)
+			assert.Equal(t, tc.expected, resources, "resources should be mutated in place")
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -163,7 +163,7 @@ func capRecommendationToContainerLimit(recommendation corev1.ResourceList, conta
 	// Iterate over limits set in the container. Unset means Infinite limit.
 	for resourceName, limit := range containerLimits {
 		recommendedValue, found := recommendation[resourceName]
-		if found && recommendedValue.MilliValue() > limit.MilliValue() {
+		if found && recommendedValue.Cmp(limit) > 0 {
 			recommendation[resourceName] = limit
 			annotations = append(annotations, toCappingAnnotation(resourceName, cappedToLimit))
 		}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -137,6 +137,11 @@ func getCappedRecommendationForContainer(
 		}
 		// TODO: If limits and policy are conflicting, set some condition on the VPA.
 		if containerControlledValues == vpa_types.ContainerControlledValuesRequestsOnly {
+			// The limits applied to the container can be higher than the limits declared in the Pod
+			// spec because fractional values are rounded up before being passed to the container
+			// runtime; to avoid API server validation errors we ensure that recommendations are
+			// capped to the limits in the Pod spec
+			resourcehelpers.CapResources(containerLimits, container.Resources.Limits)
 			annotations = capRecommendationToContainerLimit(recommendation, containerLimits)
 			if genAnnotations {
 				cappingAnnotations = append(cappingAnnotations, annotations...)

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -208,6 +208,29 @@ func TestRecommendationToLimitCapping(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("1024500m"),
 			},
 			expectedAnnotation: true,
+		}, {
+			// We pick limits that round up to the container's recommendation (upper bound) to
+			// validate the logic that determines whether to actually apply capping
+			name: "capping for RequestsOnly policy for limits within sub-milli precision of the recommendation",
+			pod: test.Pod().WithName("pod1").AddContainer(
+				test.Container().WithName(containerName).
+					WithCPULimit(resource.MustParse("19999500u")).
+					WithMemLimit(resource.MustParse("79999999500u")).Get()).Get(),
+			policy: vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{{
+					ContainerName:    vpa_types.DefaultContainerResourcePolicy,
+					ControlledValues: &requestsOnly,
+				}},
+			},
+			expectedTarget: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("19999500u"),
+				corev1.ResourceMemory: resource.MustParse("79999999500u"),
+			},
+			expectedUpperBound: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("19999500u"),
+				corev1.ResourceMemory: resource.MustParse("79999999500u"),
+			},
+			expectedAnnotation: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -177,6 +177,37 @@ func TestRecommendationToLimitCapping(t *testing.T) {
 				corev1.ResourceMemory: *resource.NewScaledQuantity(6000, 1),
 			},
 			expectedAnnotation: true,
+		}, {
+			// The kubelet rounds up fractional limits before passing them to the container runtime
+			// and reports the rounded up values back in the container status; we ensure that
+			// recommendations are limited to the limits in the Pod spec when using RequestsOnly
+			name: "capping for RequestsOnly policy for fractional limits rounded up in containerStatus",
+			pod: func() *corev1.Pod {
+				pod := test.Pod().WithName("pod1").AddContainer(
+					test.Container().WithName(containerName).
+						WithCPULimit(resource.MustParse("100500u")).
+						WithMemLimit(resource.MustParse("1024500m")).Get()).Get()
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					test.ContainerStatus().WithName(containerName).
+						WithCPULimit(resource.MustParse("101m")).
+						WithMemLimit(resource.MustParse("1025")).Get()}
+				return pod
+			}(),
+			policy: vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{{
+					ContainerName:    vpa_types.DefaultContainerResourcePolicy,
+					ControlledValues: &requestsOnly,
+				}},
+			},
+			expectedTarget: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100500u"),
+				corev1.ResourceMemory: resource.MustParse("1024500m"),
+			},
+			expectedUpperBound: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100500u"),
+				corev1.ResourceMemory: resource.MustParse("1024500m"),
+			},
+			expectedAnnotation: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently recommendations are capped to the limits in the container status when using RequestsOnly and in-place Pod resize is enabled. However, limits in the container status can be rounded up if the limits in the Pod spec are fractional. This can lead to VPA attempting to set requests higher than limits.

This PR fixes this by capping recommendations to the container limits in the Pod spec.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed bug where VPA can attempt to set requests higher than fractional limits
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recommendations in requests-only mode now respect the precise CPU and memory limits declared for containers.
  * Prevents calculated container limits from exceeding Pod-specified limits, including values with fractional precision.
  * Resources without configured maximums remain unchanged.

* **Tests**
  * Added coverage for resource capping, including values above, below, or equal to limits, fractional CPU and memory values, missing limits, and nil inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->