### PR TITLE
VPA updater: export admission controller status metric

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -200,10 +200,12 @@ func (u *updater) RunOnce(ctx context.Context) {
 		isValid, err := u.statusValidator.IsStatusValid(ctx, u.statusTimeout)
 		if err != nil {
 			klog.ErrorS(err, "Error getting Admission Controller status. Skipping update loop")
+			metrics_updater.RecordAdmissionControllerStatusInvalid("error")
 			return
 		}
 		if !isValid {
 			klog.V(0).InfoS("Admission Controller status is not valid. Skipping update loop", "timeout", u.statusTimeout)
+			metrics_updater.RecordAdmissionControllerStatusInvalid("invalid")
 			return
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -223,6 +223,13 @@ func TestRunOnce_Status(t *testing.T) {
 			expectedEvictionCount: 0,
 			expectedInPlacedCount: 0,
 		},
+		{
+			name:                  "with status check error",
+			statusValidator:       newFakeValidatorErr(errors.New("failed to get status")),
+			expectFetchCalls:      false,
+			expectedEvictionCount: 0,
+			expectedInPlacedCount: 0,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -415,14 +422,19 @@ func TestGetRateLimiter(t *testing.T) {
 
 type fakeValidator struct {
 	isValid bool
+	err     error
 }
 
 func newFakeValidator(isValid bool) status.Validator {
-	return &fakeValidator{isValid}
+	return &fakeValidator{isValid: isValid}
+}
+
+func newFakeValidatorErr(err error) status.Validator {
+	return &fakeValidator{err: err}
 }
 
 func (f *fakeValidator) IsStatusValid(ctx context.Context, statusTimeout time.Duration) (bool, error) {
-	return f.isValid, nil
+	return f.isValid, f.err
 }
 
 func TestRunOnceIgnoreNamespaceMatchingPods(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
@@ -142,6 +142,14 @@ var (
 
 	functionLatency = metrics.CreateExecutionTimeMetric(metricsNamespace,
 		"Time spent in various parts of VPA Updater main loop.")
+
+	admissionControllerStatusInvalidCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "admission_controller_status_invalid_total",
+			Help:      "Number of times Updater skipped its main loop because the Admission Controller status Lease was missing, stale or otherwise invalid.",
+		}, []string{"reason"},
+	)
 )
 
 // Register initializes all metrics for VPA Updater
@@ -160,6 +168,7 @@ func Register() {
 		vpasWithInPlaceUpdatedPodsCount,
 		failedInPlaceUpdateAttempts,
 		functionLatency,
+		admissionControllerStatusInvalidCount,
 	}
 	prometheus.MustRegister(collectors...)
 }
@@ -167,6 +176,11 @@ func Register() {
 // NewExecutionTimer provides a timer for Updater's RunOnce execution
 func NewExecutionTimer() *metrics.ExecutionTimer {
 	return metrics.NewExecutionTimer(functionLatency)
+}
+
+// RecordAdmissionControllerStatusInvalid increases the counter of skipped main loop iterations
+func RecordAdmissionControllerStatusInvalid(reason string) {
+	admissionControllerStatusInvalidCount.WithLabelValues(reason).Inc()
 }
 
 // newSizeBasedGauge provides a wrapper for counting items in a loop

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -261,6 +261,33 @@ func TestRecordFailedInPlaceUpdate(t *testing.T) {
 	}
 }
 
+func TestRecordAdmissionControllerStatusInvalid(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		reason string
+	}{
+		{
+			desc:   "error reason",
+			reason: "error",
+		},
+		{
+			desc:   "invalid reason",
+			reason: "invalid",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Cleanup(admissionControllerStatusInvalidCount.Reset)
+			RecordAdmissionControllerStatusInvalid(tc.reason)
+			val := testutil.ToFloat64(admissionControllerStatusInvalidCount.WithLabelValues(tc.reason))
+			if val != 1 {
+				t.Errorf("Unexpected value for admissionControllerStatusInvalidCount metric with label %s: got %v, want 1", tc.reason, val)
+			}
+		})
+	}
+}
+
 func TestUpdateModeAndSizeBasedGauge(t *testing.T) {
 	type addition struct {
 		vpaSize int


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If VPA updater is stuck taking action due to the admission controller status check, there is currently no way of detecting and alerting on this.

This PR fixes this by adding a corresponding metric so that we can alert on the following after 10 minutes:

```
increase(vpa_updater_admission_controller_status_invalid_total[5m]) > 0
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VPA updater metric added to expose admission controller status: vpa_updater_admission_controller_status_invalid_total
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Monitoring**
  * Added Prometheus metrics for updater iterations skipped due to invalid Admission Controller status.
  * Metrics distinguish between status-check errors and invalid status results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->