### PR TITLE
feat: add metrics Services

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -162,6 +162,10 @@ helm upgrade <release-name> <chart> \
 | admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` |  |
 | admissionController.image.tag | string | `nil` |  |
 | admissionController.logLevel | int | `4` | Log verbosity for the Admission Controller (klog -v). |
+| admissionController.metrics.service.annotations | object | `{}` | Annotations for the metrics Service. |
+| admissionController.metrics.service.enabled | bool | `true` | Create a ClusterIP Service in front of the Admission Controller's metrics port so it can be scraped. |
+| admissionController.metrics.service.labels | object | `{}` | Additional labels for the metrics Service. |
+| admissionController.metrics.service.port | int | `8944` | Port exposed by the metrics Service. Targets the container's named `prometheus` port (8944). |
 | admissionController.mutatingWebhookConfiguration.annotations | object | `{}` | Additional annotations for the MutatingWebhookConfiguration |
 | admissionController.mutatingWebhookConfiguration.failurePolicy | string | `"Ignore"` | The failurePolicy for the mutating webhook. Allowed values are: Ignore, Fail |
 | admissionController.mutatingWebhookConfiguration.namespaceSelector | object | `{}` | The namespaceSelector controls which namespaces are affected by the webhook |
@@ -232,6 +236,10 @@ helm upgrade <release-name> <chart> \
 | recommender.leaderElection.resourceNamespace | string | `""` |  |
 | recommender.leaderElection.retryPeriod | string | `"2s"` |  |
 | recommender.logLevel | int | `4` | Log verbosity for the Recommender (klog -v). |
+| recommender.metrics.service.annotations | object | `{}` | Annotations for the metrics Service. |
+| recommender.metrics.service.enabled | bool | `true` | Create a ClusterIP Service in front of the Recommender's metrics port so it can be scraped. |
+| recommender.metrics.service.labels | object | `{}` | Additional labels for the metrics Service. |
+| recommender.metrics.service.port | int | `8942` | Port exposed by the metrics Service. Targets the container's named `prometheus` port (8942). |
 | recommender.nodeSelector | object | `{}` |  |
 | recommender.podAnnotations | object | `{}` |  |
 | recommender.podDisruptionBudget.enabled | bool | `true` |  |
@@ -264,6 +272,10 @@ helm upgrade <release-name> <chart> \
 | updater.leaderElection.resourceNamespace | string | `""` |  |
 | updater.leaderElection.retryPeriod | string | `"2s"` |  |
 | updater.logLevel | int | `4` | Log verbosity for the Updater (klog -v). |
+| updater.metrics.service.annotations | object | `{}` | Annotations for the metrics Service. |
+| updater.metrics.service.enabled | bool | `true` | Create a ClusterIP Service in front of the Updater's metrics port so it can be scraped. |
+| updater.metrics.service.labels | object | `{}` | Additional labels for the metrics Service. |
+| updater.metrics.service.port | int | `8943` | Port exposed by the metrics Service. Targets the container's named `prometheus` port (8943). |
 | updater.nodeSelector | object | `{}` |  |
 | updater.podAnnotations | object | `{}` |  |
 | updater.podDisruptionBudget.enabled | bool | `true` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-metrics-service.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-metrics-service.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.admissionController.enabled .Values.admissionController.metrics.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "vertical-pod-autoscaler.admissionController.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+    {{- with .Values.admissionController.metrics.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.admissionController.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.admissionController.metrics.service.port }}
+      protocol: TCP
+      targetPort: prometheus
+  selector:
+    {{- include "vertical-pod-autoscaler.admissionController.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-metrics-service.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-metrics-service.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.recommender.enabled .Values.recommender.metrics.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "vertical-pod-autoscaler.recommender.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+    {{- with .Values.recommender.metrics.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.recommender.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.recommender.metrics.service.port }}
+      protocol: TCP
+      targetPort: prometheus
+  selector:
+    {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-metrics-service.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-metrics-service.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.updater.enabled .Values.updater.metrics.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "vertical-pod-autoscaler.updater.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
+    {{- with .Values.updater.metrics.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.updater.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.updater.metrics.service.port }}
+      protocol: TCP
+      targetPort: prometheus
+  selector:
+    {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -218,6 +218,18 @@ admissionController:
       mountPath: /etc/tls-certs
       readOnly: true
 
+  # Metrics for the Admission Controller.
+  metrics:
+    service:
+      # admissionController.metrics.service.enabled -- Create a ClusterIP Service in front of the Admission Controller's metrics port so it can be scraped.
+      enabled: true
+      # admissionController.metrics.service.port -- Port exposed by the metrics Service. Targets the container's named `prometheus` port (8944).
+      port: 8944
+      # admissionController.metrics.service.labels -- Additional labels for the metrics Service.
+      labels: {}
+      # admissionController.metrics.service.annotations -- Annotations for the metrics Service.
+      annotations: {}
+
   podDisruptionBudget:
     enabled: true
     # -- (int or string) Minimum number/percentage of pods that must be available after the eviction.
@@ -320,6 +332,18 @@ recommender:
     # Duration the clients should wait between attempting acquisition and renewal of a leadership.
     retryPeriod: "2s"
 
+  # Metrics for the Recommender.
+  metrics:
+    service:
+      # recommender.metrics.service.enabled -- Create a ClusterIP Service in front of the Recommender's metrics port so it can be scraped.
+      enabled: true
+      # recommender.metrics.service.port -- Port exposed by the metrics Service. Targets the container's named `prometheus` port (8942).
+      port: 8942
+      # recommender.metrics.service.labels -- Additional labels for the metrics Service.
+      labels: {}
+      # recommender.metrics.service.annotations -- Annotations for the metrics Service.
+      annotations: {}
+
   # PodDisruptionBudget for the Recommender.
   podDisruptionBudget:
     enabled: true
@@ -410,6 +434,18 @@ updater:
     renewDeadline: 10s
     # Duration the clients should wait between attempting acquisition and renewal of a leadership.
     retryPeriod: 2s
+
+  # Metrics for the Updater.
+  metrics:
+    service:
+      # updater.metrics.service.enabled -- Create a ClusterIP Service in front of the Updater's metrics port so it can be scraped.
+      enabled: true
+      # updater.metrics.service.port -- Port exposed by the metrics Service. Targets the container's named `prometheus` port (8943).
+      port: 8943
+      # updater.metrics.service.labels -- Additional labels for the metrics Service.
+      labels: {}
+      # updater.metrics.service.annotations -- Annotations for the metrics Service.
+      annotations: {}
 
   # PodDisruptionBudget for the Updater.
   podDisruptionBudget:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

All three components declare a named `prometheus` container port — recommender 8942, updater 8943, admission controller 8944 — but the chart renders only the admission webhook Service:

```console
$ helm template vpa .
prometheus container ports:  8944 / 8942 / 8943
Services rendered:           vpa-webhook   # targetPort 8000, the webhook
```

So the ports are exposed and then unreachable through anything the chart installs. Operators have to hand-write Services alongside the release and keep them in step with the chart's naming and label conventions.

This matters for a chart whose purpose is resource right-sizing: the recommender's metrics are how you tell whether recommendations are being produced, how stale they are, and whether the updater is acting on them.

Adds per component:

| value | default |
|---|---|
| `<component>.metrics.service.enabled` | `true` — ClusterIP Service targeting the named `prometheus` port |
| `<component>.metrics.service.port` | the component's metrics port |
| `<component>.metrics.service.labels` | `{}` |
| `<component>.metrics.service.annotations` | `{}` |

#### Which issue(s) this PR fixes:

None filed. Found while reviewing the chart against the `WARNING: This chart is currently under development and is not ready for production use.` notice in the README.

#### Special notes for your reviewer:

Updated after review: the ServiceMonitors are gone. Per @adrianmoisey's feedback the chart should not ship third-party custom resources, so it now renders only core Kubernetes objects and leaves scrape configuration to the operator. Annotation-based scraping, a hand-written ServiceMonitor or PodMonitor, or any other mechanism all work against these Services.

**The metrics Service defaults to `true`**, since that is what makes the already-exposed ports usable. This is the only change to a default install: three ClusterIP Services. The cowboysysop `vertical-pod-autoscaler` chart renders a Service per component the same way, so it is also what users migrating from it will expect.

Verified: each Service selects exactly one Deployment and its `targetPort: prometheus` resolves to that component's real metrics port with the Service port matching; the rendered Services pass API schema validation; `helm lint` is clean. Edge cases checked — component disabled, metrics disabled, all components disabled, and a stale `metrics.serviceMonitor.enabled=true` left in a user's values (inert, renders fine).

Follows the chart's existing one-resource-per-file convention, hence three new templates.

#### Does this PR introduce a user-facing change?

```release-note
Added metrics Services for the admission controller, recommender and updater, so the metrics ports the components already expose can be scraped.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes Services for exposing metrics from the admission controller, recommender, and updater.
  * Metrics Services are enabled by default and support custom ports, labels, annotations, and namespaces.
  * Configured distinct metrics ports for each component: 8944, 8942, and 8943.

* **Documentation**
  * Added Helm chart documentation for configuring component metrics Services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->