### PR TITLE
fix: don't create a PodDisruptionBudget that blocks all evictions

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.admissionController.enabled .Values.admissionController.podDisruptionBudget.enabled -}}
+{{- if and .Values.admissionController.enabled .Values.admissionController.podDisruptionBudget.enabled (gt (int .Values.admissionController.replicas) 1) -}}
 {{- if and (not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.maxUnavailable)) }}
     {{- fail "Only one of admissionController.podDisruptionBudget.minAvailable or admissionController.podDisruptionBudget.maxUnavailable should be set." }}
 {{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.admissionController.enabled .Values.admissionController.podDisruptionBudget.enabled -}}
-{{- if and .Values.admissionController.podDisruptionBudget.minAvailable .Values.admissionController.podDisruptionBudget.maxUnavailable }}
+{{- if and (not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.maxUnavailable)) }}
     {{- fail "Only one of admissionController.podDisruptionBudget.minAvailable or admissionController.podDisruptionBudget.maxUnavailable should be set." }}
 {{- end }}
 apiVersion: policy/v1
@@ -13,10 +13,10 @@ spec:
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.admissionController.selectorLabels" . | nindent 6 }}
-  {{- if and .Values.admissionController.podDisruptionBudget.minAvailable (not .Values.admissionController.podDisruptionBudget.maxUnavailable) }}
+  {{- if not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.admissionController.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if and .Values.admissionController.podDisruptionBudget.maxUnavailable (not .Values.admissionController.podDisruptionBudget.minAvailable) }}
+  {{- if not (kindIs "invalid" .Values.admissionController.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.admissionController.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.recommender.enabled) .Values.recommender.podDisruptionBudget.enabled -}}
+{{- if and (.Values.recommender.enabled) .Values.recommender.podDisruptionBudget.enabled (gt (int .Values.recommender.replicas) 1) -}}
 {{- if and (not (kindIs "invalid" .Values.recommender.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.recommender.podDisruptionBudget.maxUnavailable)) }}
     {{- fail "Only one of recommender.podDisruptionBudget.minAvailable or recommender.podDisruptionBudget.maxUnavailable should be set." }}
 {{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
@@ -1,4 +1,7 @@
 {{- if and (.Values.recommender.enabled) .Values.recommender.podDisruptionBudget.enabled -}}
+{{- if and (not (kindIs "invalid" .Values.recommender.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.recommender.podDisruptionBudget.maxUnavailable)) }}
+    {{- fail "Only one of recommender.podDisruptionBudget.minAvailable or recommender.podDisruptionBudget.maxUnavailable should be set." }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,10 +13,10 @@ spec:
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 6 }}
-  {{- if .Values.recommender.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.recommender.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.recommender.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if .Values.recommender.podDisruptionBudget.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.recommender.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.recommender.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.updater.enabled .Values.updater.podDisruptionBudget.enabled -}}
-{{- if and .Values.updater.podDisruptionBudget.minAvailable .Values.updater.podDisruptionBudget.maxUnavailable }}
+{{- if and (not (kindIs "invalid" .Values.updater.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.updater.podDisruptionBudget.maxUnavailable)) }}
     {{- fail "Only one of updater.podDisruptionBudget.minAvailable or updater.podDisruptionBudget.maxUnavailable should be set." }}
 {{- end }}
 apiVersion: policy/v1
@@ -13,10 +13,10 @@ spec:
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 6 }}
-  {{- if .Values.updater.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.updater.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.updater.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if .Values.updater.podDisruptionBudget.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.updater.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.updater.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.updater.enabled .Values.updater.podDisruptionBudget.enabled -}}
+{{- if and .Values.updater.enabled .Values.updater.podDisruptionBudget.enabled (gt (int .Values.updater.replicas) 1) -}}
 {{- if and (not (kindIs "invalid" .Values.updater.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.updater.podDisruptionBudget.maxUnavailable)) }}
     {{- fail "Only one of updater.podDisruptionBudget.minAvailable or updater.podDisruptionBudget.maxUnavailable should be set." }}
 {{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -217,6 +217,7 @@ admissionController:
       readOnly: true
 
   podDisruptionBudget:
+    # Only created when the component runs more than one replica: at a single replica any budget would permit zero voluntary disruptions and block node drains.
     enabled: true
     # -- (int or string) Minimum number/percentage of pods that must be available after the eviction.
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
@@ -320,6 +321,7 @@ recommender:
 
   # PodDisruptionBudget for the Recommender.
   podDisruptionBudget:
+    # Only created when the component runs more than one replica: at a single replica any budget would permit zero voluntary disruptions and block node drains.
     enabled: true
     # -- (int or string) Minimum number/percentage of pods that must be available after the eviction.
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
@@ -411,6 +413,7 @@ updater:
 
   # PodDisruptionBudget for the Updater.
   podDisruptionBudget:
+    # Only created when the component runs more than one replica: at a single replica any budget would permit zero voluntary disruptions and block node drains.
     enabled: true
     # -- (int or string) Minimum number/percentage of pods that must be available after the eviction.
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`podDisruptionBudget.enabled` defaults to `true` and `minAvailable` to `1` on all three components. When a component runs a single replica that budget permits **zero** voluntary disruptions, so the pod can never be evicted and `kubectl drain` on its node blocks indefinitely. In practice this stalls cluster upgrades, node rotation and Cluster Autoscaler / Karpenter consolidation.

```console
$ helm template vpa . --set recommender.replicas=1 --set updater.replicas=1 \
                      --set admissionController.replicas=1
vpa-...-admission-controller   minAvailable: 1
vpa-...-recommender            minAvailable: 1
vpa-...-updater                minAvailable: 1
```

The `replicas: 2` default hides this, but one replica is a reasonable configuration — it is the obvious choice for small or development clusters, and now that the recommender and updater support leader election only one instance is active anyway.

This only renders the budget when the component has more than one replica, and documents that in `values.yaml`. A budget over a single replica cannot express anything useful: it either allows the eviction, in which case it is a no-op, or forbids it and wedges the node.

#### Which issue(s) this PR fixes:

None filed. Found while reviewing the chart against the `WARNING: This chart is currently under development and is not ready for production use.` notice in the README.

#### Special notes for your reviewer:

**This is stacked on the PodDisruptionBudget `0`-handling fix**, which touches the same three templates. Please merge that one first; I will rebase this to a single commit once it lands.

I deliberately chose "skip below 2 replicas" over the alternatives, but this is your call and I am happy to switch:

1. **Skip the budget below 2 replicas** (this PR) — common in other charts. Downside: silently drops a resource the user enabled.
2. **`fail` the render** on the misconfiguration — louder, consistent with the existing `fail` guards, but breaks installs that currently "work".
3. **Default `maxUnavailable: 1`** instead — correct at any replica count, but changes behaviour at 2+ replicas too.

Rendered output is unchanged at the shipped defaults; all three budgets still render `minAvailable: 1` at `replicas: 2`. Components are evaluated independently, so setting one to a single replica does not affect the others.

#### Does this PR introduce a user-facing change?

```release-note
PodDisruptionBudgets are no longer created for VPA components running a single replica, where they would have blocked all voluntary evictions and prevented node drains.
```
