### PR TITLE
feat(aws): batch ASG instance termination

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -298,6 +298,7 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 		return fmt.Errorf("can't delete instance %s, which is not part of an ASG", instances[0].Name)
 	}
 
+	instancesToTerminate := make([]string, 0, len(instances))
 	for _, instance := range instances {
 		asg := m.findForInstance(*instance)
 
@@ -366,21 +367,34 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 			continue
 		}
 
+		instancesToTerminate = append(instancesToTerminate, instance.Name)
+	}
+
+	for start := 0; start < len(instancesToTerminate); start += 100 {
+		end := start + 100
+		if end > len(instancesToTerminate) {
+			end = len(instancesToTerminate)
+		}
+		batch := instancesToTerminate[start:end]
 		params := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
-			InstanceId:                     aws.String(instance.Name),
 			ShouldDecrementDesiredCapacity: aws.Bool(true),
 		}
-		start := time.Now()
-		resp, err := m.awsService.TerminateInstanceInAutoScalingGroup(context.Background(), params)
-		observeAWSRequest("TerminateInstanceInAutoScalingGroup", err, start)
+		if len(batch) == 1 {
+			params.InstanceId = aws.String(batch[0])
+		} else {
+			params.AutoScalingGroupName = aws.String(commonAsg.Name)
+			params.InstanceIds = batch
+		}
+		requestStart := time.Now()
+		_, err := m.awsService.TerminateInstanceInAutoScalingGroup(context.Background(), params)
+		observeAWSRequest("TerminateInstanceInAutoScalingGroup", err, requestStart)
 		if err != nil {
 			return err
 		}
-		klog.V(4).Infof("Terminated instance %s in autoscaling group: %s", instance.Name, aws.ToString(resp.Activity.Description))
+		klog.V(4).Infof("Terminated %d instance(s) in autoscaling group %s", len(batch), commonAsg.Name)
 
 		// Proactively decrement the size so autoscaler makes better decisions
-		commonAsg.curSize--
-
+		commonAsg.curSize -= len(batch)
 	}
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -838,17 +838,6 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 		// only setting 2 instances to be terminated out of 3 active instances
 		if i < 2 {
 			nodes = append(nodes, node)
-			a.On("TerminateInstanceInAutoScalingGroup",
-				mock.Anything,
-				&autoscaling.TerminateInstanceInAutoScalingGroupInput{
-					InstanceId:                     aws.String(fmt.Sprintf("i-000%d", i)),
-					ShouldDecrementDesiredCapacity: aws.Bool(true),
-				},
-			).Return(
-				&autoscaling.TerminateInstanceInAutoScalingGroupOutput{
-					Activity: &autoscalingtypes.Activity{Description: aws.String("Deleted instance")},
-				}, nil,
-			)
 		}
 		awsInstanceRef := AwsInstanceRef{
 			ProviderID: providerId,
@@ -857,6 +846,14 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 		awsInstanceRefs = append(awsInstanceRefs, awsInstanceRef)
 		instanceToAsg[awsInstanceRef] = commonAsg
 	}
+	a.On("TerminateInstanceInAutoScalingGroup",
+		mock.Anything,
+		&autoscaling.TerminateInstanceInAutoScalingGroupInput{
+			AutoScalingGroupName:           aws.String("test-asg"),
+			InstanceIds:                    []string{"i-0000", "i-0001"},
+			ShouldDecrementDesiredCapacity: aws.Bool(true),
+		},
+	).Return(&autoscaling.TerminateInstanceInAutoScalingGroupOutput{}, nil)
 
 	// modifying provider to bring disparity between ASG and cache
 	provider.awsManager.asgCache.asgToInstances[AwsRef{Name: "test-asg"}] = awsInstanceRefs
@@ -869,6 +866,6 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 2)
 
 	// This ensures only 2 instances are terminated which are mocked in this unit test
-	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 2)
+	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 1)
 
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -459,6 +459,53 @@ func TestDeleteNodes(t *testing.T) {
 	assert.Equal(t, 1, newSize)
 }
 
