### PR TITLE
Add AEP for vpa-slice-node-label

### DIFF
--- a/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
+++ b/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
@@ -16,6 +16,8 @@
     - [Updater](#updater)
     - [Admission Controller](#admission-controller)
   - [VPASlice Lifecycle](#vpaslice-lifecycle)
+    - [Open Questions](#open-questions)
+    - [Example](#example)
   - [Design Decisions](#design-decisions)
     - [Why separate VPASlice CRDs instead of embedding in VPA status](#why-separate-vpaslice-crds-instead-of-embedding-in-vpa-status)
     - [Why separate VPASliceCheckpoint CRDs instead of reusing VPA checkpoints](#why-separate-vpaslicecheckpoint-crds-instead-of-reusing-vpa-checkpoints)
@@ -27,6 +29,7 @@
   - [Kubernetes Version Compatibility](#kubernetes-version-compatibility)
 - [Implementation History](#implementation-history)
 - [Alternatives](#alternatives)
+  - [One DaemonSet and VPA per node pool](#one-daemonset-and-vpa-per-node-pool)
 <!-- /toc -->
 
 ## Summary

--- a/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
+++ b/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
@@ -218,6 +218,12 @@ Unlike `VerticalPodAutoscalerCheckpoint` (which stores one container per object)
 checkpoint packs all containers into a single object, yielding one checkpoint per VPASlice
 regardless of container count.
 
+The naming convention for `VPASliceCheckpoint` objects is `{vpaslice-name}`, matching the
+VPASlice's own deterministic name one-to-one. Similiar to how `VerticalPodAutoscalerCheckpoint` works, 
+the recommender will use this name for create/update operations.
+`VPASliceCheckpoint` objects will carry a label `autoscaling.k8s.io/vpaslice-name` to support
+list-by-slice queries. 
+
 ### Component Changes
 
 #### Recommender

--- a/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
+++ b/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
@@ -462,7 +462,8 @@ status:
 ```
 
 In this example, the pod on `kind-worker` was given an additional `stress --vm-bytes 200M`
-workload, driving its memory usage higher than the pod on `kind-worker2`. The VPASlice
+workload via `kubectl exec` to simulate higher resource consumption, driving its memory usage
+higher than the pod on `kind-worker2`. The VPASlice
 recommendations reflect this: `323522422` bytes (~308Mi) on `kind-worker` vs `250Mi` on
 `kind-worker2`.
 

--- a/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
+++ b/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
@@ -222,7 +222,7 @@ checkpoint packs all containers into a single object, yielding one checkpoint pe
 regardless of container count.
 
 The naming convention for `VPASliceCheckpoint` objects is `{vpaslice-name}`, matching the
-VPASlice's own deterministic name one-to-one. Similiar to how `VerticalPodAutoscalerCheckpoint` works, 
+VPASlice's own deterministic name one-to-one. Similar to how `VerticalPodAutoscalerCheckpoint` works, 
 the recommender will use this name for create/update operations.
 `VPASliceCheckpoint` objects will carry a label `autoscaling.k8s.io/vpaslice-name` to support
 list-by-slice queries. 
@@ -497,7 +497,7 @@ objects, each well within etcd limits regardless of how many slices exist. This 
 - Separate RBAC — operators can grant read access to slices without granting access to the
   parent VPA.
 - Automatic garbage collection via `ownerReferences`.
-- A pattern consistent with how Kubernetes handles similiar fan-out (EndpointSlice).
+- A pattern consistent with how Kubernetes handles Similar fan-out (EndpointSlice).
 
 #### Why separate VPASliceCheckpoint CRDs instead of reusing VPA checkpoints
 

--- a/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
+++ b/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
@@ -469,7 +469,7 @@ recommendations reflect this: `323522422` bytes (~308Mi) on `kind-worker` vs `25
 
 The `kubectl get vpaslice` output confirms the per-node recommendations at a glance:
 
-```
+```bash
 NAMESPACE   NAME                              VPA                  NODESELECTOR                                CPU   MEM         PROVIDED   AGE
 default     test-daemonset-vpa-kind-worker    test-daemonset-vpa   {"kubernetes.io/hostname":"kind-worker"}    25m   323522422   True       3h16m
 default     test-daemonset-vpa-kind-worker2   test-daemonset-vpa   {"kubernetes.io/hostname":"kind-worker2"}   25m   250Mi       True       3h16m

--- a/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
+++ b/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
@@ -497,7 +497,7 @@ objects, each well within etcd limits regardless of how many slices exist. This 
 - Separate RBAC — operators can grant read access to slices without granting access to the
   parent VPA.
 - Automatic garbage collection via `ownerReferences`.
-- A pattern consistent with how Kubernetes handles similar fan-out (EndpointSlice).
+- A pattern consistent with how Kubernetes handles similiar fan-out (EndpointSlice).
 
 #### Why separate VPASliceCheckpoint CRDs instead of reusing VPA checkpoints
 

--- a/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
+++ b/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
@@ -1,0 +1,620 @@
+# AEP-7942: Vertical Pod Autoscaling for DaemonSets with Heterogeneous Resource Requirements
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+- [Design Details](#design-details)
+  - [API Changes](#api-changes)
+    - [New field on VerticalPodAutoscalerSpec](#new-field-on-verticalpodautoscalerspec)
+    - [New CRD: VerticalPodAutoscalerSlice](#new-crd-verticalpodautoscalerslice)
+    - [New CRD: VerticalPodAutoscalerSliceCheckpoint](#new-crd-verticalpodautoscalerslicecheckpoint)
+  - [Component Changes](#component-changes)
+    - [Recommender](#recommender)
+    - [Updater](#updater)
+    - [Admission Controller](#admission-controller)
+  - [VPASlice Lifecycle](#vpaslice-lifecycle)
+  - [Design Decisions](#design-decisions)
+    - [Why separate VPASlice CRDs instead of embedding in VPA status](#why-separate-vpaslice-crds-instead-of-embedding-in-vpa-status)
+    - [Why separate VPASliceCheckpoint CRDs instead of reusing VPA checkpoints](#why-separate-vpaslicecheckpoint-crds-instead-of-reusing-vpa-checkpoints)
+    - [How the admission controller determines the target node](#how-the-admission-controller-determines-the-target-node)
+  - [Test Plan](#test-plan)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Version Skew](#version-skew)
+  - [Kubernetes Version Compatibility](#kubernetes-version-compatibility)
+- [Implementation History](#implementation-history)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+VPA today computes a single recommendation per VPA object and applies it uniformly to all matching
+pods. This works well for interchangeable replicas (e.g. Deployments) but breaks down for
+DaemonSets running across heterogeneous nodes. A security agent on a GPU node may consume far more
+CPU and memory than the same agent on a CPU-only node, yet VPA produces one recommendation for
+both. The result is either over-provisioning on quiet nodes or under-provisioning (throttling, OOM
+kills) on busy ones.
+
+This AEP introduces **VPASlice**, a mechanism that partitions VPA recommendations by node label.
+When a VPA targeting a DaemonSet sets `spec.sliceByNodeLabel` to a node label key (e.g.
+`node.kubernetes.io/instance-type`), the recommender creates a `VerticalPodAutoscalerSlice` object
+for each distinct label value observed across matching pods' nodes. Each VPASlice carries an
+independent recommendation computed from the resource usage of pods on that subset of nodes.
+
+The updater and admission controller use VPASlice recommendations to apply the correct
+per-node-group resource values to each pod.
+
+## Motivation
+
+DaemonSets are the primary workload type that runs one pod per node. In clusters with heterogeneous
+node pools (different instance types, GPU vs CPU, different kernel configurations), the resource
+consumption of a DaemonSet pod varies significantly based on the node it runs on. Examples include:
+
+- **Security agents** (e.g. Falco, Tetragon) that consume more resources on nodes with higher
+  workload density or GPU workloads.
+- **Log shippers** (e.g. Fluent Bit) that process more data on nodes running data-intensive
+  applications.
+- **Monitoring exporters** (e.g. node-exporter with GPU metrics) that have higher overhead on
+  specialized hardware.
+- **CNI agents** that scale with the number of pods or network throughput on a node.
+
+Without per-node-group recommendations, cluster operators must choose between:
+1. A single VPA that over-provisions on quiet nodes (wasting resources).
+2. A single VPA that under-provisions on busy nodes (causing OOMs or throttling).
+3. Manually creating separate DaemonSets and VPAs per node pool (operationally heavy, error-prone,
+   and drifts as node pools are added or removed).
+
+### Goals
+
+- Allow VPA to produce independent resource recommendations for subsets of a DaemonSet's pods,
+  grouped by a user-specified node label.
+- Introduce new CRDs (`VerticalPodAutoscalerSlice` and `VerticalPodAutoscalerSliceCheckpoint`)
+  that store per-group recommendations and checkpoints respectively.
+- Ensure the recommender, updater, and admission controller all participate in the VPASlice
+  lifecycle.
+- Gate the feature behind an alpha feature flag (`VPASlice`) so it can be adopted incrementally.
+
+### Non-Goals
+
+- Support for workload types other than DaemonSet. While the VPASlice mechanism could
+  conceptually apply to other controllers, this AEP restricts scope to DaemonSets only.
+- CPU startup boost for VPASlice-managed pods.
+- Multi-label slicing (slicing by more than one label key simultaneously).
+- Automatic node pool discovery or integration with cloud provider node group APIs.
+
+## Proposal
+
+Add an optional field `spec.sliceByNodeLabel` to `VerticalPodAutoscalerSpec`. When this field is
+set and the VPA targets a DaemonSet:
+
+1. The **recommender** discovers the distinct values of the specified node label across nodes that
+   run pods matched by the VPA. For each distinct value, it creates a
+   `VerticalPodAutoscalerSlice` object with an `ownerReference` pointing to the parent VPA (for
+   garbage collection). It then computes independent recommendations for each slice and writes
+   them to the slice's `status.recommendation`.
+
+2. The **updater** reads VPASlice objects and matches each pod to its correct slice by looking up
+   the pod's node labels. It applies updates using the slice-specific recommendation according
+   to the configured `updateMode`.
+
+3. The **admission controller** determines the target node for newly admitted DaemonSet pods by
+   extracting the node name from the node affinity `matchFields` that the DaemonSet controller
+   sets (see [How the admission controller determines the target node](#how-the-admission-controller-determines-the-target-node)).
+   It looks up the node's labels, matches the pod to the correct VPASlice, and injects the
+   slice-specific recommendation into the pod's resource requests.
+
+When `spec.sliceByNodeLabel` is set, the parent VPA's `status.recommendation` is intentionally
+left empty. Consumers should read per-group recommendations from the associated VPASlice objects.
+
+## Design Details
+
+### API Changes
+
+#### New field on VerticalPodAutoscalerSpec
+
+A new optional field is added to the existing `VerticalPodAutoscalerSpec`:
+
+```go
+type VerticalPodAutoscalerSpec struct {
+    // ... existing fields ...
+
+    // SliceByNodeLabel enables per-node-group recommendations for workloads
+    // (typically DaemonSets) running across heterogeneous nodes. When set,
+    // the recommender creates a VerticalPodAutoscalerSlice object for each
+    // distinct value of this node label, containing independent recommendations
+    // computed from pods on nodes with that label value.
+    //
+    // For example, setting this to "node.kubernetes.io/instance-type" produces
+    // separate recommendations for pods on m5.xlarge nodes vs c5.2xlarge nodes.
+    //
+    // When set, the VPA's own status.recommendation is left empty — consumers
+    // should read recommendations from the associated VPASlice objects instead.
+    // +optional
+    SliceByNodeLabel *string `json:"sliceByNodeLabel,omitempty"`
+}
+```
+
+The admission controller validates that:
+- The feature gate `VPASlice` is enabled.
+- `targetRef.Kind` is `DaemonSet`.
+
+#### New CRD: VerticalPodAutoscalerSlice
+
+```go
+type VerticalPodAutoscalerSlice struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    Spec   VerticalPodAutoscalerSliceSpec   `json:"spec"`
+    Status VerticalPodAutoscalerSliceStatus `json:"status,omitempty"`
+}
+
+type VerticalPodAutoscalerSliceSpec struct {
+    // VPAName is the name of the parent VerticalPodAutoscaler object.
+    VPAName string `json:"vpaName"`
+
+    // NodeSelector identifies the set of nodes this slice covers.
+    // Typically a single key-value pair derived from the parent VPA's
+    // spec.sliceByNodeLabel field.
+    NodeSelector map[string]string `json:"nodeSelector"`
+}
+
+type VerticalPodAutoscalerSliceStatus struct {
+    // Recommendation is the most recently computed resource recommendation.
+    // Reuses the same RecommendedPodResources type as VPA status.
+    Recommendation *RecommendedPodResources `json:"recommendation,omitempty"`
+
+    // Conditions indicates whether a recommendation could be computed.
+    Conditions []VerticalPodAutoscalerCondition `json:"conditions,omitempty"`
+
+    // ObservedGeneration tracks the most recent generation observed.
+    ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
+}
+```
+
+VPASlice objects carry:
+- A label `autoscaling.k8s.io/vpa-name` referencing the parent VPA (analogous to
+  `kubernetes.io/service-name` on EndpointSlice).
+- An `ownerReference` to the parent VPA for automatic garbage collection.
+
+The naming convention for VPASlice objects is `{vpa-name}-{sanitized-label-value}`, where the
+label value is lowercased and non-DNS characters are replaced with hyphens, truncated to fit the
+253-character Kubernetes name limit.
+
+#### New CRD: VerticalPodAutoscalerSliceCheckpoint
+
+```go
+type VerticalPodAutoscalerSliceCheckpoint struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    Spec   VerticalPodAutoscalerSliceCheckpointSpec   `json:"spec,omitempty"`
+    Status VerticalPodAutoscalerSliceCheckpointStatus `json:"status,omitempty"`
+}
+
+type VerticalPodAutoscalerSliceCheckpointSpec struct {
+    VPAObjectName string `json:"vpaObjectName,omitempty"`
+    VPASliceName  string `json:"vpaSliceName,omitempty"`
+}
+
+type VerticalPodAutoscalerSliceCheckpointStatus struct {
+    LastUpdateTime       metav1.Time                    `json:"lastUpdateTime,omitempty"`
+    Version              string                         `json:"version,omitempty"`
+    ContainerCheckpoints []ContainerHistogramCheckpoint  `json:"containerCheckpoints,omitempty"`
+}
+
+type ContainerHistogramCheckpoint struct {
+    ContainerName   string              `json:"containerName"`
+    CPUHistogram    HistogramCheckpoint `json:"cpuHistogram,omitempty"`
+    MemoryHistogram HistogramCheckpoint `json:"memoryHistogram,omitempty"`
+    FirstSampleStart metav1.Time        `json:"firstSampleStart,omitempty"`
+    LastSampleStart  metav1.Time        `json:"lastSampleStart,omitempty"`
+    TotalSamplesCount int               `json:"totalSamplesCount,omitempty"`
+}
+```
+
+Unlike `VerticalPodAutoscalerCheckpoint` (which stores one container per object), a slice
+checkpoint packs all containers into a single object, yielding one checkpoint per VPASlice
+regardless of container count.
+
+### Component Changes
+
+#### Recommender
+
+The recommender's main loop gains three new steps when the `VPASlice` feature gate is enabled:
+
+1. **LoadVPASlices**: Ensures VPASlice objects exist for each distinct label value observed across
+   matching pods' nodes. Creates missing slices with `ownerReferences` to the parent VPA. Then
+   loads all VPASlice CRDs into the cluster state model, removing slices whose parent VPA is no
+   longer active.
+
+2. **LoadNodes**: Loads node labels into the cluster state so that pod-to-slice association can be
+   resolved (pods are assigned to aggregation keys that carry their node's label value).
+   Currently this loads all nodes; optimizing to load only nodes that run pods matched by a
+   sliced VPA will be addressed as a follow-up feature.
+
+3. **UpdateVPASlices**: For each VPASlice, aggregates container states from matching pods,
+   computes recommendations using the same `PodResourceRecommender` as regular VPAs, and patches
+   the slice's `status`. VPAs with `sliceByNodeLabel` set are skipped during the
+   regular `UpdateVPAs` step — their `status.recommendation` remains empty.
+
+4. **MaintainCheckpointSlices**: Writes `VerticalPodAutoscalerSliceCheckpoint` objects for each
+   VPASlice, persisting per-container histogram data. On startup, checkpoints are loaded back via
+   `InitFromCheckpointSlices`.
+
+**Pods on nodes without the slice label**: When a matched DaemonSet pod runs on a node that does
+not have the `sliceByNodeLabel` label at all, no VPASlice exists for that pod. The recommender
+skips the pod during slice aggregation (it is not included in any slice's recommendation
+computation) and emits a Kubernetes event on the parent VPA warning that the pod was unmatched.
+For example: `Warning UnmatchedPod Pod test-daemonset-abc on node "unlabeled-node" has no value
+for label "node.kubernetes.io/instance-type"; skipping VPASlice recommendation`. This event is
+also logged at `WARNING` level in the recommender logs. The pod continues running with its
+existing resource requests — neither the updater nor the admission controller modifies it, since
+there is no slice recommendation to apply. The parent VPA's `status.recommendation` remains empty
+(as it does for all sliced VPAs). Operators should ensure all nodes targeted by the DaemonSet
+carry the configured label to receive per-group recommendations.
+
+The cluster state model is extended with:
+- `VpaSlice` model type holding aggregation state, conditions, and recommendation per slice.
+- `VpaSliceID` type for indexing slices.
+- `nodeLabels` map on `clusterState` for resolving pod-to-node-label associations.
+- `AddOrUpdateVpaSlice`, `DeleteVpaSlice`, `AddOrUpdateNode`, `DeleteNode` methods on the
+  `ClusterState` interface.
+- `AggregateStateKey` extended with a `NodeLabelValue()` accessor so aggregations can be scoped
+  to a specific slice.
+
+#### Updater
+
+The updater is extended to:
+
+1. **List VPASlice objects** and pair each with its parent VPA and the parent's pod selector
+   (via `VpaSliceWithNodeSelector`).
+2. **Skip VPAs with `sliceByNodeLabel`** from the normal VPA update loop.
+3. **Match pods to slices** by resolving the pod's node labels and comparing against each slice's
+   `nodeSelector` (via `GetControllingVPASliceForPod`).
+4. **Apply updates** using the slice-specific recommendation from the matched VPASlice. The
+   update mechanism depends on the configured `updateMode`.
+
+#### Admission Controller
+
+The admission controller supports both **validation** and **mutation** for VPASlice-enabled VPAs.
+
+**Mutation**: Although `pod.spec.nodeName` is empty at admission time, the DaemonSet controller
+binds each pod to a specific node via node affinity — it sets
+`spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields`
+with `key: metadata.name` and the target node's name as the value. The admission controller
+extracts the node name from this field, looks up the node's labels, matches the pod to the
+correct VPASlice, and injects the slice-specific recommendation into the pod's resource requests.
+This enables all update modes, including eviction-based modes (`Recreate`, `InPlaceOrRecreate`),
+because the replacement pod is admitted with the correct resources from the start.
+
+If the admission controller cannot determine the target node (e.g. the node affinity field is
+absent or malformed), it skips mutation and logs a warning. The pod is admitted with its original
+resource requests.
+
+**Validation**:
+
+1. Reject VPA objects that set `sliceByNodeLabel` unless the target is a DaemonSet.
+2. Reject VPA objects that set `sliceByNodeLabel` unless the `VPASlice` feature gate is enabled.
+
+### VPASlice Lifecycle
+
+1. User creates a VPA with `spec.sliceByNodeLabel: "node.kubernetes.io/instance-type"` targeting
+   a DaemonSet.
+2. The recommender's `ensureVPASlices` discovers all distinct values of the label across nodes
+   running matched pods (e.g. `m5.xlarge`, `c5.2xlarge`) and creates VPASlice objects:
+   - `my-vpa-m5-xlarge` with `nodeSelector: {"node.kubernetes.io/instance-type": "m5.xlarge"}`
+   - `my-vpa-c5-2xlarge` with `nodeSelector: {"node.kubernetes.io/instance-type": "c5.2xlarge"}`
+3. Each recommender iteration computes independent recommendations per slice and writes them to
+   the slice's `status.recommendation`.
+4. The updater and admission controller match each DaemonSet pod to its slice and apply updates
+   according to the configured `updateMode`. When `updateMode` is `Off`, recommendations are
+   available on the VPASlice objects for external consumers but no automatic updates are applied.
+5. If a new node pool is added with a new instance type, the recommender creates a new VPASlice
+   on its next iteration.
+6. If the parent VPA is deleted, all VPASlice objects are garbage collected via `ownerReferences`.
+
+#### Open Questions
+
+**Parent VPA edits**: When the parent VPA's spec is updated (e.g. resource policy, targetRef,
+or `sliceByNodeLabel` value changes), do the existing VPASlice objects need to be updated or
+recreated? IMO the `VPASlice` objects do not need to change, since they reference the
+parent VPA by name and inherit its resource policy at recommendation time. If the
+`sliceByNodeLabel` key itself changes, the recommender would create new slices for the new label
+values and the old slices would become orphaned (no matching pods). This ties into the cleanup
+question below.
+
+**Stale VPASlice cleanup**: When a `VPASlice` has no pods bound to it (e.g. a node pool was
+removed or all nodes with that label value were drained), the slice remains in the cluster with
+a stale recommendation. Do we need to include a TTL-based cleanup (e.g. the recommender deletes
+slices that have had zero matching pods for a configurable duration), or marking them with a
+condition so operators can identify and clean them up manually?
+
+#### Example
+
+Given a two-node Kind cluster (`kind-worker`, `kind-worker2`) and the following manifests:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-daemonset
+  labels:
+    app: test-daemonset
+spec:
+  selector:
+    matchLabels:
+      app: test-daemonset
+  template:
+    metadata:
+      labels:
+        app: test-daemonset
+    spec:
+      containers:
+      - name: stress
+        image: polinux/stress
+        command: ["stress"]
+        args: ["--vm", "1", "--vm-bytes", "50M", "--vm-hang", "0"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "100Mi"
+          limits:
+            cpu: "500m"
+            memory: "500Mi"
+---
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: test-daemonset-vpa
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: DaemonSet
+    name: test-daemonset
+  updatePolicy:
+    updateMode: "Off"
+  sliceByNodeLabel: "kubernetes.io/hostname"
+```
+
+The recommender automatically creates two VPASlice objects — one per node — each with
+independent recommendations derived from the resource usage on that specific node:
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscalerSlice
+metadata:
+  name: test-daemonset-vpa-kind-worker
+  namespace: default
+  ownerReferences:
+  - apiVersion: autoscaling.k8s.io/v1
+    controller: true
+    kind: VerticalPodAutoscaler
+    name: test-daemonset-vpa
+    uid: 07a3f6e9-f497-4c9d-9f44-22ed88dfec24
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: kind-worker
+  vpaName: test-daemonset-vpa
+status:
+  conditions:
+  - lastTransitionTime: "2026-09-01T06:31:38Z"
+    status: "True"
+    type: RecommendationProvided
+  recommendation:
+    containerRecommendations:
+    - containerName: stress
+      lowerBound:
+        cpu: 25m
+        memory: "317014174"
+      target:
+        cpu: 25m
+        memory: "323522422"
+      uncappedTarget:
+        cpu: 25m
+        memory: "323522422"
+      upperBound:
+        cpu: 123m
+        memory: "3627581199"
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscalerSlice
+metadata:
+  name: test-daemonset-vpa-kind-worker2
+  namespace: default
+  ownerReferences:
+  - apiVersion: autoscaling.k8s.io/v1
+    controller: true
+    kind: VerticalPodAutoscaler
+    name: test-daemonset-vpa
+    uid: 07a3f6e9-f497-4c9d-9f44-22ed88dfec24
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: kind-worker2
+  vpaName: test-daemonset-vpa
+status:
+  conditions:
+  - lastTransitionTime: "2026-09-01T06:31:38Z"
+    status: "True"
+    type: RecommendationProvided
+  recommendation:
+    containerRecommendations:
+    - containerName: stress
+      lowerBound:
+        cpu: 25m
+        memory: 250Mi
+      target:
+        cpu: 25m
+        memory: 250Mi
+      uncappedTarget:
+        cpu: 25m
+        memory: 250Mi
+      upperBound:
+        cpu: 123m
+        memory: "877084945"
+```
+
+In this example, the pod on `kind-worker` was given an additional `stress --vm-bytes 200M`
+workload, driving its memory usage higher than the pod on `kind-worker2`. The VPASlice
+recommendations reflect this: `323522422` bytes (~308Mi) on `kind-worker` vs `250Mi` on
+`kind-worker2`.
+
+The `kubectl get vpaslice` output confirms the per-node recommendations at a glance:
+
+```
+NAMESPACE   NAME                              VPA                  NODESELECTOR                                CPU   MEM         PROVIDED   AGE
+default     test-daemonset-vpa-kind-worker    test-daemonset-vpa   {"kubernetes.io/hostname":"kind-worker"}    25m   323522422   True       3h16m
+default     test-daemonset-vpa-kind-worker2   test-daemonset-vpa   {"kubernetes.io/hostname":"kind-worker2"}   25m   250Mi       True       3h16m
+```
+
+### Design Decisions
+
+#### Why separate VPASlice CRDs instead of embedding in VPA status
+
+etcd enforces a [per-object storage limit](https://etcd.io/docs/v3.8/dev-guide/limit/) (default
+1.5 MiB). A VPA's `status` already contains
+recommendation data, conditions, and other metadata. When slicing by a label with many distinct
+values (e.g. `node.kubernetes.io/instance-type` across dozens of instance types), embedding all
+per-group recommendations inside the parent VPA's `status.groups` would push the object toward
+or past this limit — especially for workloads with multiple containers, each producing target,
+lower-bound, upper-bound, and uncapped-target recommendations.
+
+Separate VPASlice objects avoid this problem by distributing recommendations across many small
+objects, each well within etcd limits regardless of how many slices exist. This also provides:
+- Independent watch semantics — consumers interested in a single node group can watch one slice
+  instead of re-parsing the entire VPA on every change.
+- Separate RBAC — operators can grant read access to slices without granting access to the
+  parent VPA.
+- Automatic garbage collection via `ownerReferences`.
+- A pattern consistent with how Kubernetes handles similar fan-out (EndpointSlice).
+
+#### Why separate VPASliceCheckpoint CRDs instead of reusing VPA checkpoints
+
+The existing `VerticalPodAutoscalerCheckpoint` stores histogram data for a single container of a
+single VPA. If we reused this type for slices, a VPA sliced across N label values with M
+containers would produce N × M checkpoint objects. This multiplicative growth creates pressure on
+etcd object count and API server list/watch overhead.
+
+`VerticalPodAutoscalerSliceCheckpoint` solves this by packing all container histograms for a
+single slice into one object (a `containerCheckpoints` list), yielding exactly one checkpoint per
+VPASlice regardless of container count. This keeps checkpoint count proportional to the number of
+slices (N) rather than N × M.
+
+#### How the admission controller determines the target node
+
+When a new DaemonSet pod is admitted, `pod.spec.nodeName` is empty — the scheduler has not yet
+assigned the pod to a node. However, the DaemonSet controller binds each pod to a specific node
+by setting a node affinity with `matchFields` on `metadata.name`:
+
+```yaml
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchFields:
+          - key: metadata.name
+            operator: In
+            values:
+            - <node-name>
+```
+
+The admission controller extracts the node name from this field, looks up the node's labels in
+its cache, and matches the pod to the correct VPASlice. This enables all update modes — including
+eviction-based modes (`Recreate`, `InPlaceOrRecreate`) — because the replacement pod is admitted
+with the correct slice-specific recommendation from the start, avoiding eviction loops.
+
+### Test Plan
+
+- **Unit tests**: All new functions in the recommender, updater, and admission controller have
+  corresponding unit tests, including:
+  - VPASlice matching logic (`PodMatchesVPASlice`, `GetControllingVPASliceForPod`).
+  - Cluster state slice management (`AddOrUpdateVpaSlice`, `DeleteVpaSlice`, aggregation
+    matching).
+  - Admission controller slice matching (`matchVPASlice`).
+  - Admission controller node name extraction from DaemonSet node affinity `matchFields`.
+  - Validation rules (DaemonSet-only).
+  - Checkpoint slice writer and reader.
+- **E2E tests**: Scenarios to cover:
+  - DaemonSet with heterogeneous nodes receives per-node-group recommendations.
+  - VPASlice objects are created and garbage collected with the parent VPA.
+  - In-place updates apply the correct slice recommendation per pod.
+  - Eviction-based updates (`Recreate`) evict pods and the admission controller injects the
+    correct slice recommendation into the replacement pod.
+  - The admission controller correctly extracts the target node from DaemonSet pod node affinity.
+  - Pods on nodes missing the `sliceByNodeLabel` label are skipped (no recommendation applied)
+    and the recommender emits a warning event on the parent VPA.
+
+### Feature Enablement and Rollback
+
+- **Feature gate name**: `VPASlice`
+- **Components depending on the feature gate**: recommender, updater, admission-controller.
+- **When the gate is enabled**: The recommender creates VPASlice and VPASliceCheckpoint objects
+  for VPAs with `sliceByNodeLabel` set. The updater and admission controller use VPASlice
+  recommendations for matching pods. VPAs with `sliceByNodeLabel` skip the normal recommendation
+  pipeline (their `status.recommendation` stays empty).
+- **When the gate is disabled after being enabled**: Existing VPASlice and VPASliceCheckpoint
+  objects remain in the cluster but are not read or updated by any component. The parent VPA's
+  `status.recommendation` will begin to be populated again on the next recommender cycle
+  (since the `sliceByNodeLabel` skip is gated). Pods will receive the global recommendation
+  rather than per-slice recommendations. The VPASlice CRDs can be manually cleaned up, or will
+  be garbage collected when the parent VPA is deleted.
+- **When the VPA object with `sliceByNodeLabel` is updated to remove the field**: The recommender
+  stops creating new slices and starts writing recommendations to the VPA's `status.recommendation`
+  again. Existing VPASlice objects are garbage collected via `ownerReferences` when the parent VPA
+  is deleted, or can be manually removed.
+
+### Graduation Criteria
+
+- **Alpha → Beta**:
+  - E2E tests are stable for at least 2 releases.
+  - No open bugs against the `VPASlice` feature gate.
+  - Positive user feedback from at least two production deployments.
+- **Beta → GA**:
+  - Feature has been stable in beta for at least 2 releases.
+  - Consider expanding support beyond DaemonSet.
+
+### Version Skew
+
+The `VPASlice` feature gate must be enabled on all three components (recommender, updater,
+admission-controller) for the feature to work correctly:
+
+- **New recommender, old updater/admission-controller**: The recommender creates VPASlice objects
+  and skips writing recommendations to the parent VPA. The old updater and admission controller
+  ignore VPASlice objects and see an empty `status.recommendation` on the parent VPA, resulting
+  in no updates being applied to DaemonSet pods with `sliceByNodeLabel`.
+- **New updater, old recommender**: The updater looks for VPASlice objects but finds none (the
+  old recommender doesn't create them). It falls through to normal VPA processing.
+- **New admission-controller, old recommender**: The admission controller attempts VPASlice
+  matching but finds no slices. It returns `nil` for the matching VPA, and the pod receives no
+  VPA-injected resources — the same behavior as when no VPA matches.
+
+The feature gate fully mitigates skew: all components must have the gate enabled for
+`sliceByNodeLabel` VPAs to function. Enabling the gate on only some components is safe (no
+crashes or data corruption) but results in sliced VPAs being effectively inactive.
+
+### Kubernetes Version Compatibility
+
+When using `updateMode: Off`, `Recreate`, or `InPlaceOrRecreate` (falling back to eviction),
+VPASlice works on any Kubernetes version — no in-place update support is required.
+
+When using `updateMode: InPlace` or `InPlaceOrRecreate` (for the in-place path), this feature
+requires Kubernetes 1.27+ with the `InPlacePodVerticalScaling` feature gate enabled (alpha in
+1.27, beta in 1.33). When running on an older Kubernetes version that does not support in-place
+pod updates, the `InPlace` update mode will not function, and the admission controller will
+reject VPA objects that specify both `sliceByNodeLabel` and `InPlace` mode if the `InPlace`
+feature gate is not enabled.
+
+## Implementation History
+
+- 2026-09-01: Initial AEP version.
+
+## Alternatives
+
+### One DaemonSet and VPA per node pool
+
+Operators can manually create separate DaemonSets (with node selectors) and corresponding VPAs
+for each node pool. This works but is operationally heavy: it requires updating DaemonSet
+manifests every time node pools are added or removed, risks configuration drift, and scales
+poorly in clusters with many node pools.

--- a/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
+++ b/vertical-pod-autoscaler/enhancements/7942-vpa-slice-node-label/README.md
@@ -541,6 +541,8 @@ with the correct slice-specific recommendation from the start, avoiding eviction
     matching).
   - Admission controller slice matching (`matchVPASlice`).
   - Admission controller node name extraction from DaemonSet node affinity `matchFields`.
+  - Admission controller skips resource mutation and logs a warning when the target node
+    cannot be determined (absent `matchFields`, empty `values`, malformed node affinity etc).
   - Validation rules (DaemonSet-only).
   - Checkpoint slice writer and reader.
 - **E2E tests**: Scenarios to cover:


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add AEP for Vertical Pod Autoscaling for DaemonSets with Heterogeneous Resource Requirements
This is a WIP to get community feedback about the general approach and changes.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
There is a working POC I have built in https://github.com/kubernetes/autoscaler/compare/master...omerap12:autoscaler:vpaslice for folks who would like to test/see the actual implementation.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an enhancement proposal for VPASlice, providing Vertical Pod Autoscaler recommendations tailored to node groups identified by labels.
  * Documented proposed APIs, lifecycle, component behavior, feature gating, compatibility, testing, rollout, rollback, and graduation criteria.
  * Documented handling for pods on nodes without the configured label, including warning events and skipped recommendation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->