### PR TITLE
VPA: keep memory-only aggregates from being GC'd as empty

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -104,7 +104,8 @@ type AggregateContainerState struct {
 	// AggregateMemoryPeaks is a distribution of memory peaks from all containers:
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
-	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
+	// TotalSamplesCount is CPU-only (checkpoint field). First/LastSampleStart
+	// also follow memory samples so memory-only aggregates age correctly.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
 	TotalSamplesCount int
@@ -229,6 +230,7 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 		a.addCPUSample(sample)
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+		a.observeSampleTime(sample.MeasureStart)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -252,13 +254,17 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 	cpuUsageCores := CoresFromCPUAmount(sample.Usage)
 	a.AggregateCPUUsage.AddSample(
 		cpuUsageCores, minSampleWeight, sample.MeasureStart)
-	if sample.MeasureStart.After(a.LastSampleStart) {
-		a.LastSampleStart = sample.MeasureStart
-	}
-	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
-		a.FirstSampleStart = sample.MeasureStart
-	}
+	a.observeSampleTime(sample.MeasureStart)
 	a.TotalSamplesCount++
+}
+
+func (a *AggregateContainerState) observeSampleTime(t time.Time) {
+	if t.After(a.LastSampleStart) {
+		a.LastSampleStart = t
+	}
+	if a.FirstSampleStart.IsZero() || t.Before(a.FirstSampleStart) {
+		a.FirstSampleStart = t
+	}
 }
 
 // SaveToCheckpoint serializes AggregateContainerState as VerticalPodAutoscalerCheckpointStatus.
