### PR TITLE
VPA: don't apply eviction requirements to in-place updates

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -342,7 +342,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 
 		if (updateMode == vpa_types.UpdateModeInPlaceOrRecreate) || (updateMode == vpa_types.UpdateModeInPlace && inPlaceFeatureEnabled) {
 			// EvictionRequirements apply to eviction only, not in-place resize.
-			podsForInPlace = u.getPodsUpdateOrder(filterNonInPlaceUpdatablePods(podsAvailableForUpdate, inPlaceLimiter, vpa, len(livePods), u.infeasibleAttempts, u.eventRecorder), vpa, nil)
+			podsForInPlace = u.getPodsUpdateOrder(filterNonInPlaceUpdatablePods(podsAvailableForUpdate, inPlaceLimiter, vpa, len(livePods), u.infeasibleAttempts, u.eventRecorder), vpa, priority.NewDefaultPodEvictionAdmission())
 			inPlaceUpdatablePodsCounter.Add(vpaSize, len(podsForInPlace))
 			if len(podsForInPlace) > 0 {
 				withInPlaceUpdatable = true
@@ -688,8 +688,8 @@ func getRateLimiter(rateLimit float64, rateLimitBurst int) *rate.Limiter {
 }
 
 // getPodsUpdateOrder returns list of pods that should be updated ordered by update priority.
-// admission is applied when non-nil (eviction path). In-place candidates pass nil so
-// EvictionRequirements do not block a resize.
+// In-place candidates pass a default (admit-all) admission so EvictionRequirements
+// do not block a resize; eviction paths pass u.evictionAdmission.
 func (u *updater) getPodsUpdateOrder(pods []*corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler, admission priority.PodEvictionAdmission) []*corev1.Pod {
 	updateconfig := priority.UpdateConfig{
 		MinChangePriority:          u.defaultUpdateThreshold,
@@ -706,9 +706,6 @@ func (u *updater) getPodsUpdateOrder(pods []*corev1.Pod, vpa *vpa_types.Vertical
 		priorityCalculator.AddPod(pod, time.Now(), u.infeasibleAttempts)
 	}
 
-	if admission == nil {
-		admission = priority.NewDefaultPodEvictionAdmission()
-	}
 	return priorityCalculator.GetSortedPods(admission)
 }
 

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -341,7 +341,8 @@ func (u *updater) RunOnce(ctx context.Context) {
 		withEvictable := false
 
 		if (updateMode == vpa_types.UpdateModeInPlaceOrRecreate) || (updateMode == vpa_types.UpdateModeInPlace && inPlaceFeatureEnabled) {
-			podsForInPlace = u.getPodsUpdateOrder(filterNonInPlaceUpdatablePods(podsAvailableForUpdate, inPlaceLimiter, vpa, len(livePods), u.infeasibleAttempts, u.eventRecorder), vpa)
+			// EvictionRequirements apply to eviction only, not in-place resize.
+			podsForInPlace = u.getPodsUpdateOrder(filterNonInPlaceUpdatablePods(podsAvailableForUpdate, inPlaceLimiter, vpa, len(livePods), u.infeasibleAttempts, u.eventRecorder), vpa, nil)
 			inPlaceUpdatablePodsCounter.Add(vpaSize, len(podsForInPlace))
 			if len(podsForInPlace) > 0 {
 				withInPlaceUpdatable = true
@@ -353,7 +354,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 				continue
 			}
 			// We evict the pod when the mode is set to Recreate or Auto. The latter mode is deprecated.
-			podsForEviction = u.getPodsUpdateOrder(filterNonEvictablePods(podsAvailableForUpdate, evictionLimiter), vpa)
+			podsForEviction = u.getPodsUpdateOrder(filterNonEvictablePods(podsAvailableForUpdate, evictionLimiter), vpa, u.evictionAdmission)
 			evictablePodsCounter.Add(vpaSize, updateMode, len(podsForEviction))
 			if len(podsForEviction) > 0 {
 				withEvictable = true
@@ -427,6 +428,10 @@ func (u *updater) RunOnce(ctx context.Context) {
 			}
 			withInPlaceUpdated = true
 			metrics_updater.AddInPlaceUpdatedPod(vpaSize, vpa.Name, vpa.Namespace)
+		}
+
+		if withInPlaceUpdatable && len(podsForEviction) > 0 {
+			podsForEviction = u.getPodsUpdateOrder(podsForEviction, vpa, u.evictionAdmission)
 		}
 
 		for _, pod := range podsForEviction {
@@ -682,8 +687,10 @@ func getRateLimiter(rateLimit float64, rateLimitBurst int) *rate.Limiter {
 	return rateLimiter
 }
 
-// getPodsUpdateOrder returns list of pods that should be updated ordered by update priority
-func (u *updater) getPodsUpdateOrder(pods []*corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) []*corev1.Pod {
+// getPodsUpdateOrder returns list of pods that should be updated ordered by update priority.
+// admission is applied when non-nil (eviction path). In-place candidates pass nil so
+// EvictionRequirements do not block a resize.
+func (u *updater) getPodsUpdateOrder(pods []*corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler, admission priority.PodEvictionAdmission) []*corev1.Pod {
 	updateconfig := priority.UpdateConfig{
 		MinChangePriority:          u.defaultUpdateThreshold,
 		PodLifetimeUpdateThreshold: u.podLifetimeUpdateThreshold,
@@ -699,7 +706,10 @@ func (u *updater) getPodsUpdateOrder(pods []*corev1.Pod, vpa *vpa_types.Vertical
 		priorityCalculator.AddPod(pod, time.Now(), u.infeasibleAttempts)
 	}
 
-	return priorityCalculator.GetSortedPods(u.evictionAdmission)
+	if admission == nil {
+		admission = priority.NewDefaultPodEvictionAdmission()
+	}
+	return priorityCalculator.GetSortedPods(admission)
 }
 
 func filterPods(pods []*corev1.Pod, predicate func(*corev1.Pod) bool) []*corev1.Pod {

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -201,6 +201,89 @@ func TestRunOnce_Mode(t *testing.T) {
 	}
 }
 
+func TestRunOnceInPlaceIgnoresEvictionRequirements(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	replicas := int32(1)
+	labels := map[string]string{"app": "testingApp"}
+	selector := parseLabelSelector("app = testingApp")
+	containerName := "container1"
+	rc := corev1.ReplicationController{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ReplicationController",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		Spec: corev1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	vpaObj := test.VerticalPodAutoscaler().
+		WithContainer(containerName).
+		WithTarget("2", "200M").
+		WithMinAllowed(containerName, "1", "100M").
+		WithMaxAllowed(containerName, "3", "1G").
+		WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
+		WithEvictionRequirements([]*vpa_types.EvictionRequirement{{
+			Resources:         []corev1.ResourceName{corev1.ResourceMemory},
+			ChangeRequirement: vpa_types.TargetLowerThanRequests,
+		}}).
+		WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
+			Kind:       rc.Kind,
+			Name:       rc.Name,
+			APIVersion: rc.APIVersion,
+		}).
+		Get()
+
+	pod := test.Pod().WithName("test_0").
+		AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("100M")).Get()).
+		WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+		Get()
+	pod.Labels = labels
+
+	eviction := &test.PodsEvictionRestrictionMock{}
+	inplace := &test.PodsInPlaceRestrictionMock{}
+	inplace.On("CanInPlaceUpdate", pod).Return(utils.InPlaceApproved)
+	inplace.On("InPlaceUpdate", pod, nil).Return(nil)
+	eviction.On("CanEvict", pod).Return(true)
+
+	factory := &restriction.FakePodsRestrictionFactory{
+		Eviction: eviction,
+		InPlace:  inplace,
+	}
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	podLister := &test.PodListerMock{}
+	podLister.On("List").Return([]*corev1.Pod{pod}, nil)
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaObj}, nil).Once()
+
+	mockSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
+
+	updater := &updater{
+		vpaLister:                    vpaLister,
+		podLister:                    podLister,
+		restrictionFactory:           factory,
+		evictionRateLimiter:          rate.NewLimiter(rate.Inf, 0),
+		inPlaceRateLimiter:           rate.NewLimiter(rate.Inf, 0),
+		evictionAdmission:            priority.NewScalingDirectionPodEvictionAdmission(),
+		recommendationProcessor:      &test.FakeRecommendationProcessor{},
+		selectorFetcher:              mockSelectorFetcher,
+		controllerFetcher:            controllerfetcher.FakeControllerFetcher{},
+		useAdmissionControllerStatus: true,
+		statusValidator:              newFakeValidator(true),
+		priorityProcessor:            priority.NewProcessor(),
+	}
+
+	updater.RunOnce(context.Background())
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 1)
+	eviction.AssertNumberOfCalls(t, "Evict", 0)
+}
+
 func TestRunOnce_Status(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -284,6 +284,88 @@ func TestRunOnceInPlaceIgnoresEvictionRequirements(t *testing.T) {
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
 }
 
+func TestRunOnceInPlaceEvictFallbackHonorsEvictionRequirements(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	replicas := int32(1)
+	labels := map[string]string{"app": "testingApp"}
+	selector := parseLabelSelector("app = testingApp")
+	containerName := "container1"
+	rc := corev1.ReplicationController{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ReplicationController",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		Spec: corev1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	vpaObj := test.VerticalPodAutoscaler().
+		WithContainer(containerName).
+		WithTarget("2", "200M").
+		WithMinAllowed(containerName, "1", "100M").
+		WithMaxAllowed(containerName, "3", "1G").
+		WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
+		WithEvictionRequirements([]*vpa_types.EvictionRequirement{{
+			Resources:         []corev1.ResourceName{corev1.ResourceMemory},
+			ChangeRequirement: vpa_types.TargetLowerThanRequests,
+		}}).
+		WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
+			Kind:       rc.Kind,
+			Name:       rc.Name,
+			APIVersion: rc.APIVersion,
+		}).
+		Get()
+
+	pod := test.Pod().WithName("test_0").
+		AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("100M")).Get()).
+		WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+		Get()
+	pod.Labels = labels
+
+	eviction := &test.PodsEvictionRestrictionMock{}
+	inplace := &test.PodsInPlaceRestrictionMock{}
+	inplace.On("CanInPlaceUpdate", pod).Return(utils.InPlaceEvict)
+	eviction.On("CanEvict", pod).Return(true)
+
+	factory := &restriction.FakePodsRestrictionFactory{
+		Eviction: eviction,
+		InPlace:  inplace,
+	}
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	podLister := &test.PodListerMock{}
+	podLister.On("List").Return([]*corev1.Pod{pod}, nil)
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaObj}, nil).Once()
+
+	mockSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
+
+	updater := &updater{
+		vpaLister:                    vpaLister,
+		podLister:                    podLister,
+		restrictionFactory:           factory,
+		evictionRateLimiter:          rate.NewLimiter(rate.Inf, 0),
+		inPlaceRateLimiter:           rate.NewLimiter(rate.Inf, 0),
+		evictionAdmission:            priority.NewScalingDirectionPodEvictionAdmission(),
+		recommendationProcessor:      &test.FakeRecommendationProcessor{},
+		selectorFetcher:              mockSelectorFetcher,
+		controllerFetcher:            controllerfetcher.FakeControllerFetcher{},
+		useAdmissionControllerStatus: true,
+		statusValidator:              newFakeValidator(true),
+		priorityProcessor:            priority.NewProcessor(),
+	}
+
+	updater.RunOnce(context.Background())
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 0)
+	eviction.AssertNumberOfCalls(t, "Evict", 0)
+}
+
 func TestRunOnce_Status(t *testing.T) {
 	tests := []struct {
 		name                  string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area vertical-pod-autoscaler

#### What this PR does / why we need it:

`EvictionRequirements` were checked in `getPodsUpdateOrder`, which the in-place path also uses. A memory scale-up with `TargetLowerThanRequests` then never got an in-place resize — same log line as in the issue (`Pod removed from update queue by PodEvictionAdmission`).

In-place candidates skip that admission now; it still runs when we actually evict (including InPlaceOrRecreate fallback).

#### Which issue(s) this PR fixes:
Fixes #10181

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix VPA applying EvictionRequirements to in-place updates in InPlaceOrRecreate mode
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In-place pod updates now proceed when eviction requirements would otherwise block them.
  * Eviction fallback correctly respects eviction requirements and prevents blocked evictions.
  * Eviction candidates remain properly ordered when combined with in-place updates.

* **Tests**
  * Added coverage for in-place updates and eviction fallback behavior when eviction requirements are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->