### PR TITLE
docs: make the cert-manager example render

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -53,6 +53,8 @@ Important: You are responsible for creating the TLS secret before or after insta
 If the secret is created after the Helm install, you must restart the admission controller pod to trigger webhook registration.
 
 ### cert-manager managed
+
+Using an existing `Issuer` or `ClusterIssuer`:
 ```yaml
 admissionController:
   registerWebhook: false
@@ -60,6 +62,21 @@ admissionController:
     enabled: false
   certManager:
     enabled: true
+    issuerRef:
+      name: my-issuer
+      kind: ClusterIssuer
+```
+
+Or letting the chart create a namespaced self-signed issuer:
+```yaml
+admissionController:
+  registerWebhook: false
+  certGen:
+    enabled: false
+  certManager:
+    enabled: true
+    createSelfSignedIssuer:
+      enabled: true
 ```
 In this mode:
 - Helm creates the MutatingWebhookConfiguration

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md.gotmpl
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md.gotmpl
@@ -50,6 +50,8 @@ Important: You are responsible for creating the TLS secret before or after insta
 If the secret is created after the Helm install, you must restart the admission controller pod to trigger webhook registration.
 
 ### cert-manager managed
+
+Using an existing `Issuer` or `ClusterIssuer`:
 ```yaml
 admissionController:
   registerWebhook: false
@@ -57,6 +59,21 @@ admissionController:
     enabled: false
   certManager:
     enabled: true
+    issuerRef:
+      name: my-issuer
+      kind: ClusterIssuer
+```
+
+Or letting the chart create a namespaced self-signed issuer:
+```yaml
+admissionController:
+  registerWebhook: false
+  certGen:
+    enabled: false
+  certManager:
+    enabled: true
+    createSelfSignedIssuer:
+      enabled: true
 ```
 In this mode:
 - Helm creates the MutatingWebhookConfiguration


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The cert-manager snippet in the chart README sets only `certManager.enabled`, which is not enough to install. With `createSelfSignedIssuer.enabled` defaulting to `false` and `issuerRef.name` to `""`, the chart's own validation aborts the render:

```console
$ helm template vpa . \
    --set admissionController.certManager.enabled=true \
    --set admissionController.certGen.enabled=false

Error: admissionController.certManager.issuerRef.name is required when
admissionController.certManager.createSelfSignedIssuer.enabled is false.
```

The prose below the block already explains that one of the two must be supplied, but the copy-pasteable YAML does not — so following the README literally fails.

This replaces the single incomplete snippet with the two working configurations the prose describes: using an existing `Issuer`/`ClusterIssuer`, and letting the chart create a namespaced self-signed issuer.

#### Which issue(s) this PR fixes:

None filed. Found while reviewing the chart against the `WARNING: This chart is currently under development and is not ready for production use.` notice in the README.

#### Special notes for your reviewer:

Both configurations were verified with `helm template`. Edited in `README.md.gotmpl` with `README.md` regenerated via helm-docs, so the generated file stays in sync with the CI `fail-on-diff` check.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified webhook TLS configuration when using cert-manager.
  - Added examples for using an existing `Issuer` or `ClusterIssuer`.
  - Added an example for enabling a namespaced self-signed issuer.
  - Documented the default requirement and the available self-signed issuer option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->