### PR TITLE
feat: add topologySpreadConstraints to the VPA helm chart

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -174,6 +174,7 @@ helm upgrade <release-name> <chart> \
 | admissionController.tls.key | string | `""` |  |
 | admissionController.tls.secretName | string | `"vpa-tls-certs"` |  |
 | admissionController.tolerations | list | `[]` |  |
+| admissionController.topologySpreadConstraints | list | `[]` | Topology spread constraints for scheduling the Admission Controller, used to spread replicas across failure domains such as zones. |
 | admissionController.volumeMounts[0].mountPath | string | `"/etc/tls-certs"` |  |
 | admissionController.volumeMounts[0].name | string | `"tls-certs"` |  |
 | admissionController.volumeMounts[0].readOnly | bool | `true` |  |
@@ -228,6 +229,7 @@ helm upgrade <release-name> <chart> \
 | recommender.serviceAccount.create | bool | `true` |  |
 | recommender.serviceAccount.labels | object | `{}` |  |
 | recommender.tolerations | list | `[]` |  |
+| recommender.topologySpreadConstraints | list | `[]` | Topology spread constraints for scheduling the Recommender, used to spread replicas across failure domains such as zones. |
 | updater.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].key | string | `"app.kubernetes.io/component"` |  |
 | updater.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].operator | string | `"In"` |  |
 | updater.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0] | string | `"updater"` |  |
@@ -260,3 +262,4 @@ helm upgrade <release-name> <chart> \
 | updater.serviceAccount.create | bool | `true` |  |
 | updater.serviceAccount.labels | object | `{}` |  |
 | updater.tolerations | list | `[]` |  |
+| updater.topologySpreadConstraints | list | `[]` | Topology spread constraints for scheduling the Updater, used to spread replicas across failure domains such as zones. |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -55,6 +55,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.admissionController.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.admissionController.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -118,4 +118,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.recommender.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -54,6 +54,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.updater.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: updater
           image: {{ include "vertical-pod-autoscaler.updater.image" . }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -103,6 +103,9 @@ admissionController:
   # List of node taints to tolerate.
   tolerations: []
 
+  # admissionController.topologySpreadConstraints -- Topology spread constraints for scheduling the Admission Controller, used to spread replicas across failure domains such as zones.
+  topologySpreadConstraints: []
+
   # admissionController.registerWebhook -- Whether to register webhook via the application itself or via Helm. Set to false when using Helm-managed webhook. Security issue: granting delete on mutatingwebhookconfigurations is a potential security risk as it allows the admission controller to remove any webhook configurations.
   registerWebhook: false
 
@@ -302,6 +305,9 @@ recommender:
   # Tolerations for scheduling the Recommender.
   tolerations: []
 
+  # recommender.topologySpreadConstraints -- Topology spread constraints for scheduling the Recommender, used to spread replicas across failure domains such as zones.
+  topologySpreadConstraints: []
+
   # Leader election configuration for the Recommender.
   # When running multiple replicas, leader election ensures only one instance is actively processing.
   leaderElection:
@@ -392,6 +398,9 @@ updater:
 
   # Tolerations for scheduling the Updater.
   tolerations: []
+
+  # updater.topologySpreadConstraints -- Topology spread constraints for scheduling the Updater, used to spread replicas across failure domains such as zones.
+  topologySpreadConstraints: []
 
   # Leader election configuration for the Updater.
   # When running multiple replicas, leader election ensures only one instance is actively processing.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a `topologySpreadConstraints` value to the `admissionController`, `recommender` and `updater` components of the VPA Helm chart.

The chart already exposes `nodeSelector`, `affinity` and `tolerations` on all three components, but there is currently no way to set `topologySpreadConstraints`. That leaves pod anti-affinity as the only way to spread replicas across failure domains, and anti-affinity is a poor substitute for it:

- **It is binary rather than a gradient.** `requiredDuringSchedulingIgnoredDuringExecution` with `topologyKey: topology.kubernetes.io/zone` means "at most one pod per zone". There is no way to express "roughly even", so as soon as `replicas` exceeds the number of zones the surplus pods are permanently unschedulable. `maxSkew` handles this natively.
- **It cannot express `minDomains`**, i.e. "use at least N zones" rather than merely satisfying skew within one.
- **It cannot express `matchLabelKeys`**, so the skew calculation cannot be scoped to the current ReplicaSet revision during a rolling update.
- **It has no equivalent of `nodeAffinityPolicy` / `nodeTaintsPolicy`**, which matter when the components are pinned to a tainted node pool.
- Inter-pod affinity is also [documented as expensive](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) at scale, whereas spread constraints are counted per domain.

This is relevant for anyone running the VPA components with `replicas > 1` for availability — which the chart already supports, and which the recently added leader election makes practical for the recommender and updater.

#### Implementation

The new value is rendered with the same `{{- with }}` / `toYaml` pattern already used for `nodeSelector`, `affinity` and `tolerations` in each deployment template, and is placed directly after the `tolerations` block in all three.

It defaults to `[]` and is only emitted when set, so **rendered output is unchanged for existing users**. Verified with `helm template` against default values: zero occurrences of `topologySpreadConstraints`.

Documented via helm-docs comments so the generated README table carries a description; `README.md` regenerated with `helm-docs` (the only diff is the three new rows).

#### Testing

- `helm lint` passes with default values and with spread constraints set.
- `helm template` with constraints on all three components renders them into the correct pod specs, including `minDomains` and both `DoNotSchedule` and `ScheduleAnyway`.
- Rendered manifests validate with `kubectl apply --dry-run=client`.
- `helm template` with default values produces no `topologySpreadConstraints` keys.

#### Which issue(s) this PR fixes:

None — I did not find an existing issue for this. Happy to open one first if the maintainers prefer that flow.

#### Special notes for your reviewer:

`Chart.yaml` is intentionally left untouched — the chart version bump appears to be handled separately by maintainers (e.g. `chart(vpa): bump chart version to 0.10.0 to publish appVersion 1.7.0`). Glad to add it here if you'd rather it ride along.

#### Does this PR introduce a user-facing change?

```release-note
Added `topologySpreadConstraints` support to the admission controller, recommender and updater in the vertical-pod-autoscaler Helm chart.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Pod Topology Spread Constraints]: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional topology spread constraints for the admission controller, recommender, and updater components.
  * Configure replica distribution across failure domains, such as availability zones, through the chart values.

* **Documentation**
  * Documented the new configuration options and their default empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->