### PR TITLE
fix: correctly handling duplicate key/value taints on scaleway

### DIFF
--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider_test.go
@@ -85,7 +85,7 @@ func createTestPool(id string, autoscaling bool, size, minSize, maxSize int) sca
 		Labels: map[string]string{
 			"kubernetes.io/hostname": "node-1",
 		},
-		Taints:           map[string]string{},
+		NodeTaints:       []scalewaygo.Taint{},
 		NodePricePerHour: 0.05,
 		CreatedAt:        &now,
 		UpdatedAt:        &now,

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -19,9 +19,11 @@ package scaleway
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/api/validate/content"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/scaleway/scalewaygo"
 	"k8s.io/klog/v2"
@@ -313,6 +315,16 @@ func convertTaints(taints []scalewaygo.Taint) []apiv1.Taint {
 		case apiv1.TaintEffectPreferNoSchedule:
 			effect = apiv1.TaintEffectPreferNoSchedule
 		default:
+			klog.Warningf("ignoring taint %s with unsupported effect %s", taint.Key, taint.Effect)
+			continue
+		}
+
+		if errs := content.IsLabelKey(taint.Key); len(errs) > 0 {
+			klog.Warningf("ignoring taint with invalid key %s: %s", taint.Key, strings.Join(errs, "; "))
+			continue
+		}
+		if errs := content.IsLabelValue(taint.Value); len(errs) > 0 {
+			klog.Warningf("ignoring taint %s with invalid value %s: %s", taint.Key, taint.Value, strings.Join(errs, "; "))
 			continue
 		}
 

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -19,7 +19,6 @@ package scaleway
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -225,7 +224,7 @@ func (ng *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 	}
 
 	node.Status.Conditions = cloudprovider.BuildReadyConditions()
-	node.Spec.Taints = parseTaints(ng.pool.Taints)
+	node.Spec.Taints = convertTaints(ng.pool.NodeTaints)
 
 	nodeInfo := framework.NewNodeInfo(&node, nil, framework.NewPodInfo(cloudprovider.BuildKubeProxy(ng.pool.Name), nil))
 
@@ -300,28 +299,28 @@ func fromScwStatus(status scalewaygo.NodeStatus) *cloudprovider.InstanceStatus {
 	return st
 }
 
