### PR TITLE
fix: ship a restricted-compliant security context by default

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -218,7 +218,9 @@ helm upgrade <release-name> <chart> \
 | admissionController.volumes[0].secret.items[2].path | string | `"serverKey.pem"` |  |
 | admissionController.volumes[0].secret.secretName | string | `"vpa-tls-certs"` |  |
 | commonLabels | object | `{}` |  |
-| containerSecurityContext | object | `{}` |  |
+| containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | crds.enabled | bool | `true` | Whether to install and manage the VPA CRDs. Disable if you manage CRDs separately. |
 | crds.keep | bool | `true` | Whether to add the helm.sh/resource-policy: keep annotation to the CRDs, so they are not removed by `helm uninstall`. |
 | fullnameOverride | string | `nil` |  |
@@ -226,6 +228,7 @@ helm upgrade <release-name> <chart> \
 | nameOverride | string | `nil` |  |
 | podSecurityContext.runAsNonRoot | bool | `true` |  |
 | podSecurityContext.runAsUser | int | `65534` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | rbac.create | bool | `true` |  |
 | rbac.extraRules | list | `[]` |  |
 | recommender.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].key | string | `"app.kubernetes.io/component"` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -19,8 +19,15 @@ rbac:
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65534
+  seccompProfile:
+    type: RuntimeDefault
 
-containerSecurityContext: {}
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 admissionController:
   enabled: true

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -18,10 +18,18 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534 # nobody
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: admission-controller
           image: registry.k8s.io/autoscaling/vpa-admission-controller:1.7.1
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: NAMESPACE
               valueFrom:

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,10 +20,18 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534 # nobody
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: recommender
         image: registry.k8s.io/autoscaling/vpa-recommender:1.7.1
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         resources:
           limits:
             cpu: 200m

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -18,10 +18,18 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534 # nobody
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: updater
           image: registry.k8s.io/autoscaling/vpa-updater:1.7.1
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: NAMESPACE
               valueFrom:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`containerSecurityContext` defaults to `{}` and `podSecurityContext` sets only `runAsNonRoot`/`runAsUser`, so the three VPA workloads render without `allowPrivilegeEscalation: false`, without dropping capabilities and without a seccomp profile. That fails the Pod Security Standards `restricted` profile, so the chart cannot be installed into a namespace enforcing it without every user hand-writing these values.

This sets the restricted baseline by default:

```yaml
podSecurityContext:       # + seccompProfile: RuntimeDefault
containerSecurityContext:
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  capabilities: {drop: [ALL]}
```

The same gap exists in the raw `deploy/` manifests, which set only `runAsNonRoot`/`runAsUser` and no container `securityContext` at all, so `vpa-up.sh` installs are unhardened too. All three are aligned here.

#### Precedent

[`kubernetes-sigs/metrics-server`](https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml) ships this same set as its chart default — same Kubernetes org, and a comparable cluster addon:

```yaml
securityContext:
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  runAsUser: 1000
  seccompProfile:
    type: RuntimeDefault
  capabilities:
    drop:
      - ALL
```

The official [`ingress-nginx`](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml) chart also defaults the controller to `allowPrivilegeEscalation: false` and `seccompProfile: {type: RuntimeDefault}`. It keeps `readOnlyRootFilesystem: false`, since nginx writes to its root filesystem — which is a good illustration that the seccomp profile gets set explicitly even by charts that cannot take the rest of the restricted set.

#### Which issue(s) this PR fixes:

None filed. Found while reviewing the chart against the `WARNING: This chart is currently under development and is not ready for production use.` notice in the README. Related: #10214.

#### Special notes for your reviewer:

This is the chart being made self-consistent rather than adopting a new policy: the `certGen` block already sets exactly this for its hook jobs, so today the short-lived jobs are hardened while the long-running controllers are not.

On `--seccomp-default`: the kubelet flag makes `RuntimeDefault` the runtime default, but Pod Security Admission validates the pod spec at creation and never reads kubelet config. The [`restricted` profile](https://kubernetes.io/docs/concepts/security/pod-security-standards/) requires the field to be present — "Both the `Unconfined` profile and the *absence* of a profile are prohibited" — and the [seccomp docs](https://kubernetes.io/docs/tutorials/security/seccomp/) note that enabling the flag "will neither change the Kubernetes `securityContext.seccompProfile` API field nor add the deprecated annotations of the workload". So a namespace enforcing `restricted` still rejects pods without it.

`readOnlyRootFilesystem` is safe for these images — the components read TLS material from a mounted Secret and log to stderr. There is no `CreateTemp`/`TempFile`/`WriteFile` anywhere in the recommender, updater or admission-controller source; the only `/tmp` reference in the tree is in the standalone `pkg/admission-controller/gencerts.sh` helper script. Anyone passing klog's `--log_file`/`--log_dir` through `extraArgs` would need a writable mount, which is worth noting but is opt-in.

Because Helm merges map values, these defaults cannot be cleared with `containerSecurityContext: {}` — the individual field has to be set, e.g. `--set containerSecurityContext.readOnlyRootFilesystem=false`.

Verified: every Deployment and Job the chart renders, and every `deploy/` manifest, satisfies PSS `restricted`. This does change rendered pod specs, which is the intent.

`Chart.yaml` is intentionally untouched — version bumps appear to be separate maintainer commits.

#### Does this PR introduce a user-facing change?

```release-note
The chart now ships a Pod Security Standards restricted-compliant security context by default (seccompProfile: RuntimeDefault, allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities dropped). Because Helm merges map values, these cannot be cleared with `containerSecurityContext: {}` — set the individual field to false to opt out.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Hardened default container settings by disabling privilege escalation, enabling a read-only root filesystem, and dropping Linux capabilities.
  * Applied the `RuntimeDefault` seccomp profile to VPA pods by default across the admission controller, recommender, and updater components.

* **Documentation**
  * Updated chart configuration documentation to describe the new pod and container security defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->