### PR TITLE
Improve RELEASE.md

### DIFF
--- a/vertical-pod-autoscaler/RELEASE.md
+++ b/vertical-pod-autoscaler/RELEASE.md
@@ -12,6 +12,8 @@
   - [Option 1: (Preferred) Automatic](#option-1-preferred-automatic)
   - [Option 2: Manual](#option-2-manual)
 - [Test the release](#test-the-release)
+  - [Option 1: Locally using kind](#option-1-locally-using-kind)
+  - [Option 2: On a GKE cluster](#option-2-on-a-gke-cluster)
 - [Promote image](#promote-image)
 - [Update Helm chart](#update-helm-chart)
 - [Finalize release](#finalize-release)
@@ -133,6 +135,33 @@ for component in recommender updater admission-controller ; do TAG=`grep 'const 
 
 ## Test the release
 
+You can test the release either locally using [kind](https://kind.sigs.k8s.io/) (Option 1) or on a
+GKE cluster (Option 2). In both cases the staged release images from
+`gcr.io/k8s-staging-autoscaling` are tested, not a local build.
+
+### Option 1: Locally using kind
+
+[hack/run-e2e-locally.sh](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/hack/run-e2e-locally.sh)
+creates a kind cluster, deploys VPA and runs the e2e tests. Set `PULL_IMAGES=true` so the staged
+release images are pulled instead of building images from your local checkout.
+
+1.  [ ] Run all test suites against the staged images:
+
+    ```shell
+    export REGISTRY=gcr.io/k8s-staging-autoscaling
+    export TAG=`grep 'const versionCore = ' common/version.go | cut -d '"' -f 2`
+    export PULL_IMAGES=true
+    ./hack/run-e2e-locally.sh full-vpa
+    ./hack/run-e2e-locally.sh actuation
+    ./hack/run-e2e-locally.sh admission-controller
+    ./hack/run-e2e-locally.sh updater
+    ./hack/run-e2e-locally.sh recommender
+    ```
+
+    Note: each invocation recreates the kind cluster, so the suites can be run back-to-back.
+
+### Option 2: On a GKE cluster
+
 1.  [ ] Create a Kubernetes cluster. If you're using GKE you can use the following command:
 
     ```shell
@@ -159,7 +188,6 @@ for component in recommender updater admission-controller ; do TAG=`grep 'const 
     ./hack/run-e2e-tests.sh admission-controller
     ./hack/run-e2e-tests.sh updater
     ./hack/run-e2e-tests.sh recommender
-
     ```
 
 ## Promote image

--- a/vertical-pod-autoscaler/RELEASE.md
+++ b/vertical-pod-autoscaler/RELEASE.md
@@ -1,5 +1,24 @@
 # VPA Release Instructions
 
+## Contents
+
+<!-- toc -->
+- [Release Schedule](#release-schedule)
+- [Open issue to track the release](#open-issue-to-track-the-release)
+- [Rollup all changes](#rollup-all-changes)
+  - [New minor release](#new-minor-release)
+  - [New patch release](#new-patch-release)
+- [Build and stage images](#build-and-stage-images)
+  - [Option 1: (Preferred) Automatic](#option-1-preferred-automatic)
+  - [Option 2: Manual](#option-2-manual)
+- [Test the release](#test-the-release)
+- [Promote image](#promote-image)
+- [Update Helm chart](#update-helm-chart)
+- [Finalize release](#finalize-release)
+- [Update dependabot](#update-dependabot)
+- [Permissions](#permissions)
+<!-- /toc -->
+
 These are instructions for releasing VPA. We aim to release a new VPA minor version after each minor Kubernetes release.
 We release patch versions as needed.
 

--- a/vertical-pod-autoscaler/RELEASE.md
+++ b/vertical-pod-autoscaler/RELEASE.md
@@ -151,10 +151,15 @@ for component in recommender updater admission-controller ; do TAG=`grep 'const 
     ```
 
 1.  [ ] [Run](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/hack/run-e2e-tests.sh)
-    the `full-vpa` test suite:
+    on all test suites:
 
     ```shell
     ./hack/run-e2e-tests.sh full-vpa
+    ./hack/run-e2e-tests.sh actuation
+    ./hack/run-e2e-tests.sh admission-controller
+    ./hack/run-e2e-tests.sh updater
+    ./hack/run-e2e-tests.sh recommender
+
     ```
 
 ## Promote image

--- a/vertical-pod-autoscaler/hack/.notableofcontents
+++ b/vertical-pod-autoscaler/hack/.notableofcontents
@@ -3,4 +3,3 @@
 ./charts/README.md
 ./docs/api.md
 ./enhancements/README.md
-./RELEASE.md

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
@@ -74,6 +74,7 @@ function print_help {
   echo "Environment variables:"
   echo "  REGISTRY           - Container image registry (default: localhost:5001)"
   echo "  TAG                - Container image tag (default: latest)"
+  echo "  PULL_IMAGES        - Pull images from the registry instead of building them locally (default: false)"
   echo "  FEATURE_GATES      - Comma-separated list of feature gates to enable"
   echo "  EXTRA_HELM_VALUES  - Path to an additional Helm values file to use during installation"
 }
@@ -119,10 +120,14 @@ helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
 helm repo update metrics-server
 helm upgrade --install --set args={--kubelet-insecure-tls} metrics-server metrics-server/metrics-server --namespace kube-system --version 3.13.0 --wait
 
-# Build and load Docker images for each component
+# Build (or pull) and load Docker images for each component
 for COMPONENT in ${COMPONENTS}; do
-  ALL_ARCHITECTURES=${ARCH} make --directory "${SCRIPT_ROOT}/pkg/${COMPONENT}" docker-build REGISTRY="${REGISTRY}" TAG="${TAG}"
-  docker tag "${REGISTRY}/vpa-${COMPONENT}-${ARCH}:${TAG}" "${REGISTRY}/vpa-${COMPONENT}:${TAG}"
+  if [ "${PULL_IMAGES:-false}" == "true" ]; then
+    docker pull "${REGISTRY}/vpa-${COMPONENT}:${TAG}"
+  else
+    ALL_ARCHITECTURES=${ARCH} make --directory "${SCRIPT_ROOT}/pkg/${COMPONENT}" docker-build REGISTRY="${REGISTRY}" TAG="${TAG}"
+    docker tag "${REGISTRY}/vpa-${COMPONENT}-${ARCH}:${TAG}" "${REGISTRY}/vpa-${COMPONENT}:${TAG}"
+  fi
   kind load docker-image "${REGISTRY}/vpa-${COMPONENT}:${TAG}"
 done
 

--- a/vertical-pod-autoscaler/hack/run-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-locally.sh
@@ -30,6 +30,14 @@ function print_help {
   echo " - admission-controller"
   echo " - actuation"
   echo " - full-vpa"
+  echo ""
+  echo "Environment variables:"
+  echo "  REGISTRY                 - Container image registry (default: localhost:5001)"
+  echo "  TAG                      - Container image tag (default: latest)"
+  echo "  PULL_IMAGES              - Pull images from the registry instead of building them locally (default: false)"
+  echo "  ENABLE_ALL_FEATURE_GATES - Set to 'true' to enable all alpha/beta feature gates"
+  echo "  ARTIFACTS                - Directory to store test log artifacts (default: temp dir)"
+  echo "  NUMPROC                  - Test concurrency (default: 4)"
 }
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Ticks off a few items from https://github.com/kubernetes/autoscaler/issues/10054

This PR does the following:

1. Adds a TOC to RELEASE.md
2. Ensures that the releases runs through all the e2e tests 
3. Adds a PULL_IMAGES env-var to the local e2e test scripts, and updates the release documentation on using them

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a table of contents and expanded local KIND testing guidance.
  * Added instructions for running all VPA test suites on GKE.
  * Documented local end-to-end testing options, including image pulling, registry settings, feature gates, artifact storage, and test concurrency.

* **Testing**
  * Local test setup now supports pulling prebuilt images or building images locally before loading them into KIND.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->