### PR TITLE
Document the --unready-nodes-scope flag

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -896,6 +896,14 @@ CA stops all operations until the situation improves. If there are fewer unready
 but they are concentrated in a particular node group,
 then this node group may be excluded from future scale-ups.
 
+By default this check looks at every node in the cluster, including nodes that belong to no
+autoscaled node group. On clusters that mix autoscaled node groups with an externally managed
+node fleet, `--unready-nodes-scope=autoscaled` restricts the check to nodes in autoscaled node
+groups, so unready nodes CA does not manage no longer stop it from acting on the ones it does.
+The per-node-group check is unaffected either way, and the status ConfigMap keeps reporting
+cluster-wide node counts, so under `autoscaled` those counts can exceed the configured
+thresholds while the cluster is still reported healthy.
+
 ### How fast is Cluster Autoscaler?
 
 By default, scale-up is considered up to 10 seconds after pod is marked as unschedulable, and scale-down 10 minutes after a node becomes unneeded.
@@ -1145,6 +1153,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `status-config-map-name` | Status configmap name | "cluster-autoscaler-status" |
 | `status-taint` | Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready | [] |
 | `stderrthreshold` | logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) | 2 |
+| `unready-nodes-scope` | Which nodes the cluster-wide unready check gating autoscaling counts. Available values: [cluster,autoscaled]. "cluster" counts every node in the cluster, "autoscaled" counts only nodes belonging to an autoscaled node group. | "cluster" |
 | `unremovable-node-recheck-timeout` | The timeout before we check again a node that couldn't be removed before | 5m0s |
 | `user-agent` | User agent used for HTTP calls. | "cluster-autoscaler" |
 | `v` | number for the log level verbosity |  |


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area cluster-autoscaler

#### What this PR does / why we need it:

Documents the new `--unready-nodes-scope` flag, which can exclude nodes known to be outside autoscaled node groups from the cluster-wide unready node health check.

Adds a paragraph to "How does CA deal with unready nodes?" in `cluster-autoscaler/FAQ.md` explaining when to use the flag and why nodes whose node group lookup fails remain included. It also notes that the per-node-group check is unaffected and the status ConfigMap keeps reporting cluster-wide node counts, so under `autoscaled` those counts can exceed the configured thresholds while the cluster is still reported healthy.

The flag table is generated from the binary's `--help` output. The new row will be generated after the dependency update described below.

The flag itself is implemented in `kubernetes-sigs/cluster-autoscaler`, which now owns `pkg/clusterstate` and the flag set: https://github.com/kubernetes-sigs/cluster-autoscaler/pull/88

#### Which issue(s) this PR fixes:

Documentation for kubernetes/autoscaler#10161. Not marked `Fixes`, so that merging the docs does not close the issue ahead of the implementation.

#### Special notes for your reviewer:

Keep this PR on hold until all of the following are complete:

- https://github.com/kubernetes-sigs/cluster-autoscaler/pull/88 is merged.
- This repository pins `sigs.k8s.io/cluster-autoscaler` to a revision that includes the implementation.
- The autoscaler binary is rebuilt with that dependency and the flag table is regenerated with `cluster-autoscaler/hack/update-faq-flags.sh`, restoring the `unready-nodes-scope` row from `--help`.

The implementation merging alone is not enough to remove the hold. Once the dependency and generated table are updated, remove the hold and request another review from @norbertcyran.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the FAQ with details about the `--unready-nodes-scope=autoscaled` setting.
  * Clarified that externally managed unready nodes can be excluded from cluster-wide autoscaling checks, while nodes with unknown ownership remain included.
  * Noted that per-node-group checks are unchanged and status reporting may still show counts above configured thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->