### PR TITLE
fix: certgen jobs reference an undefined priorityClassName value

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -120,6 +120,7 @@ helm upgrade <release-name> <chart> \
 | admissionController.certGen.image.tag | string | `"v20231011-8b53cabe0"` | An image tag for the admissionController.certGen.image.repository image. |
 | admissionController.certGen.nodeSelector | object | `{}` |  |
 | admissionController.certGen.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The securityContext block for the certgen pod(s) |
+| admissionController.certGen.priorityClassName | string | `""` | Priority class name for the certgen job pods. These jobs gate the release as pre-install/pre-upgrade and post-install/post-upgrade hooks, so a priority class can help them schedule on a busy cluster. |
 | admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
 | admissionController.certGen.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The securityContext block for the certgen container(s) |
 | admissionController.certGen.tolerations | list | `[]` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certgen-patch.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certgen-patch.yaml
@@ -23,7 +23,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.priorityClassName }}
+      {{- with .Values.admissionController.certGen.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
       containers:

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certgen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certgen.yaml
@@ -24,7 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.priorityClassName }}
+      {{- with .Values.admissionController.certGen.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
       containers:

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -138,6 +138,8 @@ admissionController:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    # admissionController.certGen.priorityClassName -- Priority class name for the certgen job pods. These jobs gate the release as pre-install/pre-upgrade and post-install/post-upgrade hooks, so a priority class can help them schedule on a busy cluster.
+    priorityClassName: ""
 
   certManager:
     # admissionController.certManager.enabled -- If true, cert-manager manages the webhook certificate lifecycle.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Both certgen jobs guard on `.Values.priorityClassName`, but the chart has no top-level `priorityClassName` value and never had one, so the `with` block never fires and the jobs can never be given a priority class.

Every other scheduling field on these jobs correctly reads from `.Values.admissionController.certGen.*` (`nodeSelector`, `affinity`, `tolerations`), which makes this look like an oversight rather than a deliberate chart-wide setting.

This points the reference at `admissionController.certGen.priorityClassName` and adds the value, defaulting to `""` so rendered output is unchanged unless set.

#### Which issue(s) this PR fixes:

None filed. Found while reviewing the chart against the `WARNING: This chart is currently under development and is not ready for production use.` notice in the README.

#### Special notes for your reviewer:

These jobs run as `pre-install`/`pre-upgrade` and `post-install`/`post-upgrade` hooks and gate the release, so being able to prioritise them matters on a contended cluster. The ingress-nginx chart exposes the same knob for the same job.

`Chart.yaml` is intentionally untouched — version bumps appear to be separate maintainer commits.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the certgen jobs referencing an undefined priorityClassName value; added admissionController.certGen.priorityClassName.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated configuration option for setting the priority class of admission controller certificate-generation job pods.
  * Documented the new option, which defaults to no priority class and applies to certificate-generation release hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->