### PR TITLE
VPA recommender: fix checkpoint garbage collection timeout

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -69,6 +69,7 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `alsologtostderr` | bool | false | log to standard error as well as files (no effect when -logtostderr=true) |
 | `alsologtostderrthreshold` | severity |  | logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true) |
 | `checkpoints-gc-interval` | duration | 10m0s | How often orphaned checkpoints should be garbage collected |
+| `checkpoints-gc-timeout` | duration | 1m0s | Timeout for garbage collecting orphaned checkpoints |
 | `checkpoints-timeout` | duration | 1m0s | Timeout for writing checkpoints since the start of the recommender's main loop |
 | `confidence-interval-cpu` | duration | 24h0m0s | The time interval used for computing the confidence multiplier for the CPU lower and upper bound. Default: 24h |
 | `confidence-interval-memory` | duration | 24h0m0s | The time interval used for computing the confidence multiplier for the memory lower and upper bound. Default: 24h |

--- a/vertical-pod-autoscaler/pkg/recommender/config/config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config.go
@@ -42,6 +42,7 @@ type RecommenderConfig struct {
 	RecommenderName         string
 	MetricsFetcherInterval  time.Duration
 	CheckpointsGCInterval   time.Duration
+	CheckpointsGCTimeout    time.Duration
 	CheckpointsWriteTimeout time.Duration
 	Address                 string
 	Storage                 string
@@ -114,6 +115,7 @@ func DefaultRecommenderConfig() *RecommenderConfig {
 		RecommenderName:         input.DefaultRecommenderName,
 		MetricsFetcherInterval:  1 * time.Minute,
 		CheckpointsGCInterval:   10 * time.Minute,
+		CheckpointsGCTimeout:    time.Minute,
 		CheckpointsWriteTimeout: time.Minute,
 		Address:                 ":8942",
 		Storage:                 "",
@@ -186,6 +188,7 @@ func InitRecommenderFlags() *RecommenderConfig {
 	flag.StringVar(&config.RecommenderName, "recommender-name", config.RecommenderName, "Set the recommender name. Recommender will generate recommendations for VPAs that configure the same recommender name. If the recommender name is left as default it will also generate recommendations that don't explicitly specify recommender. You shouldn't run two recommenders with the same name in a cluster.")
 	flag.DurationVar(&config.MetricsFetcherInterval, "recommender-interval", config.MetricsFetcherInterval, `How often metrics should be fetched`)
 	flag.DurationVar(&config.CheckpointsGCInterval, "checkpoints-gc-interval", config.CheckpointsGCInterval, `How often orphaned checkpoints should be garbage collected`)
+	flag.DurationVar(&config.CheckpointsGCTimeout, "checkpoints-gc-timeout", config.CheckpointsGCTimeout, `Timeout for garbage collecting orphaned checkpoints`)
 	flag.DurationVar(&config.CheckpointsWriteTimeout, "checkpoints-timeout", config.CheckpointsWriteTimeout, `Timeout for writing checkpoints since the start of the recommender's main loop`)
 	flag.StringVar(&config.Address, "address", config.Address, "The address to expose Prometheus metrics.")
 	flag.StringVar(&config.Storage, "storage", config.Storage, `Specifies storage mode. Supported values: prometheus, checkpoint (default: checkpoint)`)

--- a/vertical-pod-autoscaler/pkg/recommender/config/config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config.go
@@ -274,6 +274,11 @@ func ValidateRecommenderConfig(config *RecommenderConfig) {
 		klog.InfoS("DEPRECATION WARNING: The 'min-checkpoints' flag is deprecated and has no effect. It will be removed in a future release.")
 	}
 
+	if config.CheckpointsGCTimeout <= 0 {
+		klog.ErrorS(nil, "--checkpoints-gc-timeout must be a positive duration", "checkpoints-gc-timeout", config.CheckpointsGCTimeout)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+
 	if config.PrometheusBearerToken != "" && config.PrometheusBearerTokenFile != "" && config.Username != "" {
 		klog.ErrorS(nil, "--bearer-token, --bearer-token-file and --username are mutually exclusive and can't be set together.")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -77,7 +77,7 @@ type ClusterStateFeeder interface {
 	DeleteRemovedPods()
 
 	// GarbageCollectCheckpoints removes historical checkpoints that don't have a matching VPA.
-	GarbageCollectCheckpoints(ctx context.Context)
+	GarbageCollectCheckpoints(ctx context.Context) error
 }
 
 // ClusterStateFeederFactory makes instances of ClusterStateFeeder.
@@ -310,15 +310,14 @@ func (feeder *clusterStateFeeder) InitFromCheckpoints(ctx context.Context) {
 	}
 }
 
-func (feeder *clusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context) {
+func (feeder *clusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context) error {
 	klog.V(3).InfoS("Starting garbage collection of checkpoints")
 
 	allVPAKeys := map[model.VpaID]bool{}
 
 	allVpaResources, err := feeder.vpaLister.List(labels.Everything())
 	if err != nil {
-		klog.ErrorS(err, "Cannot list VPAs")
-		return
+		return fmt.Errorf("failed to list VPAs: %w", err)
 	}
 	for _, vpa := range allVpaResources {
 		vpaID := model.VpaID{
@@ -330,10 +329,10 @@ func (feeder *clusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context)
 
 	namespaceList, err := feeder.coreClient.Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		klog.ErrorS(err, "Cannot list namespaces")
-		return
+		return fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
+	var errs error
 	for _, namespaceItem := range namespaceList.Items {
 		namespace := namespaceItem.Name
 		// Clean the namespace if any of the following conditions are true:
@@ -344,11 +343,11 @@ func (feeder *clusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context)
 			klog.V(3).InfoS("Skipping namespace; it does not meet cleanup criteria", "namespace", namespace, "vpaObjectNamespace", feeder.vpaObjectNamespace, "ignoredNamespaces", feeder.ignoredNamespaces)
 			continue
 		}
-		err := feeder.cleanupCheckpointsForNamespace(ctx, namespace, allVPAKeys)
-		if err != nil {
-			klog.ErrorS(err, "error cleaning checkpoints")
+		if err := feeder.cleanupCheckpointsForNamespace(ctx, namespace, allVPAKeys); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error cleaning checkpoints in namespace %s: %w", namespace, err))
 		}
 	}
+	return errs
 }
 
 func (feeder *clusterStateFeeder) shouldIgnoreNamespace(namespace string) bool {

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -340,7 +340,7 @@ func (feeder *clusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context)
 		vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
 		if !allVPAKeys[vpaID] {
 			if err := feeder.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(checkpoint.Namespace).Delete(ctx, checkpoint.Name, metav1.DeleteOptions{}); err != nil {
-				errs = errors.Join(errs, fmt.Errorf("Orphaned VPA checkpoint cleanup - failed to delete checkpoint %s: %w", klog.KObj(checkpoint), err))
+				errs = errors.Join(errs, fmt.Errorf("orphaned VPA checkpoint cleanup - failed to delete checkpoint %s: %w", klog.KObj(checkpoint), err))
 				continue
 			}
 			klog.V(3).InfoS("Orphaned VPA checkpoint cleanup - deleting", "checkpoint", klog.KObj(checkpoint))

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -18,6 +18,7 @@ package input
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -339,10 +340,10 @@ func (feeder *clusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context)
 		vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
 		if !allVPAKeys[vpaID] {
 			if err := feeder.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(checkpoint.Namespace).Delete(ctx, checkpoint.Name, metav1.DeleteOptions{}); err != nil {
-				errs = errors.Join(errs, fmt.Errorf("failed to delete checkpoint %s: %w", klog.KObj(checkpoint), err))
+				errs = errors.Join(errs, fmt.Errorf("Orphaned VPA checkpoint cleanup - failed to delete checkpoint %s: %w", klog.KObj(checkpoint), err))
 				continue
 			}
-			klog.V(3).InfoS("Orphaned VPA checkpoint cleanup - deleted", "checkpoint", klog.KObj(checkpoint))
+			klog.V(3).InfoS("Orphaned VPA checkpoint cleanup - deleting", "checkpoint", klog.KObj(checkpoint))
 		}
 	}
 	return errs

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	kube_client "k8s.io/client-go/kubernetes"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -83,7 +82,6 @@ type ClusterStateFeeder interface {
 // ClusterStateFeederFactory makes instances of ClusterStateFeeder.
 type ClusterStateFeederFactory struct {
 	ClusterState        model.ClusterState
-	KubeClient          kube_client.Interface
 	MetricsClient       metrics.MetricsClient
 	VpaCheckpointClient vpa_api.VerticalPodAutoscalerCheckpointsGetter
 	VpaCheckpointLister vpa_lister.VerticalPodAutoscalerCheckpointLister
@@ -102,7 +100,6 @@ type ClusterStateFeederFactory struct {
 // Make creates new ClusterStateFeeder with internal data providers, based on kube client.
 func (m ClusterStateFeederFactory) Make() *clusterStateFeeder {
 	return &clusterStateFeeder{
-		coreClient:          m.KubeClient.CoreV1(),
 		metricsClient:       m.MetricsClient,
 		oomChan:             m.OOMObserver.GetObservedOomsChannel(),
 		vpaCheckpointClient: m.VpaCheckpointClient,
@@ -215,7 +212,6 @@ func NewPodListerAndOOMObserver(ctx context.Context, kubeClient kube_client.Inte
 }
 
 type clusterStateFeeder struct {
-	coreClient          typedcorev1.CoreV1Interface
 	specClient          spec.SpecClient
 	metricsClient       metrics.MetricsClient
 	oomChan             <-chan oom.OomInfo
@@ -327,24 +323,27 @@ func (feeder *clusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context)
 		allVPAKeys[vpaID] = true
 	}
 
-	namespaceList, err := feeder.coreClient.Namespaces().List(ctx, metav1.ListOptions{})
+	checkpointList, err := feeder.vpaCheckpointLister.List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("failed to list namespaces: %w", err)
+		return fmt.Errorf("failed to list VPA checkpoints: %w", err)
 	}
 
 	var errs error
-	for _, namespaceItem := range namespaceList.Items {
-		namespace := namespaceItem.Name
-		// Clean the namespace if any of the following conditions are true:
-		// 1. `vpaObjectNamespace` is set and matches the current namespace.
-		// 2. `ignoredNamespaces` is set, but the current namespace is not in the list.
-		// 3. Neither `vpaObjectNamespace` nor `ignoredNamespaces` is set, so all namespaces are included.
-		if feeder.shouldIgnoreNamespace(namespace) {
-			klog.V(3).InfoS("Skipping namespace; it does not meet cleanup criteria", "namespace", namespace, "vpaObjectNamespace", feeder.vpaObjectNamespace, "ignoredNamespaces", feeder.ignoredNamespaces)
+	for _, checkpoint := range checkpointList {
+		// Skip the checkpoint if any of the following conditions are true:
+		// 1. `vpaObjectNamespace` is set and doesn't match the checkpoint's namespace.
+		// 2. `ignoredNamespaces` is set and contains the checkpoint's namespace.
+		if feeder.shouldIgnoreNamespace(checkpoint.Namespace) {
+			klog.V(3).InfoS("Skipping checkpoint; its namespace does not meet cleanup criteria", "checkpoint", klog.KObj(checkpoint), "vpaObjectNamespace", feeder.vpaObjectNamespace, "ignoredNamespaces", feeder.ignoredNamespaces)
 			continue
 		}
-		if err := feeder.cleanupCheckpointsForNamespace(ctx, namespace, allVPAKeys); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("error cleaning checkpoints in namespace %s: %w", namespace, err))
+		vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
+		if !allVPAKeys[vpaID] {
+			if err := feeder.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(checkpoint.Namespace).Delete(ctx, checkpoint.Name, metav1.DeleteOptions{}); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to delete checkpoint %s: %w", klog.KObj(checkpoint), err))
+				continue
+			}
+			klog.V(3).InfoS("Orphaned VPA checkpoint cleanup - deleted", "checkpoint", klog.KObj(checkpoint))
 		}
 	}
 	return errs
@@ -360,26 +359,6 @@ func (feeder *clusterStateFeeder) shouldIgnoreNamespace(namespace string) bool {
 		return true
 	}
 	return false
-}
-
-func (feeder *clusterStateFeeder) cleanupCheckpointsForNamespace(ctx context.Context, namespace string, allVPAKeys map[model.VpaID]bool) error {
-	var err error
-	checkpointList, err := feeder.vpaCheckpointLister.VerticalPodAutoscalerCheckpoints(namespace).List(labels.Everything())
-
-	if err != nil {
-		return err
-	}
-	for _, checkpoint := range checkpointList {
-		vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
-		if !allVPAKeys[vpaID] {
-			if errFeeder := feeder.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(namespace).Delete(ctx, checkpoint.Name, metav1.DeleteOptions{}); errFeeder != nil {
-				err = errors.Join(err, fmt.Errorf("failed to delete orphaned checkpoint %s: %w", klog.KRef(namespace, checkpoint.Name), errFeeder))
-				continue
-			}
-			klog.V(3).InfoS("Orphaned VPA checkpoint cleanup - deleting", "checkpoint", klog.KRef(namespace, checkpoint.Name))
-		}
-	}
-	return err
 }
 
 func implicitDefaultRecommender(selectors []*vpa_types.VerticalPodAutoscalerRecommenderSelector) bool {

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -1079,7 +1079,8 @@ func TestCanCleanupCheckpoints(t *testing.T) {
 		recommenderName:     "default",
 	}
 
-	feeder.GarbageCollectCheckpoints(tctx)
+	err = feeder.GarbageCollectCheckpoints(tctx)
+	assert.NoError(t, err)
 
 	assert.Contains(t, deletedCheckpoints, "nonExistentVPA")
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -1069,7 +1069,7 @@ func TestCanCleanupCheckpoints(t *testing.T) {
 		recommenderName:     "default",
 	}
 
-	err = feeder.GarbageCollectCheckpoints(tctx)
+	err := feeder.GarbageCollectCheckpoints(tctx)
 	assert.NoError(t, err)
 
 	assert.Contains(t, deletedCheckpoints, "nonExistentVPA")

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -55,6 +55,7 @@ type recommender struct {
 	clusterStateFeeder            input.ClusterStateFeeder
 	checkpointWriter              checkpoint.CheckpointWriter
 	checkpointsGCInterval         time.Duration
+	checkpointsGCTimeout          time.Duration
 	checkpointsWriteTimeout       time.Duration
 	controllerFetcher             controllerfetcher.ControllerFetcher
 	lastCheckpointGC              time.Time
@@ -153,11 +154,18 @@ func (r *recommender) UpdateVPAs() {
 
 func (r *recommender) MaintainCheckpoints(ctx context.Context) {
 	if r.useCheckpoints {
-		r.checkpointWriter.StoreCheckpoints(ctx, r.updateWorkerCount)
+		writeCtx, cancelWrite := context.WithTimeout(ctx, r.checkpointsWriteTimeout)
+		defer cancelWrite()
+		r.checkpointWriter.StoreCheckpoints(writeCtx, r.updateWorkerCount)
 
 		if time.Since(r.lastCheckpointGC) > r.checkpointsGCInterval {
-			r.lastCheckpointGC = time.Now()
-			r.clusterStateFeeder.GarbageCollectCheckpoints(ctx)
+			gcCtx, cancelGC := context.WithTimeout(ctx, r.checkpointsGCTimeout)
+			defer cancelGC()
+			if err := r.clusterStateFeeder.GarbageCollectCheckpoints(gcCtx); err != nil {
+				klog.ErrorS(err, "Checkpoint garbage collection failed to complete, will retry next run")
+			} else {
+				r.lastCheckpointGC = time.Now()
+			}
 		}
 	}
 }
@@ -187,9 +195,7 @@ func (r *recommender) RunOnce() {
 	r.UpdateVPAs()
 	timer.ObserveStep("UpdateVPAs")
 
-	stepCtx, cancelFunc := context.WithDeadline(ctx, time.Now().Add(r.checkpointsWriteTimeout))
-	defer cancelFunc()
-	r.MaintainCheckpoints(stepCtx)
+	r.MaintainCheckpoints(ctx)
 	timer.ObserveStep("MaintainCheckpoints")
 
 	r.clusterState.RateLimitedGarbageCollectAggregateCollectionStates(ctx, time.Now(), r.controllerFetcher)
@@ -211,6 +217,7 @@ type RecommenderFactory struct {
 	RecommendationPostProcessors []RecommendationPostProcessor
 
 	CheckpointsGCInterval   time.Duration
+	CheckpointsGCTimeout    time.Duration
 	CheckpointsWriteTimeout time.Duration
 	UseCheckpoints          bool
 	UpdateWorkerCount       int
@@ -224,6 +231,7 @@ func (c RecommenderFactory) Make() Recommender {
 		clusterStateFeeder:            c.ClusterStateFeeder,
 		checkpointWriter:              c.CheckpointWriter,
 		checkpointsGCInterval:         c.CheckpointsGCInterval,
+		checkpointsGCTimeout:          c.CheckpointsGCTimeout,
 		checkpointsWriteTimeout:       c.CheckpointsWriteTimeout,
 		controllerFetcher:             c.ControllerFetcher,
 		useCheckpoints:                c.UseCheckpoints,

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
@@ -162,6 +162,7 @@ func NewRecommenderController(
 		},
 		RecommendationPostProcessors: postProcessors,
 		CheckpointsGCInterval:        config.CheckpointsGCInterval,
+		CheckpointsGCTimeout:         config.CheckpointsGCTimeout,
 		CheckpointsWriteTimeout:      config.CheckpointsWriteTimeout,
 		UseCheckpoints:               useCheckpoints,
 		UpdateWorkerCount:            config.UpdateWorkerCount,

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package routines
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -30,6 +31,7 @@ import (
 
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_fake "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/fake"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
@@ -346,4 +348,35 @@ func (k mockAggregateStateKey) Labels() labels.Labels {
 	// Should return empty on error
 	labels, _ := labels.ConvertSelectorToLabelsMap(k.labels)
 	return labels
+}
+
+type fakeClusterStateFeeder struct {
+	input.ClusterStateFeeder
+}
+
+// GarbageCollectCheckpoints fails iff ctx is already done
+func (f *fakeClusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context) error {
+	return ctx.Err()
+}
+
+type noopCheckpointWriter struct{}
+
+func (noopCheckpointWriter) StoreCheckpoints(context.Context, int) {}
+
+func TestMaintainCheckpointsGCUsesIndependentTimeout(t *testing.T) {
+	feeder := &fakeClusterStateFeeder{}
+
+	// Construct a recommender where checkpoint updates timeout straight away
+	r := &recommender{
+		clusterStateFeeder:      feeder,
+		checkpointWriter:        noopCheckpointWriter{},
+		useCheckpoints:          true,
+		checkpointsWriteTimeout: 0,
+		checkpointsGCTimeout:    time.Minute,
+	}
+
+	r.MaintainCheckpoints(context.Background())
+
+	// Ensure that garbage collection was invoked and succeeded
+	assert.False(t, r.lastCheckpointGC.IsZero())
 }

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
@@ -355,7 +355,7 @@ type fakeClusterStateFeeder struct {
 }
 
 // GarbageCollectCheckpoints fails iff ctx is already done
-func (f *fakeClusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context) error {
+func (*fakeClusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context) error {
 	return ctx.Err()
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently recommender checkpoint updating and garbage collection use a single context timeout. if the recommender fails to update all checkpoints within its timeout (very possible on large clusters) garbage collection fails straight away since it cannot list checkpoints (context has already expired). This makes it impossible for garbage collection to run and the number of checkpoint resources gradually grows.

This PR fixes this by defining a dedicated timeout for garbage collection and only marking garbage collection as complete when it has completed successfully (so that failed garbage collection is retried on the next interval).

Note that even if checkpoint updating times out, VPA will pick up from where it left off since VPAs are sorted by the last time their checkpoint was written, so checkpointing will just become less frequent as the number of checkpoints grows rather than checkpointing being skipped completely for some VPAs: https://github.com/kubernetes/autoscaler/blob/55c37cd5eb550756c5ccc5a89e9068d77797e575/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go#L69-L71

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for cleaning up orphaned VPA checkpoints.
  * Exposed the `--checkpoints-gc-timeout` command-line option, defaulting to one minute.
  * Added validation requiring the timeout to be greater than zero.

* **Bug Fixes**
  * Checkpoint cleanup failures are now reported instead of silently logged.
  * Cleanup status is recorded only after successful completion, improving retry behavior.
  * Cleanup continues across namespaces while reporting any errors encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->