### PR TITLE
Introduce Cloud KMS error code

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -95,6 +95,10 @@ const (
 	// node group couldn't be scaled up because of invalid TPU configuration.
 	ErrorUnsupportedTpuConfiguration = "UNSUPPORTED_TPU_CONFIGURATION"
 
+	// ErrorCodeCloudKms is an error code used in InstanceErrorInfo if there were
+	// Cloud Key Management Service (KMS) issues.
+	ErrorCodeCloudKms = "CLOUD_KMS_ERROR"
+
 	// ErrorCodeOther is an error code used in InstanceErrorInfo if other error occurs.
 	ErrorCodeOther = "OTHER"
 
@@ -641,6 +645,11 @@ func GetErrorInfo(errorCode, errorMessage, instanceStatus string, previousErrorI
 			ErrorClass: cloudprovider.OtherErrorClass,
 			ErrorCode:  ErrorAutomaticReservationsNoCapacity,
 		}
+	} else if isCloudKmsError(errorMessage) {
+		return &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OtherErrorClass,
+			ErrorCode:  ErrorCodeCloudKms,
+		}
 	} else if isInstanceStatusNotRunningYet(instanceStatus) {
 		if previousErrorInfo != nil {
 			// keep the current error
@@ -711,6 +720,10 @@ func isVmExternalIpAccessPolicyConstraintError(errorCode, errorMessage string) b
 func isTpuConfigurationInvalidError(errorCode, errorMessage string) bool {
 	return strings.Contains(errorCode, "CONDITION_NOT_MET") &&
 		strings.Contains(errorMessage, "Unsupported TPU configuration")
+}
+
+func isCloudKmsError(errorMessage string) bool {
+	return strings.Contains(errorMessage, "Cloud KMS error")
 }
 
 func isInstanceStatusNotRunningYet(instanceStatus string) bool {

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -258,6 +258,12 @@ func TestErrors(t *testing.T) {
 			expectedErrorCode:  ErrorAutomaticReservationsNoCapacity,
 			expectedErrorClass: cloudprovider.OtherErrorClass,
 		},
+		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "Instance 'bad-instance-creation' creation failed: Cloud KMS error when using key projects/my-project/locations/us-central1/keyRings/my-keyring/cryptoKeys/my-key: Permission 'cloudkms.cryptoKeyVersions.useToEncrypt' denied",
+			expectedErrorCode:  "CLOUD_KMS_ERROR",
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
 	}
 	for _, tc := range testCases {
 		for _, errorCode := range tc.errorCodes {


### PR DESCRIPTION


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

We're currently not classifying Cloud KMS errors explicitly, the error gets classified as generic OTHER.

 By parsing the error message for Cloud KMS, we map it to CLOUD_KMS_ERROR so that metrics (like cluster_node_provisioning_failed_attempts_count_per_ccc) surface informative error codes for KMS issues, speeding up customer self-debugging and reducing ticket load.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a `CLOUD_KMS_ERROR` error code to the cluster autoscaler GCE cloud provider to identify issues related to the Cloud Key Management Service.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Cloud KMS permission failures during GCE autoscaling operations.
  * Cloud KMS errors are now clearly classified for more accurate diagnostics and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->