### PR TITLE
cluster-autoscaler: GCE NodeGroupForNode returns nil for foreign providerIDs

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -129,8 +129,13 @@ func (gce *GceCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.N
 	logger := klog.FromContext(ctx)
 	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
-		logger.Error(err, "Error extracting node.Spec.ProviderID for node", "node", klog.KObj(node))
-		return nil, err
+		// Nodes from other providers (e.g. a non-GCE control plane or workers
+		// from other clouds in a mixed cluster) are not managed by this
+		// provider. Per the CloudProvider contract, return nil instead of an
+		// error: returning an error aborts whole core loops (node-info
+		// building, resource-quota tracking) for the entire cluster.
+		logger.V(4).Info("Node has non-GCE providerID, treating as unmanaged", "node", klog.KObj(node), "providerID", node.Spec.ProviderID)
+		return nil, nil
 	}
 	mig, err := gce.gceManager.GetMigForInstance(ctx, ref)
 	if err != nil {
@@ -203,12 +208,13 @@ func (ref GceRef) ToProviderId() string {
 // gce://<project-id>/<zone>/<name>
 // TODO(piosz): add better check whether the id is correct
 func GceRefFromProviderId(id string) (GceRef, error) {
-	if len(id) == 0 {
-		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got nil")
+	const prefix = "gce://"
+	if !strings.HasPrefix(id, prefix) {
+		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got %v", id)
 	}
 
-	splitted := strings.Split(id[6:], "/")
-	if len(splitted) != 3 {
+	splitted := strings.Split(strings.TrimPrefix(id, prefix), "/")
+	if len(splitted) != 3 || splitted[0] == "" || splitted[1] == "" || splitted[2] == "" {
 		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got %v", id)
 	}
 	return GceRef{

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -154,6 +154,34 @@ func TestNodeGroupForNode(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 }
 
+func TestNodeGroupForNodeWithForeignProviderId(t *testing.T) {
+	gceManagerMock := &gceManagerMock{}
+	gce := &GceCloudProvider{
+		gceManager: gceManagerMock,
+	}
+	for _, providerId := range []string{
+		"k3s://control-plane-1",
+		"azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+		"",
+		// Short foreign ID that would panic on a bare id[6:] slice.
+		"x",
+		// Foreign ID with three path components: without an explicit gce://
+		// prefix check it would be misparsed as a GCE reference.
+		"aws://project/zone/name",
+		// gce:// scheme but with a missing/empty component.
+		"gce://project/zone",
+		"gce:///zone/name",
+	} {
+		n := BuildTestNode("n1", 1000, 1000)
+		n.Spec.ProviderID = providerId
+
+		nodeGroup, err := gce.NodeGroupForNode(context.Background(), n)
+		assert.NoError(t, err)
+		assert.Nil(t, nodeGroup)
+	}
+	mock.AssertExpectationsForObjects(t, gceManagerMock)
+}
+
 func TestGetResourceLimiter(t *testing.T) {
 	gceManagerMock := &gceManagerMock{}
 	resourceLimiter := cloudprovider.NewResourceLimiter(


### PR DESCRIPTION
Recreates #10145 on top of current master with proper history (the original branch was pushed from a shallow clone, so it had no common ancestry with master — GitHub showed the whole repo as the diff and refused reopen after the closing force-push).

The change is identical to the final state of #10145, including the fixes for the review feedback from @ppmechlinski and CodeRabbit (parser hardening).

## What this does

In a mixed-providerID cluster (self-managed control plane with `k3s://` providerIDs, or nodes from other clouds), the GCE provider currently fails hard on any non-`gce://` providerID, which prevents scale-up entirely. This changes `NodeGroupForNode` to return `nil` for foreign providerIDs — matching the AWS and Azure providers, and the direction being discussed for the `CloudProvider` contract in #9877 (see also the AWS-side quick fix #10149 for the same class of issue).

```release-note
cluster-autoscaler: the GCE provider now treats nodes with non-GCE providerIDs as unmanaged instead of failing, enabling mixed-provider clusters
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nodes with non-GCE or malformed provider identifiers.
  * Invalid provider identifiers are now safely ignored without producing errors or triggering unnecessary cloud-manager requests.
  * Added validation to reject missing project, zone, or instance details.
  * Prevented malformed or incomplete node identifiers from disrupting node-group discovery.
  * Improved stability when processing nodes managed by other cloud providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->