### PR TITLE
clusterapi: set resource slice count for DRA scale-from-zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -403,7 +403,8 @@ func (r *unstructuredScalableResource) InstanceResourceSlices(nodeName string) (
 				Driver:   driver,
 				NodeName: &nodeName,
 				Pool: resourceapi.ResourcePool{
-					Name: nodeName,
+					Name:               nodeName,
+					ResourceSliceCount: 1,
 				},
 			},
 		}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -402,6 +402,7 @@ func (r *unstructuredScalableResource) InstanceResourceSlices(nodeName string) (
 			Spec: resourceapi.ResourceSliceSpec{
 				Driver:   driver,
 				NodeName: &nodeName,
+				// TODO: Derive ResourceSliceCount from the number of generated ResourceSlices instead of hard-coding it.
 				Pool: resourceapi.ResourcePool{
 					Name:               nodeName,
 					ResourceSliceCount: 1,

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -30,6 +30,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/dynamic-resource-allocation/cel"
+	"k8s.io/dynamic-resource-allocation/structured"
 	"k8s.io/utils/ptr"
 )
 
@@ -449,6 +451,113 @@ func TestAnnotations(t *testing.T) {
 			Build()
 		test(t, testConfig, testConfig.machineDeployment)
 	})
+}
+
+// fakeDeviceClassLister is the minimal structured.DeviceClassLister needed to
+// drive the DRA allocator in TestInstanceResourceSlicesAreAllocatable.
+type fakeDeviceClassLister struct {
+	classes []*resourceapi.DeviceClass
+}
+
+func (f fakeDeviceClassLister) List() ([]*resourceapi.DeviceClass, error) {
+	return f.classes, nil
+}
+
+func (f fakeDeviceClassLister) Get(className string) (*resourceapi.DeviceClass, error) {
+	for _, class := range f.classes {
+		if class.Name == className {
+			return class, nil
+		}
+	}
+	return nil, fmt.Errorf("device class %q not found", className)
+}
+
+// TestInstanceResourceSlicesAreAllocatable is a regression test for #10199.
+// It feeds the ResourceSlice(s) returned by InstanceResourceSlices into the
+// real DRA structured allocator (k8s.io/dynamic-resource-allocation/structured)
+// and asserts that a matching claim can actually be allocated from them.
+//
+// Before the #10199 fix, ResourceSliceCount was left at its zero value, so the
+// allocator always treated the synthetic pool as incomplete and refused to
+// allocate from it, no matter how many devices it advertised. Asserting
+// ResourceSliceCount == 1 alone does not catch that: this test additionally
+// exercises the same allocator logic the scheduler relies on.
+func TestInstanceResourceSlicesAreAllocatable(t *testing.T) {
+	testNodeName := "test-node"
+	draDriver := "test-driver"
+	deviceClassName := "test-class"
+
+	annotations := map[string]string{
+		gpuCountKey:  "1",
+		draDriverKey: draDriver,
+	}
+
+	controller := NewTestMachineController(t)
+	defer controller.Stop()
+	testConfig := NewTestConfigBuilder().
+		ForMachineSet().
+		WithNodeCount(1).
+		WithAnnotations(annotations).
+		Build()
+	controller.AddTestConfigs(testConfig)
+
+	sr, err := newUnstructuredScalableResource(controller.machineController, testConfig.machineSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	slices, err := sr.InstanceResourceSlices(testNodeName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slices) != 1 {
+		t.Fatalf("expected exactly one generated ResourceSlice, got %d", len(slices))
+	}
+
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: testNodeName}}
+	class := &resourceapi.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: deviceClassName}}
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "test-claim-uid"},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{
+				Requests: []resourceapi.DeviceRequest{
+					{
+						Name: "gpu",
+						Exactly: &resourceapi.ExactDeviceRequest{
+							DeviceClassName: deviceClassName,
+							AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+							Count:           1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	allocator, err := structured.NewAllocator(
+		context.Background(),
+		structured.Features{},
+		structured.AllocatedState{},
+		fakeDeviceClassLister{classes: []*resourceapi.DeviceClass{class}},
+		slices,
+		cel.NewCache(1, cel.Features{}),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct DRA allocator: %v", err)
+	}
+
+	results, err := allocator.Allocate(context.Background(), node, []*resourceapi.ResourceClaim{claim})
+	if err != nil {
+		t.Fatalf("DRA allocator returned an unexpected error: %v", err)
+	}
+
+	// A nil/empty result means the allocator could not satisfy the claim. That is
+	// exactly what happens when the synthetic ResourcePool advertises the wrong
+	// ResourceSliceCount: the allocator treats the pool as incomplete and refuses
+	// to allocate from it, regardless of how many matching devices it contains.
+	if len(results) == 0 {
+		t.Fatal("DRA allocator could not allocate a device from the ClusterAPI-generated ResourceSlice; the synthetic pool is being treated as incomplete (regression of #10199)")
+	}
 }
 
 func TestCanScaleFromZero(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -29,9 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/dynamic-resource-allocation/cel"
 	"k8s.io/dynamic-resource-allocation/structured"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
+	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/utils/ptr"
 )
 
@@ -472,6 +475,9 @@ func (f fakeDeviceClassLister) Get(className string) (*resourceapi.DeviceClass, 
 	return nil, fmt.Errorf("device class %q not found", className)
 }
 
+// TODO: Move this allocator validation to a shared test helper or centralized
+// template validation once one exists, rather than duplicating it across providers.
+// See #7799.
 // TestInstanceResourceSlicesAreAllocatable is a regression test for #10199.
 // It feeds the ResourceSlice(s) returned by InstanceResourceSlices into the
 // real DRA structured allocator (k8s.io/dynamic-resource-allocation/structured)
@@ -534,9 +540,13 @@ func TestInstanceResourceSlicesAreAllocatable(t *testing.T) {
 		},
 	}
 
+	features := dynamicresources.AllocatorFeatures(
+		plfeature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate),
+	)
+
 	allocator, err := structured.NewAllocator(
 		context.Background(),
-		structured.Features{},
+		features,
 		structured.AllocatedState{},
 		fakeDeviceClassLister{classes: []*resourceapi.DeviceClass{class}},
 		slices,

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -348,7 +348,8 @@ func TestAnnotations(t *testing.T) {
 			Driver:   draDriver,
 			NodeName: &testNodeName,
 			Pool: resourceapi.ResourcePool{
-				Name: testNodeName,
+				Name:               testNodeName,
+				ResourceSliceCount: 1,
 			},
 			Devices: []resourceapi.Device{
 				{

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -54,6 +54,7 @@ require (
 	k8s.io/cloud-provider-aws v1.35.1
 	k8s.io/cloud-provider-gcp/providers v0.28.2
 	k8s.io/component-base v0.37.0-rc.1
+	k8s.io/dynamic-resource-allocation v0.37.0-rc.1
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubelet v0.37.0-rc.1
 	k8s.io/kubernetes v1.37.0-rc.1
@@ -237,7 +238,6 @@ require (
 	k8s.io/cri-client v0.0.0 // indirect
 	k8s.io/cri-streaming v0.0.0 // indirect
 	k8s.io/csi-translation-lib v0.27.0 // indirect
-	k8s.io/dynamic-resource-allocation v0.37.0-rc.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20260408192533-25e2208e0dc3 // indirect
 	k8s.io/kms v0.37.0-rc.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Cluster API scale-from-zero generates a synthetic `ResourceSlice` for node
groups configured with DRA capacity annotations.

The generated `ResourcePool` currently leaves `ResourceSliceCount` at its
zero value. The DRA allocator treats that pool as incomplete, so its devices
are ignored and DRA workloads cannot trigger scale-from-zero.

Set `ResourceSliceCount` to 1, matching the single `ResourceSlice` generated
for the synthetic node.

The existing `TestAnnotations` coverage is updated to verify the generated
resource slice contains the correct pool metadata.

#### Which issue(s) this PR fixes:

Fixes #10199

#### Special notes for your reviewer:

Verified that the updated test fails when the production change is removed:
the expected `ResourceSliceCount` is 1 while the generated value remains 0.

Validation:

`go test -race -vet=all ./cloudprovider/clusterapi/...`

The separate MIG device-attribute limitation mentioned in #10199 is outside
the scope of this change.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Cluster API DRA scale-from-zero by generating ResourceSlices with a valid resource slice count.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPU resource pools now correctly report their resource slice count, allowing matching claims to be allocated successfully.
  * Improved compatibility with dynamic resource allocation for GPU workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->