-func parseTaints(taints map[string]string) []apiv1.Taint {
+func convertTaints(taints []scalewaygo.Taint) []apiv1.Taint {
 	k8sTaints := make([]apiv1.Taint, 0, len(taints))
-	for key, valueEffect := range taints {
-		splittedValueEffect := strings.Split(valueEffect, ":")
-		var taint apiv1.Taint
 
-		switch apiv1.TaintEffect(splittedValueEffect[len(splittedValueEffect)-1]) {
+	for _, taint := range taints {
+		var effect apiv1.TaintEffect
+
+		switch apiv1.TaintEffect(taint.Effect) {
 		case apiv1.TaintEffectNoExecute:
-			taint.Effect = apiv1.TaintEffectNoExecute
+			effect = apiv1.TaintEffectNoExecute
 		case apiv1.TaintEffectNoSchedule:
-			taint.Effect = apiv1.TaintEffectNoSchedule
+			effect = apiv1.TaintEffectNoSchedule
 		case apiv1.TaintEffectPreferNoSchedule:
-			taint.Effect = apiv1.TaintEffectPreferNoSchedule
+			effect = apiv1.TaintEffectPreferNoSchedule
 		default:
 			continue
 		}
-		if len(splittedValueEffect) == 2 {
-			taint.Value = splittedValueEffect[0]
-		}
-		taint.Key = key
 
-		k8sTaints = append(k8sTaints, taint)
+		k8sTaints = append(k8sTaints, apiv1.Taint{
+			Key:    taint.Key,
+			Value:  taint.Value,
+			Effect: effect,
+		})
 	}
 
 	return k8sTaints

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
@@ -18,6 +18,7 @@ package scaleway
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -738,15 +739,33 @@ func TestConvertTaints(t *testing.T) {
 		assert.Empty(t, k8sTaints)
 	})
 
-	t.Run("value is kept as-is", func(t *testing.T) {
+	t.Run("valid keys and values are kept as-is", func(t *testing.T) {
 		taints := []scalewaygo.Taint{
-			{Key: "key1", Value: "value:with:colons", Effect: "NoSchedule"},
+			{Key: "example.com/key1", Value: "value.with-separators_1", Effect: "NoSchedule"},
 		}
 
 		k8sTaints := convertTaints(taints)
-		assert.Len(t, k8sTaints, 1)
-		assert.Equal(t, "key1", k8sTaints[0].Key)
-		assert.Equal(t, "value:with:colons", k8sTaints[0].Value)
+		require.Len(t, k8sTaints, 1)
+		assert.Equal(t, "example.com/key1", k8sTaints[0].Key)
+		assert.Equal(t, "value.with-separators_1", k8sTaints[0].Value)
+		assert.Equal(t, apiv1.TaintEffectNoSchedule, k8sTaints[0].Effect)
+	})
+
+	t.Run("taints with invalid key or value are skipped", func(t *testing.T) {
+		taints := []scalewaygo.Taint{
+			{Key: "key1", Value: "value:with:colons", Effect: "NoSchedule"},
+			{Key: "key with spaces", Value: "value1", Effect: "NoSchedule"},
+			{Key: "not/a/valid/key", Value: "value1", Effect: "NoSchedule"},
+			{Key: "", Value: "value1", Effect: "NoSchedule"},
+			{Key: strings.Repeat("k", 64), Value: "value1", Effect: "NoSchedule"},
+			{Key: "key2", Value: strings.Repeat("v", 64), Effect: "NoSchedule"},
+			{Key: "key3", Value: "value3", Effect: "NoSchedule"},
+		}
+
+		k8sTaints := convertTaints(taints)
+		require.Len(t, k8sTaints, 1)
+		assert.Equal(t, "key3", k8sTaints[0].Key)
+		assert.Equal(t, "value3", k8sTaints[0].Value)
 		assert.Equal(t, apiv1.TaintEffectNoSchedule, k8sTaints[0].Effect)
 	})
 

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
@@ -507,9 +507,9 @@ func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
 				"kubernetes.io/hostname":           "test-node",
 				"node.kubernetes.io/instance-type": "DEV1-M",
 			},
-			Taints: map[string]string{
-				"key1": "value1:NoSchedule",
-				"key2": "NoExecute",
+			NodeTaints: []scalewaygo.Taint{
+				{Key: "key1", Value: "value1", Effect: "NoSchedule"},
+				{Key: "key2", Effect: "NoExecute"},
 			},
 		},
 	}
@@ -691,17 +691,17 @@ func TestFromScwStatus(t *testing.T) {
 	}
 }
 
-func TestParseTaints(t *testing.T) {
-	t.Run("parse various taint formats", func(t *testing.T) {
-		taints := map[string]string{
-			"key1": "value1:NoSchedule",
-			"key2": "value2:NoExecute",
-			"key3": "value3:PreferNoSchedule",
-			"key4": "NoSchedule",
-			"key5": "invalid:InvalidEffect",
+func TestConvertTaints(t *testing.T) {
+	t.Run("convert various taint effects", func(t *testing.T) {
+		taints := []scalewaygo.Taint{
+			{Key: "key1", Value: "value1", Effect: "NoSchedule"},
+			{Key: "key2", Value: "value2", Effect: "NoExecute"},
+			{Key: "key3", Value: "value3", Effect: "PreferNoSchedule"},
+			{Key: "key4", Effect: "NoSchedule"},
+			{Key: "key5", Value: "invalid", Effect: "InvalidEffect"},
 		}
 
-		k8sTaints := parseTaints(taints)
+		k8sTaints := convertTaints(taints)
 		assert.Len(t, k8sTaints, 4) // key5 should be skipped
 
 		taintMap := make(map[string]apiv1.Taint)
@@ -731,22 +731,34 @@ func TestParseTaints(t *testing.T) {
 	})
 
 	t.Run("empty taints", func(t *testing.T) {
-		taints := map[string]string{}
-		k8sTaints := parseTaints(taints)
+		k8sTaints := convertTaints(nil)
+		assert.Empty(t, k8sTaints)
+
+		k8sTaints = convertTaints([]scalewaygo.Taint{})
 		assert.Empty(t, k8sTaints)
 	})
 
-	t.Run("taint with multiple colons has no value", func(t *testing.T) {
-		// parseTaints only extracts value if there are exactly 2 parts (value:Effect)
-		// With multiple colons, the value is not extracted
-		taints := map[string]string{
-			"key1": "value:with:colons:NoSchedule",
+	t.Run("value is kept as-is", func(t *testing.T) {
+		taints := []scalewaygo.Taint{
+			{Key: "key1", Value: "value:with:colons", Effect: "NoSchedule"},
 		}
 
-		k8sTaints := parseTaints(taints)
+		k8sTaints := convertTaints(taints)
 		assert.Len(t, k8sTaints, 1)
 		assert.Equal(t, "key1", k8sTaints[0].Key)
-		assert.Equal(t, "", k8sTaints[0].Value) // No value extracted for multiple colons
+		assert.Equal(t, "value:with:colons", k8sTaints[0].Value)
 		assert.Equal(t, apiv1.TaintEffectNoSchedule, k8sTaints[0].Effect)
+	})
+
+	t.Run("duplicated keys are all converted", func(t *testing.T) {
+		taints := []scalewaygo.Taint{
+			{Key: "key1", Value: "value1", Effect: "NoSchedule"},
+			{Key: "key1", Value: "value1", Effect: "NoExecute"},
+		}
+
+		k8sTaints := convertTaints(taints)
+		require.Len(t, k8sTaints, 2)
+		assert.Equal(t, apiv1.TaintEffectNoSchedule, k8sTaints[0].Effect)
+		assert.Equal(t, apiv1.TaintEffectNoExecute, k8sTaints[1].Effect)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/scaleway/scalewaygo/scaleway_kapsule_api.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scalewaygo/scaleway_kapsule_api.go
@@ -276,6 +276,16 @@ const (
 	PoolStatusUpgrading = PoolStatus("upgrading")
 )
 
+// Taint is the abstraction used to represent a taint on a node
+type Taint struct {
+	// Key: the key of the taint
+	Key string `json:"key"`
+	// Value: the value of the taint
+	Value string `json:"value"`
+	// Effect: the effect of the taint
+	Effect string `json:"effect"`
+}
+
 // Pool is the abstraction used to gather nodes with the same specs
 type Pool struct {
 	// ID: the ID of the pool
@@ -308,8 +318,8 @@ type Pool struct {
 	Allocatable map[string]int64 `json:"allocatable"`
 	// Labels: labels applied to each node of the pool
 	Labels map[string]string `json:"labels"`
-	// Taints: taints applied to each node of the pool
-	Taints map[string]string `json:"taints"`
+	// NodeTaints: taints applied to each node of the pool
+	NodeTaints []Taint `json:"node_taints"`
 	// CreatedAt: the date at which the pool was created
 	CreatedAt *time.Time `json:"created_at"`
 	// UpdatedAt: the date at which the pool was last updated


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Scaleway provider had an issue overriding taints with the same key/value but different effects. A new field is now returned by Scaleway API with a correct list of taints and the previous one is still returned so this change is retro-compatible. This PR update the Scaleway provider to use the new field.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
The issue was never raised by a user of the provider, so I don't think it's necessary to add it to the changelog.
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Scaleway node taint handling to support key, value, and effect details.
  * Preserved valid taints, including values containing colons, while filtering unsupported effects and invalid keys or values.
  * Improved compatibility with the current Scaleway pool configuration format.

* **Tests**
  * Expanded coverage for empty taints, duplicate keys, colon-containing values, invalid keys and values, and unsupported effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->