### PR TITLE
fix: add missing labels to updater leader-locking RoleBinding

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-rolebinding.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-rolebinding.yaml
@@ -5,6 +5,8 @@ kind: RoleBinding
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}-leader-locking-binding
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`updater-rolebinding.yaml` is the only object in the chart with no `labels` block, so it carries neither the standard `app.kubernetes.io` labels nor anything set via `commonLabels`.

Rendering with a common label set shows 43 of 44 objects picking it up, with this RoleBinding the sole exception:

```console
$ helm template vpa . --set commonLabels.myorg=test
43/44 objects carry commonLabels
MISSING: RoleBinding/vpa-vertical-pod-autoscaler-updater-leader-locking-binding
```

Its sibling `updater-role.yaml` already includes the updater labels helper; this applies the same include. Coverage becomes 44/44.

#### Which issue(s) this PR fixes:

None filed. Found while reviewing the chart against the `WARNING: This chart is currently under development and is not ready for production use.` notice in the README.

#### Special notes for your reviewer:

Same class of gap as b03e61af1 (`fix: add missing labels to vpa updater cluster roles in the helm chart`) — that sweep missed this one object.

`Chart.yaml` is intentionally untouched — version bumps appear to be separate maintainer commits (e.g. `chart(vpa): bump chart version to 0.10.0 to publish appVersion 1.7.0`).

#### Does this PR introduce a user-facing change?

```release-note
Fixed the updater leader-locking RoleBinding not receiving chart labels or commonLabels.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added updater labels to the leader-election role binding for improved resource identification and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->