### PR TITLE
VPA: set explicit FieldManager on API writes

### DIFF
--- a/vertical-pod-autoscaler/common/fieldmanager.go
+++ b/vertical-pod-autoscaler/common/fieldmanager.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// Field manager names identifying which VPA component owns a field when writing
+// to the API server. Setting these explicitly means the API server records
+// ownership against a stable, recognizable name instead of deriving one from the
+// User-Agent, and they are a prerequisite for Server-Side Apply.
+const (
+	// FieldManagerRecommender is used by the VPA recommender.
+	FieldManagerRecommender = "vpa-recommender"
+	// FieldManagerUpdater is used by the VPA updater.
+	FieldManagerUpdater = "vpa-updater"
+	// FieldManagerAdmissionController is used by the VPA admission controller.
+	FieldManagerAdmissionController = "vpa-admission-controller"
+)

--- a/vertical-pod-autoscaler/pkg/admission-controller/certs.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/certs.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	admissionregistrationv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	"k8s.io/klog/v2"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 )
 
 func readFile(filePath string) []byte {
@@ -154,7 +156,7 @@ func (cr *certReloader) reloadWebhookCA() error {
 	}
 	klog.V(2).InfoS("New client CA found, reloading and patching webhook")
 	patch := fmt.Appendf(nil, `{"webhooks":[{"name":"%s","clientConfig":{"caBundle":"%s"}}]}`, webhookName, base64NewBundle)
-	_, err = client.Patch(context.TODO(), webhookConfigName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	_, err = client.Patch(context.TODO(), webhookConfigName, types.StrategicMergePatchType, patch, metav1.PatchOptions{FieldManager: common.FieldManagerAdmissionController})
 	if err == nil {
 		klog.V(2).InfoS("Successfully patched webhook with new client CA")
 	}

--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -29,6 +29,7 @@ import (
 	typedadmregv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	"k8s.io/klog/v2"
 
+	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/config"
 )
 
@@ -186,7 +187,7 @@ func selfRegistration(clientset kubernetes.Interface, caCert []byte, webHookDela
 			},
 		},
 	}
-	if _, err := client.Create(context.TODO(), webhookConfig, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(context.TODO(), webhookConfig, metav1.CreateOptions{FieldManager: common.FieldManagerAdmissionController}); err != nil {
 		klog.Fatal(err)
 	} else {
 		klog.V(3).Info("Self registration as MutatingWebhook succeeded.")

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
+	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_api "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
@@ -90,7 +91,7 @@ func processCheckpointUpdateForVPA(vpa *model.Vpa, writer *checkpointWriter) {
 			},
 			Status: *containerCheckpoint,
 		}
-		err = api_util.CreateOrUpdateVpaCheckpoint(writer.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(vpa.ID.Namespace), &vpaCheckpoint)
+		err = api_util.CreateOrUpdateVpaCheckpoint(writer.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(vpa.ID.Namespace), &vpaCheckpoint, common.FieldManagerRecommender)
 		if err != nil {
 			klog.ErrorS(err, "Cannot save checkpoint for VPA", "vpa", klog.KRef(vpa.ID.Namespace, vpaCheckpoint.Spec.VPAObjectName), "container", vpaCheckpoint.Spec.ContainerName)
 		} else {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_api "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/checkpoint"
@@ -103,7 +104,7 @@ func processVPAUpdate(r *recommender, vpa *model.Vpa, observedVpa *vpaautoscalin
 	}
 
 	_, err := vpa_utils.UpdateVpaStatusIfNeeded(
-		r.vpaClient.VerticalPodAutoscalers(vpa.ID.Namespace), vpa.ID.VpaName, vpa.AsStatus(), &observedVpa.Status)
+		r.vpaClient.VerticalPodAutoscalers(vpa.ID.Namespace), vpa.ID.VpaName, vpa.AsStatus(), &observedVpa.Status, common.FieldManagerRecommender)
 	if err != nil {
 		klog.ErrorS(err, "Cannot update VPA", "vpa", klog.KRef(vpa.ID.Namespace, vpa.ID.VpaName))
 	}

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
+	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	resource_updates "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -255,7 +256,7 @@ func (ip *PodsInPlaceRestrictionImpl) InPlaceUpdate(podToUpdate *corev1.Pod, vpa
 		return err
 	}
 
-	res, err := ip.client.CoreV1().Pods(podToUpdate.Namespace).Patch(context.TODO(), podToUpdate.Name, k8stypes.JSONPatchType, patch, metav1.PatchOptions{}, "resize")
+	res, err := ip.client.CoreV1().Pods(podToUpdate.Namespace).Patch(context.TODO(), podToUpdate.Name, k8stypes.JSONPatchType, patch, metav1.PatchOptions{FieldManager: common.FieldManagerUpdater}, "resize")
 	if err != nil {
 		return err
 	}
