### PR TITLE
fix: honour PodDisruptionBudget minAvailable/maxUnavailable of 0

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.admissionController.enabled .Values.admissionController.podDisruptionBudget.enabled -}}
-{{- if and .Values.admissionController.podDisruptionBudget.minAvailable .Values.admissionController.podDisruptionBudget.maxUnavailable }}
+{{- if and (not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.maxUnavailable)) }}
     {{- fail "Only one of admissionController.podDisruptionBudget.minAvailable or admissionController.podDisruptionBudget.maxUnavailable should be set." }}
 {{- end }}
 apiVersion: policy/v1
@@ -13,10 +13,10 @@ spec:
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.admissionController.selectorLabels" . | nindent 6 }}
-  {{- if and .Values.admissionController.podDisruptionBudget.minAvailable (not .Values.admissionController.podDisruptionBudget.maxUnavailable) }}
+  {{- if not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.admissionController.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if and .Values.admissionController.podDisruptionBudget.maxUnavailable (not .Values.admissionController.podDisruptionBudget.minAvailable) }}
+  {{- if not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.admissionController.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
@@ -1,4 +1,7 @@
 {{- if and (.Values.recommender.enabled) .Values.recommender.podDisruptionBudget.enabled -}}
+{{- if and (not (kindIs "invalid" .Values.recommender.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.recommender.podDisruptionBudget.maxUnavailable)) }}
+    {{- fail "Only one of recommender.podDisruptionBudget.minAvailable or recommender.podDisruptionBudget.maxUnavailable should be set." }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,10 +13,10 @@ spec:
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 6 }}
-  {{- if .Values.recommender.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.recommender.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.recommender.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if .Values.recommender.podDisruptionBudget.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.recommender.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.recommender.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.updater.enabled .Values.updater.podDisruptionBudget.enabled -}}
-{{- if and .Values.updater.podDisruptionBudget.minAvailable .Values.updater.podDisruptionBudget.maxUnavailable }}
+{{- if and (not (kindIs "invalid" .Values.updater.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.updater.podDisruptionBudget.maxUnavailable)) }}
     {{- fail "Only one of updater.podDisruptionBudget.minAvailable or updater.podDisruptionBudget.maxUnavailable should be set." }}
 {{- end }}
 apiVersion: policy/v1
@@ -13,10 +13,10 @@ spec:
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 6 }}
-  {{- if .Values.updater.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.updater.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.updater.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if .Values.updater.podDisruptionBudget.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.updater.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.updater.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Two defects in the PodDisruptionBudget templates.

**1. `minAvailable`/`maxUnavailable` of `0` is silently dropped.** The fields are gated with a plain `if`, which Go templates treat as false for the integer `0`. A user asking for `minAvailable: 0` gets a budget with a selector and no budget field at all:

```console
$ helm template vpa . --set recommender.podDisruptionBudget.minAvailable=0
spec: {'selector': {...}}     # minAvailable dropped
```

Gating on whether the value is *set* rather than on its truthiness passes `0` through like any other value.

**2. `recommender` is missing the mutual-exclusion guard.** `admission-controller-pdb.yaml` and `updater-pdb.yaml` already `fail` the render when both `minAvailable` and `maxUnavailable` are set, and `values.yaml` documents them as mutually exclusive — but the recommender rendered both and left the API server to reject the object. This adds the same guard for consistency.

#### Which issue(s) this PR fixes:

None filed. Found while reviewing the chart against the `WARNING: This chart is currently under development and is not ready for production use.` notice in the README.

#### Special notes for your reviewer:

Rendered output is unchanged for existing users: with the shipped defaults all three budgets still render `minAvailable: 1`. Verified `minAvailable: 0` and `maxUnavailable: 0` now both pass through, and that all three components reject the both-set case.

`Chart.yaml` is intentionally untouched — version bumps appear to be separate maintainer commits.

#### Does this PR introduce a user-facing change?

```release-note
Fixed PodDisruptionBudget minAvailable/maxUnavailable values of 0 being silently dropped, and added the missing mutual-exclusion guard to the recommender budget.
```
