### PR TITLE
feat: allow the vpa log levels to be set by helm values

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -74,7 +74,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-            - --v=4
             - --stderrthreshold=info
           {{- if .Values.admissionController.registerWebhook }}
             - --register-webhook=true

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -59,7 +59,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-            - --v=4
             - --stderrthreshold=info
             {{- /* Smart auto-enable: if enabled is null, auto-enable when replicas > 1 */ -}}
             {{- $leaderElectionEnabled := .Values.recommender.leaderElection.enabled }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -64,7 +64,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           args:
-            - --v=4
             - --stderrthreshold=info
             {{- if eq (include "vertical-pod-autoscaler.updater.leaderElectionEnabled" .) "true" }}
             - --leader-elect=true


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allows the log levels to be changed via helm values (extraArgs) instead of hardcoding this setting into the template.  The default vpa log level is 4 ([docs](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/flags.md)) so removing the hardcoded default from the chart shouldn't change anything for existing deployments.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