@@ -266,7 +267,7 @@ func (ip *PodsInPlaceRestrictionImpl) InPlaceUpdate(podToUpdate *corev1.Pod, vpa
 		if err != nil {
 			return err
 		}
-		res, err = ip.client.CoreV1().Pods(podToUpdate.Namespace).Patch(context.TODO(), podToUpdate.Name, k8stypes.JSONPatchType, patch, metav1.PatchOptions{})
+		res, err = ip.client.CoreV1().Pods(podToUpdate.Namespace).Patch(context.TODO(), podToUpdate.Name, k8stypes.JSONPatchType, patch, metav1.PatchOptions{FieldManager: common.FieldManagerUpdater})
 		if err != nil {
 			klog.V(4).ErrorS(err, "Failed to patch pod annotations", "pod", klog.KObj(res), "patches", string(patch))
 		} else {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -75,19 +75,21 @@ type patchRecord struct {
 	Value any    `json:"value"`
 }
 
-func patchVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, patches []patchRecord) (result *vpa_types.VerticalPodAutoscaler, err error) {
+func patchVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, patches []patchRecord, fieldManager string) (result *vpa_types.VerticalPodAutoscaler, err error) {
 	bytes, err := json.Marshal(patches)
 	if err != nil {
 		klog.ErrorS(err, "Cannot marshal VPA status patches", "patches", patches)
 		return nil, err
 	}
 
-	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, metav1.PatchOptions{}, "status")
+	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, metav1.PatchOptions{FieldManager: fieldManager}, "status")
 }
 
 // UpdateVpaStatusIfNeeded updates the status field of the VPA API object.
+// fieldManager identifies the component performing the write, so that the API
+// server can attribute field ownership to it.
 func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, newStatus,
-	oldStatus *vpa_types.VerticalPodAutoscalerStatus) (result *vpa_types.VerticalPodAutoscaler, err error) {
+	oldStatus *vpa_types.VerticalPodAutoscalerStatus, fieldManager string) (result *vpa_types.VerticalPodAutoscaler, err error) {
 	patches := []patchRecord{{
 		Op:    "add",
 		Path:  "/status",
@@ -95,7 +97,7 @@ func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, v
 	}}
 
 	if !apiequality.Semantic.DeepEqual(*oldStatus, *newStatus) {
-		return patchVpaStatus(vpaClient, vpaName, patches)
+		return patchVpaStatus(vpaClient, vpaName, patches, fieldManager)
 	}
 	return nil, nil
 }
