### PR TITLE
Increase logging verbosity in e2e tests

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -143,6 +143,7 @@ helm upgrade <release-name> <chart> \
 | admissionController.image.pullPolicy | string | `"IfNotPresent"` |  |
 | admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` |  |
 | admissionController.image.tag | string | `nil` |  |
+| admissionController.logLevel | int | `4` | Log verbosity for the Admission Controller (klog -v). |
 | admissionController.mutatingWebhookConfiguration.annotations | object | `{}` | Additional annotations for the MutatingWebhookConfiguration |
 | admissionController.mutatingWebhookConfiguration.failurePolicy | string | `"Ignore"` | The failurePolicy for the mutating webhook. Allowed values are: Ignore, Fail |
 | admissionController.mutatingWebhookConfiguration.namespaceSelector | object | `{}` | The namespaceSelector controls which namespaces are affected by the webhook |
@@ -212,6 +213,7 @@ helm upgrade <release-name> <chart> \
 | recommender.leaderElection.resourceName | string | `"vpa-recommender-lease"` |  |
 | recommender.leaderElection.resourceNamespace | string | `""` |  |
 | recommender.leaderElection.retryPeriod | string | `"2s"` |  |
+| recommender.logLevel | int | `4` | Log verbosity for the Recommender (klog -v). |
 | recommender.nodeSelector | object | `{}` |  |
 | recommender.podAnnotations | object | `{}` |  |
 | recommender.podDisruptionBudget.enabled | bool | `true` |  |
@@ -243,6 +245,7 @@ helm upgrade <release-name> <chart> \
 | updater.leaderElection.resourceName | string | `"vpa-updater-lease"` |  |
 | updater.leaderElection.resourceNamespace | string | `""` |  |
 | updater.leaderElection.retryPeriod | string | `"2s"` |  |
+| updater.logLevel | int | `4` | Log verbosity for the Updater (klog -v). |
 | updater.nodeSelector | object | `{}` |  |
 | updater.podAnnotations | object | `{}` |  |
 | updater.podDisruptionBudget.enabled | bool | `true` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -74,7 +74,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-            - --v=4
             - --stderrthreshold=info
           {{- if .Values.admissionController.registerWebhook }}
             - --register-webhook=true
@@ -83,6 +82,9 @@ spec:
           {{- end }}
             - --webhook-service={{ .Values.admissionController.service.name }}
             - --reload-cert=true
+          {{- with .Values.admissionController.logLevel }}
+            - --v={{ . }}
+          {{- end }}
           {{- with .Values.admissionController.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -59,7 +59,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-            - --v=4
             - --stderrthreshold=info
             {{- /* Smart auto-enable: if enabled is null, auto-enable when replicas > 1 */ -}}
             {{- $leaderElectionEnabled := .Values.recommender.leaderElection.enabled }}
@@ -74,6 +73,9 @@ spec:
             - --leader-elect-renew-deadline={{ .Values.recommender.leaderElection.renewDeadline }}
             - --leader-elect-retry-period={{ .Values.recommender.leaderElection.retryPeriod }}
             {{- end }}
+          {{- with .Values.recommender.logLevel }}
+            - --v={{ . }}
+          {{- end }}
           {{- with .Values.recommender.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -64,7 +64,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           args:
-            - --v=4
             - --stderrthreshold=info
             {{- if eq (include "vertical-pod-autoscaler.updater.leaderElectionEnabled" .) "true" }}
             - --leader-elect=true
@@ -74,6 +73,9 @@ spec:
             - --leader-elect-renew-deadline={{ .Values.updater.leaderElection.renewDeadline }}
             - --leader-elect-retry-period={{ .Values.updater.leaderElection.retryPeriod }}
             {{- end }}
+          {{- with .Values.updater.logLevel }}
+            - --v={{ . }}
+          {{- end }}
           {{- with .Values.updater.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -68,6 +68,9 @@ admissionController:
   # Additional environment variables for the Admission Controller default container.
   extraEnv: []
 
+  # admissionController.logLevel -- Log verbosity for the Admission Controller (klog -v).
+  logLevel: 4
+
   # Additional args for the Admission Controller default container.
   extraArgs: []
 
@@ -264,6 +267,9 @@ recommender:
   # Additional environment variables for the Recommender default container.
   extraEnv: []
 
+  # recommender.logLevel -- Log verbosity for the Recommender (klog -v).
+  logLevel: 4
+
   # Additional args for the Recommender default container.
   extraArgs: []
 
@@ -332,6 +338,9 @@ updater:
 
   # Annotations to add to the Updater deployment.
   annotations: {}
+
+  # updater.logLevel -- Log verbosity for the Updater (klog -v).
+  logLevel: 4
 
   # Additional args for the updater
   extraArgs:

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -120,8 +120,6 @@ for COMPONENT in ${COMPONENTS}; do
 done
 
 # Propagate FEATURE_GATES (set on alpha/beta CI lanes) to component args.
-# Helm --set replaces lists; for admissionController we re-add --reload-cert
-# (set in values-e2e.yaml for the cert-rotation test) so it isn't dropped.
 # Commas in the value are escaped so Helm --set treats it as one assignment.
 if [[ -n "${FEATURE_GATES:-}" ]]; then
   ESCAPED_FEATURE_GATES="${FEATURE_GATES//,/\\,}"
@@ -134,10 +132,7 @@ if [[ -n "${FEATURE_GATES:-}" ]]; then
         HELM_SET_ARGS+=("--set" "updater.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
       admission-controller)
-        HELM_SET_ARGS+=(
-          "--set" "admissionController.extraArgs[0]=--reload-cert"
-          "--set" "admissionController.extraArgs[1]=--feature-gates=${ESCAPED_FEATURE_GATES}"
-        )
+        HELM_SET_ARGS+=("--set" "admissionController.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
     esac
   done

--- a/vertical-pod-autoscaler/hack/e2e/values-e2e.yaml
+++ b/vertical-pod-autoscaler/hack/e2e/values-e2e.yaml
@@ -21,9 +21,7 @@ admissionController:
   registerWebhook: true
   certGen:
     enabled: false
-  # Enable certificate reload for e2e rotation test
-  extraArgs:
-    - --reload-cert
+  logLevel: 6
   # Mount certificates with legacy key names (matching gencerts.sh format)
   volumes:
     - name: tls-certs
@@ -42,6 +40,7 @@ recommender:
     enabled: false
   leaderElection:
     enabled: false
+  logLevel: 6
 
 updater:
   enabled: false
@@ -51,3 +50,4 @@ updater:
     enabled: false
   leaderElection:
     enabled: false
+  logLevel: 6


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As suggested by Max in https://github.com/kubernetes/autoscaler/pull/10162

This should help debug flakes and test failures.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This also adjusts how the `--v` is set in the helm chart.
`extraArgs` is a list, and Helm doesn't merge lists.
So this change hoists it up to its own value allowing it to be defaulted and overridden easily.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added configurable log levels for the admission controller, recommender, and updater, defaulting to verbosity level 4.
* Deployment configuration now controls component logging verbosity.

## Documentation
* Documented the available logging settings and their impact on diagnostic output.

## Chores
* Increased logging verbosity in end-to-end test environments for improved troubleshooting.
* Local end-to-end runs now retain deployed resources after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->