+func TestDeleteInstancesBatchBoundaries(t *testing.T) {
+	for _, count := range []int{1, 100, 101} {
+		t.Run(fmt.Sprintf("%d instances", count), func(t *testing.T) {
+			a := &autoScalingMock{}
+			awsService := awsWrapper{a, nil, nil}
+			group := &asg{AwsRef: AwsRef{Name: "test-asg"}, curSize: count}
+			cache := &asgCache{
+				awsService:        &awsService,
+				instanceToAsg:     make(map[AwsInstanceRef]*asg, count),
+				instanceLifecycle: make(map[AwsInstanceRef]autoscalingtypes.LifecycleState, count),
+			}
+			instances := make([]*AwsInstanceRef, count)
+			instanceIDs := make([]string, count)
+			for i := range instances {
+				id := fmt.Sprintf("i-%03d", i)
+				ref := &AwsInstanceRef{Name: id}
+				instances[i] = ref
+				instanceIDs[i] = id
+				cache.instanceToAsg[*ref] = group
+				cache.instanceLifecycle[*ref] = autoscalingtypes.LifecycleStateInService
+			}
+
+			for start := 0; start < count; start += 100 {
+				end := start + 100
+				if end > count {
+					end = count
+				}
+				input := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+					ShouldDecrementDesiredCapacity: aws.Bool(true),
+				}
+				if end-start == 1 {
+					input.InstanceId = aws.String(instanceIDs[start])
+				} else {
+					input.AutoScalingGroupName = aws.String(group.Name)
+					input.InstanceIds = instanceIDs[start:end]
+				}
+				a.On("TerminateInstanceInAutoScalingGroup", mock.Anything, input).
+					Return(&autoscaling.TerminateInstanceInAutoScalingGroupOutput{}, nil)
+			}
+
+			assert.NoError(t, cache.DeleteInstances(instances))
+			assert.Equal(t, 0, group.curSize)
+			a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", (count+99)/100)
+		})
+	}
+}
+
 func TestDeleteNodesTerminatingInstances(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -16,13 +16,14 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/skewer/v2 v2.0.1
-	github.com/aws/aws-sdk-go-v2 v1.40.1
+	github.com/aws/aws-sdk-go-v2 v1.43.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.3
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.15
-	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.62.2
+	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.72.2
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.275.1
 	github.com/aws/aws-sdk-go-v2/service/eks v1.76.1
-	github.com/aws/smithy-go v1.24.0
+	github.com/aws/smithy-go v1.27.8
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/digitalocean/godo v1.169.0
 	github.com/golang/protobuf v1.5.4
@@ -96,8 +97,8 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.3 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.15 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.15 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.38 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.38 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.29.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.45.2 // indirect

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -102,6 +102,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go-v2 v1.40.1 h1:difXb4maDZkRH0x//Qkwcfpdg1XQVXEAEs2DdXldFFc=
 github.com/aws/aws-sdk-go-v2 v1.40.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
+github.com/aws/aws-sdk-go-v2 v1.43.7 h1:msCzvkeYJA9ehbV8mRRmkZLo/zJg/+yDVLNtflg83hQ=
+github.com/aws/aws-sdk-go-v2 v1.43.7/go.mod h1:tXpPM+v0D1lndmga+HqqLDIzUFJlEeR21aspVklHF00=
 github.com/aws/aws-sdk-go-v2/config v1.32.3 h1:cpz7H2uMNTDa0h/5CYL5dLUEzPSLo2g0NkbxTRJtSSU=
 github.com/aws/aws-sdk-go-v2/config v1.32.3/go.mod h1:srtPKaJJe3McW6T/+GMBZyIPc+SeqJsNPJsd4mOYZ6s=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.3 h1:01Ym72hK43hjwDeJUfi1l2oYLXBAOR8gNSZNmXmvuas=
@@ -110,12 +112,18 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.15 h1:utxLraaifrSBkeyII9mIbV
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.15/go.mod h1:hW6zjYUDQwfz3icf4g2O41PHi77u10oAzJ84iSzR/lo=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.15 h1:Y5YXgygXwDI5P4RkteB5yF7v35neH7LfJKBG+hzIons=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.15/go.mod h1:K+/1EpG42dFSY7CBj+Fruzm8PsCGWTXJ3jdeJ659oGQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.38 h1:MBMg0zJ6i4TkAJ0dVFLKKn2cOkY6FkicmUDM67BRr6g=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.38/go.mod h1:9MWuJbyiUyj6eA7W1/zm1zuePDPSB3g+xcgRQeMWsXc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.15 h1:AvltKnW9ewxX2hFmQS0FyJH93aSvJVUEFvXfU+HWtSE=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.15/go.mod h1:3I4oCdZdmgrREhU74qS1dK9yZ62yumob+58AbFR4cQA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.38 h1:lHm4jPf3k1Lz5ZWc+Vcn3MKVwym+26kWCba9FkJ4f0Y=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.38/go.mod h1:Rn+P2XR+FbyZzjmWKjg/KUZNxmGfr5oZwh5jQiE+CzI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.62.2 h1:4vkR4XUVIwSVT2fvvyu8AILWhVyVjOmhoh9ypmaXJvI=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.62.2/go.mod h1:Cgjwf3SCxOBGVpExtoRyLUCASG+EaIpSSm6NH96/SuI=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.72.2 h1:QRj6kv7NZ33+Va/bGzDNd+WbCuocF5wQLx1av7Oj9Xs=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.72.2/go.mod h1:7/hlAWgVGLsdlxD+xwD3/S/19CPE6hYlbmtAtjWQy4I=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.275.1 h1:nEpHPUp2UKzxiLBoaLLTnIrWBmb1OL0vf8KHDHjNqcQ=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.275.1/go.mod h1:6xabBAflTTz4OO5f/P4QJrjzZ0WTYjRka+ZWXFqWw8U=
 github.com/aws/aws-sdk-go-v2/service/eks v1.76.1 h1:UMBn4P/diOhCX0S8Ctflbr2EeDG4ijn6XWRsMOElGZg=
@@ -140,6 +148,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.3 h1:tzMkjh0yTChUqJDgGkcDdxvZDSrJ
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.3/go.mod h1:T270C0R5sZNLbWUe8ueiAF42XSZxxPocTaGSgs5c/60=
 github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
 github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.27.8 h1:FR0dxZfIlV7Z8eh2iHfIofdunw382XsDV3Mxt9nUvRY=
+github.com/aws/smithy-go v1.27.8/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=


### PR DESCRIPTION
Implements AWS EC2 Auto Scaling batch instance termination for Cluster Autoscaler scale-down.

AWS announcement: https://aws.amazon.com/about-aws/whats-new/2026/08/amazon-ec2-auto-scaling-batch-termination/

Changes:
- Batch eligible instance IDs in groups of up to 100.
- Preserve the existing single-instance request path.
- Preserve lifecycle filtering and proactive size updates.
- Update AWS SDK and tests.

Fixes #10186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved AWS instance termination by processing eligible instances in batches, reducing the number of termination requests.
  * Updated cached Auto Scaling Group capacity accurately after batched terminations.

* **Maintenance**
  * Updated AWS SDK dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->