@@ -319,8 +321,10 @@ func GetContainerControlledValues(name string, vpaResourcePolicy *vpa_types.PodR
 
 // CreateOrUpdateVpaCheckpoint updates the status field of the VPA Checkpoint API object.
 // If object doesn't exits it is created.
+// fieldManager identifies the component performing the write, so that the API
+// server can attribute field ownership to it.
 func CreateOrUpdateVpaCheckpoint(vpaCheckpointClient vpa_api.VerticalPodAutoscalerCheckpointInterface,
-	vpaCheckpoint *vpa_types.VerticalPodAutoscalerCheckpoint) error {
+	vpaCheckpoint *vpa_types.VerticalPodAutoscalerCheckpoint, fieldManager string) error {
 	patches := make([]patchRecord, 0)
 	patches = append(patches, patchRecord{
 		Op:    "replace",
@@ -331,9 +335,9 @@ func CreateOrUpdateVpaCheckpoint(vpaCheckpointClient vpa_api.VerticalPodAutoscal
 	if err != nil {
 		return fmt.Errorf("cannot marshal VPA checkpoint status patches %+v. Reason: %+v", patches, err)
 	}
-	_, err = vpaCheckpointClient.Patch(context.TODO(), vpaCheckpoint.Name, types.JSONPatchType, bytes, metav1.PatchOptions{})
+	_, err = vpaCheckpointClient.Patch(context.TODO(), vpaCheckpoint.Name, types.JSONPatchType, bytes, metav1.PatchOptions{FieldManager: fieldManager})
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("\"%s\" not found", vpaCheckpoint.Name)) {
-		_, err = vpaCheckpointClient.Create(context.TODO(), vpaCheckpoint, metav1.CreateOptions{})
+		_, err = vpaCheckpointClient.Create(context.TODO(), vpaCheckpoint, metav1.CreateOptions{FieldManager: fieldManager})
 	}
 	if err != nil {
 		return fmt.Errorf("cannot save checkpoint for vpa %s/%s container %s. Reason: %+v", vpaCheckpoint.Namespace, vpaCheckpoint.Name, vpaCheckpoint.Spec.ContainerName, err)

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_fake "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/fake"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
@@ -99,7 +100,7 @@ func TestUpdateVpaIfNeeded(t *testing.T) {
 		t.Run(tc.caseName, func(t *testing.T) {
 			fakeClient := vpa_fake.NewSimpleClientset(&vpa_types.VerticalPodAutoscalerList{Items: []vpa_types.VerticalPodAutoscaler{*tc.observedVpa}}) //nolint:staticcheck // https://github.com/kubernetes/autoscaler/issues/8954
 			_, err := UpdateVpaStatusIfNeeded(fakeClient.AutoscalingV1().VerticalPodAutoscalers(tc.updatedVpa.Namespace),
-				tc.updatedVpa.Name, &tc.updatedVpa.Status, &tc.observedVpa.Status)
+				tc.updatedVpa.Name, &tc.updatedVpa.Status, &tc.observedVpa.Status, common.FieldManagerRecommender)
 			assert.NoError(t, err, "Unexpected error occurred.")
 			actions := fakeClient.Actions()
 			if tc.expectedUpdate {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

VPA components send Patch requests with an empty `metav1.PatchOptions{}`, so
the API server derives the field manager from the client's User-Agent. VPA
never sets one explicitly, so it falls back to the binary name — which is why
`managedFields` on a VPA object currently shows `manager: recommender` rather
than a name VPA chose.

This sets an explicit, per-component `FieldManager` on VPA's API writes, via
new constants in `common/`:

| Constant | Value |
|---|---|
| `FieldManagerRecommender` | `vpa-recommender` |
| `FieldManagerUpdater` | `vpa-updater` |
| `FieldManagerAdmissionController` | `vpa-admission-controller` |

Call sites updated:

- `pkg/utils/vpa/api.go` — VPA `/status` patch, checkpoint patch, and the
  checkpoint `Create` fallback
- `pkg/updater/restriction/pods_inplace_restriction.go` — pod `/resize` and
  annotation patches
- `pkg/admission-controller/certs.go` — webhook CA patch
- `pkg/admission-controller/config.go` — webhook self-registration `Create`

The load-bearing reason is that **Server-Side Apply requires a field manager** —
the API server rejects apply requests that don't set one — so this is a
prerequisite for part 2 of #10198. Secondarily, it makes the name a deliberate
choice rather than an implicit consequence of what the binary is called.

There is no behavior change: `FieldManager` is honored on all patch types, not
just apply. This PR does **not** introduce Server-Side Apply; all call sites
still use `JSONPatchType`/`StrategicMergePatchType`.

#### Which issue(s) this PR fixes:

Part of #10198

#### Special notes for your reviewer:

This is part 1 of #10198. Part 2 (switching to `types.ApplyPatchType` behind a
toggle) will follow once the design question on the issue is settled — in
particular @adrianmoisey's point about whether SSA can be enabled by default
rather than opt-in.

A few deliberate choices:

- **`pkg/admission-controller/logic/server.go` is intentionally unchanged.** It
  sets `admissionv1.PatchTypeJSONPatch` on the AdmissionReview *response*, which
  is not an API call — the admission API only permits JSONPatch there.

- **`fieldManager` is threaded as a parameter** through `UpdateVpaStatusIfNeeded`
  and `CreateOrUpdateVpaCheckpoint` rather than hardcoded. Only the recommender
  calls them today, but `pkg/utils/vpa` is a shared package and a hardcoded
  component name there would be wrong as soon as a second caller appears. Happy
  to switch to a constant if you'd prefer the YAGNI version.

- **`config.go`'s `Create` is included** even though it isn't a Patch: it creates
  the same webhook config that `certs.go` later patches, so including it keeps
  ownership of that object under a single manager.

- **`pkg/utils/status` was deliberately left alone.** Those are lease
  `Update`/`Create` calls shared by the updater *and* the admission controller,
  so a single hardcoded manager name would be incorrect there. Out of scope.

On @maxcao13's migration question: this does change the `managedFields` manager
name from `recommender`/`updater`/`admission-controller` to the `vpa-` prefixed
equivalents. Since these are `Update` operations, the first write under the new
name should take over ownership of the same fields and the stale entry should
drop out once it owns nothing — but flagging it explicitly in case that
assumption deserves a closer look.

#### Does this PR introduce a user-facing change?

```release-note
VPA components now set an explicit FieldManager on API writes. Field ownership
in `managedFields` is attributed to `vpa-recommender`, `vpa-updater`, or
`vpa-admission-controller` instead of a name derived from the client's
User-Agent.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit field ownership tracking for VPA status, checkpoint, webhook, pod resize, and annotation updates.
  * Improved compatibility with Kubernetes Server-Side Apply by identifying the responsible VPA component for API changes.

* **Bug Fixes**
  * Prevented ambiguous ownership records when multiple VPA components modify Kubernetes resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->