@@ -311,7 +317,11 @@ func (a *AggregateContainerState) isExpired(now time.Time) bool {
 }
 
 func (a *AggregateContainerState) isEmpty() bool {
-	return a.TotalSamplesCount == 0
+	// TotalSamplesCount only tracks CPU; a memory histogram still counts.
+	if a.TotalSamplesCount != 0 {
+		return false
+	}
+	return a.AggregateMemoryPeaks == nil || a.AggregateMemoryPeaks.IsEmpty()
 }
 
 func (*AggregateContainerState) convertQuantityToFloat64(quantity *resource.Quantity) float64 {

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -104,8 +104,8 @@ type AggregateContainerState struct {
 	// AggregateMemoryPeaks is a distribution of memory peaks from all containers:
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
-	// TotalSamplesCount is CPU-only (checkpoint field). First/LastSampleStart
-	// also follow memory samples so memory-only aggregates age correctly.
+	// TotalSamplesCount is CPU-only (checkpoint field)
+	// First/LastSampleStart also follow memory samples so memory-only aggregates age correctly.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
 	TotalSamplesCount int
@@ -229,8 +229,7 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 	case ResourceCPU:
 		a.addCPUSample(sample)
 	case ResourceMemory:
-		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
-		a.observeSampleTime(sample.MeasureStart)
+		a.addMemorySample(sample)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -256,6 +255,11 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 		cpuUsageCores, minSampleWeight, sample.MeasureStart)
 	a.observeSampleTime(sample.MeasureStart)
 	a.TotalSamplesCount++
+}
+
+func (a *AggregateContainerState) addMemorySample(sample *ContainerUsageSample) {
+	a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	a.observeSampleTime(sample.MeasureStart)
 }
 
 func (a *AggregateContainerState) observeSampleTime(t time.Time) {
@@ -305,6 +309,19 @@ func (a *AggregateContainerState) LoadFromCheckpoint(checkpoint *vpa_types.Verti
 	err = a.AggregateCPUUsage.LoadFromCheckpoint(&checkpoint.CPUHistogram)
 	if err != nil {
 		return err
+	}
+	// Older checkpoints only stamped First/LastSampleStart from CPU samples.
+	// A memory-only histogram would then look non-empty but expire immediately
+	// because LastSampleStart is still zero.
+	if a.LastSampleStart.IsZero() && a.AggregateMemoryPeaks != nil && !a.AggregateMemoryPeaks.IsEmpty() {
+		if !checkpoint.LastUpdateTime.Time.IsZero() {
+			a.LastSampleStart = checkpoint.LastUpdateTime.Time
+		} else if !a.CreationTime.IsZero() {
+			a.LastSampleStart = a.CreationTime
+		}
+		if a.FirstSampleStart.IsZero() {
+			a.FirstSampleStart = a.LastSampleStart
+		}
 	}
 	return nil
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -214,6 +214,33 @@ func TestAggregateContainerStateIsExpired(t *testing.T) {
 	assert.True(t, csEmpty.isExpired(testTimestamp.Add(8*24*time.Hour)))
 }
 
+func TestAggregateContainerStateIsEmptyMemoryOnly(t *testing.T) {
+	cs := NewAggregateContainerState()
+	assert.True(t, cs.isEmpty())
+
+	cs.AddSample(&ContainerUsageSample{
+		MeasureStart: testTimestamp,
+		Usage:        MemoryAmountFromBytes(32 * 1024 * 1024),
+		Resource:     ResourceMemory,
+	})
+	assert.False(t, cs.isEmpty())
+	assert.Equal(t, 0, cs.TotalSamplesCount)
+	assert.Equal(t, testTimestamp, cs.FirstSampleStart)
+	assert.Equal(t, testTimestamp, cs.LastSampleStart)
+}
+
+func TestAggregateContainerStateIsExpiredMemoryOnly(t *testing.T) {
+	cs := NewAggregateContainerState()
+	cs.CreationTime = testTimestamp.Add(-9 * 24 * time.Hour)
+	cs.AddSample(&ContainerUsageSample{
+		MeasureStart: testTimestamp,
+		Usage:        MemoryAmountFromBytes(64 * 1024 * 1024),
+		Resource:     ResourceMemory,
+	})
+	assert.False(t, cs.isExpired(testTimestamp.Add(7*24*time.Hour)))
+	assert.True(t, cs.isExpired(testTimestamp.Add(8*24*time.Hour)))
+}
+
 func TestUpdateFromPolicyScalingMode(t *testing.T) {
 	scalingModeAuto := vpa_types.ContainerScalingModeAuto
 	scalingModeOff := vpa_types.ContainerScalingModeOff

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -200,6 +200,29 @@ func TestAggregateContainerStateLoadFromCheckpoint(t *testing.T) {
 	assert.False(t, cs.AggregateMemoryPeaks.IsEmpty())
 }
 
+func TestLoadFromCheckpointMemoryOnlyLegacyTimestamps(t *testing.T) {
+	lastUpdate := testTimestamp.Add(time.Hour)
+	checkpoint := vpa_types.VerticalPodAutoscalerCheckpointStatus{
+		Version:        SupportedCheckpointVersion,
+		LastUpdateTime: metav1.NewTime(lastUpdate),
+		MemoryHistogram: vpa_types.HistogramCheckpoint{
+			BucketWeights: map[int]uint32{
+				0: 10,
+			},
+			TotalWeight: 1.0,
+		},
+	}
+
+	cs := NewAggregateContainerState()
+	cs.CreationTime = testTimestamp.Add(-9 * 24 * time.Hour)
+	assert.NoError(t, cs.LoadFromCheckpoint(&checkpoint))
+	assert.False(t, cs.isEmpty())
+	assert.Equal(t, lastUpdate, cs.LastSampleStart)
+	assert.Equal(t, lastUpdate, cs.FirstSampleStart)
+	assert.False(t, cs.isExpired(lastUpdate.Add(7*24*time.Hour)))
+	assert.True(t, cs.isExpired(lastUpdate.Add(8*24*time.Hour)))
+}
+
 func TestAggregateContainerStateIsExpired(t *testing.T) {
 	cs := NewAggregateContainerState()
 	cs.LastSampleStart = testTimestamp

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -218,6 +218,34 @@ func TestClusterGCAggregateContainerStateLeavesEmptyInactiveWithController(t *te
 	assert.NotEmpty(t, vpa.aggregateContainerStates)
 }
 
+func TestClusterGCKeepsMemoryOnlyInactiveWithoutController(t *testing.T) {
+	ctx := context.Background()
+
+	cluster := NewClusterState(testGcPeriod)
+	vpa := addTestVpa(cluster)
+	pod := addTestPod(cluster)
+	controller := &fakeControllerFetcher{
+		key: nil,
+		err: nil,
+	}
+
+	assert.NoError(t, cluster.AddOrUpdateContainer(testContainerID, testRequest))
+	assert.NoError(t, cluster.AddSample(&ContainerUsageSampleWithKey{
+		ContainerUsageSample: ContainerUsageSample{
+			MeasureStart: testTimestamp,
+			Usage:        MemoryAmountFromBytes(32 * 1024 * 1024),
+			Resource:     ResourceMemory,
+		},
+		Container: testContainerID,
+	}))
+
+	cluster.pods[pod.ID].Phase = corev1.PodSucceeded
+	cluster.garbageCollectAggregateCollectionStates(ctx, testTimestamp, controller)
+
+	assert.NotEmpty(t, cluster.aggregateStateMap)
+	assert.NotEmpty(t, vpa.aggregateContainerStates)
+}
+
 func TestClusterGCAggregateContainerStateLeavesValid(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area vertical-pod-autoscaler

#### What this PR does / why we need it:

Short CronJobs that only ever OOM never produce a CPU sample. `isEmpty()` only looked at `TotalSamplesCount` (CPU), so GC dropped the memory histogram and the recommendation fell back to the floor.

Treat a non-empty memory histogram as non-empty, and stamp First/LastSampleStart from memory samples so expiry uses the last peak instead of CreationTime.

#### Which issue(s) this PR fixes:
Fixes #10211

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix VPA dropping OOM-based memory history for short-lived pods that never produce CPU samples
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking of memory-only usage samples for accurate sample timing and state detection.
  * Corrected expiration handling for states containing only memory data.
  * Preserved memory-only data during cluster cleanup when workloads are inactive.

* **Tests**
  * Added coverage for memory-only states, expiration behavior, and cleanup retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->