### PR TITLE
fix: bump kube-webhook-certgen to v1.6.9

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -146,7 +146,7 @@ helm upgrade <release-name> <chart> \
 | admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
 | admissionController.certGen.image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the certgen image. Recommend not changing this |
 | admissionController.certGen.image.repository | string | `"registry.k8s.io/ingress-nginx/kube-webhook-certgen"` | An image that contains certgen for creating certificates. |
-| admissionController.certGen.image.tag | string | `"v20231011-8b53cabe0"` | An image tag for the admissionController.certGen.image.repository image. |
+| admissionController.certGen.image.tag | string | `"v1.6.9"` | An image tag for the admissionController.certGen.image.repository image. |
 | admissionController.certGen.nodeSelector | object | `{}` |  |
 | admissionController.certGen.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The securityContext block for the certgen pod(s) |
 | admissionController.certGen.priorityClassName | string | `""` | Priority class name for the certgen job pods. These jobs gate the release as pre-install/pre-upgrade and post-install/post-upgrade hooks, so a priority class can help them schedule on a busy cluster. |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -118,7 +118,7 @@ admissionController:
       # admissionController.certGen.image.repository -- An image that contains certgen for creating certificates.
       repository: registry.k8s.io/ingress-nginx/kube-webhook-certgen
       # admissionController.certGen.image.tag -- An image tag for the admissionController.certGen.image.repository image.
-      tag: v20231011-8b53cabe0
+      tag: v1.6.9
       # admissionController.certGen.image.pullPolicy -- The pull policy for the certgen image. Recommend not changing this
       pullPolicy: IfNotPresent
        # admissionController.certGen.env -- Additional environment variables to be added to the certgen container. Format is KEY: Value format


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The certgen image is pinned to `v20231011-8b53cabe0`, a date-tagged build from October 2023. The image is produced by ingress-nginx, which has since moved to semver tags and currently ships `v1.6.9`.

This is more than a routine dependency bump: the certgen jobs run with a ClusterRole granting `get`/`update`/`patch` on `mutatingwebhookconfigurations`, so a multi-year-old unpatched base image is a poor place to sit.

#### Changelog

The image is built inside `kubernetes/ingress-nginx` and has no standalone release page, so the authoritative history is the image directory itself:

- [`images/kube-webhook-certgen/TAG` history](https://github.com/kubernetes/ingress-nginx/commits/main/images/kube-webhook-certgen/TAG) — every version bump
- [`images/kube-webhook-certgen` history](https://github.com/kubernetes/ingress-nginx/commits/main/images/kube-webhook-certgen) — the changes behind them

The tag the chart is on predates the semver scheme, which starts at `v0.0.1` in January 2024:

| Date | Tag |
| --- | --- |
| 2023-10-11 | `v20231011-8b53cabe0` ← chart is here |
| 2024-01-13 | `v0.0.1` |
| 2024-02-27 | `v0.0.2` |
| 2024-02-27 | `v1.4.0` |
| 2024-04-05 | `v1.4.1` |
| 2024-07-08 | `v1.4.2` |
| 2024-08-13 | `v1.4.3` |
| 2024-10-05 | `v1.4.4` |
| 2024-12-25 | `v1.5.0` |
| 2025-01-12 | `v1.5.1` |
| 2025-03-24 | `v1.5.2` |
| 2025-04-27 | `v1.5.3` |
| 2025-05-28 | `v1.5.4` |
| 2025-06-29 | `v1.6.0` |
| 2025-08-08 | `v1.6.1` |
| 2025-08-28 | `v1.6.2` |
| 2025-09-27 | `v1.6.3` |
| 2025-10-29 | `v1.6.4` |
| 2025-11-27 | `v1.6.5` |
| 2026-01-21 | `v1.6.6` |
| 2026-01-29 | `v1.6.7` |
| 2026-03-09 | `v1.6.8` |
| 2026-03-19 | `v1.6.9` ← this PR |

143 commits touched the image in that window. Going through them, none change the CLI or its behaviour — they are dependency bumps, Go toolchain bumps and build infrastructure:

- **Go 1.21 → 1.26.1**, with continuous `golang.org/x/net`, `protobuf` and `k8s.io/*` client library updates
- `k8s.io/kube-aggregator` tracked up to 0.35.0
- Image build migrated to Artifact Registry ([#12840](https://github.com/kubernetes/ingress-nginx/pull/12840)) and reworked ([#13010](https://github.com/kubernetes/ingress-nginx/pull/13010))

So the upgrade is behaviourally inert — the value is entirely in the patched base image and runtime.

#### Which issue(s) this PR fixes:

None filed. Found while reviewing the chart against the `WARNING: This chart is currently under development and is not ready for production use.` notice in the README.

#### Special notes for your reviewer:

The CLI surface is unchanged — I checked ingress-nginx's own jobs at v1.6.9 and they invoke the same `create --host --namespace --secret-name` and `patch --webhook-name --namespace --secret-name`. `--patch-validating` is the counterpart of the `--patch-mutating` flag they pass; both are still supported.

The chart also leaves `--cert-name` and `--key-name` at their defaults, which are unchanged in v1.6.9, so the generated Secret keeps the same key layout before and after.

Worth a follow-up: the chart builds image references as `repository:tag` with no digest support, so this cannot be pinned by digest the way ingress-nginx pins the same image.

`Chart.yaml` is intentionally untouched — version bumps appear to be separate maintainer commits (e.g. `chart(vpa): bump chart version to 0.10.0 to publish appVersion 1.7.0`).

#### Does this PR introduce a user-facing change?

```release-note
Bumped kube-webhook-certgen from v20231011-8b53cabe0 to v1.6.9.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default certificate-generation image to version `v1.6.9`.
  * Updated the chart documentation to reflect the new default image version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->