### PR TITLE
Fix drastic scale down of nodes when SKU.Capacity quickly equals 0

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -260,6 +260,12 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 	curSize := *set.SKU.Capacity
 	vmssSizeMutex.Unlock()
 
+	// Azure VMSS API will return SKU.Capacity = 0 (known anomaly). This added check ensures scale down does not occur.
+	if curSize == 0 && scaleSet.curSize > 0 {
+		klog.Infof("VMSS: %s, API returned size 0, while in memory size is %d, ignoring drastic value and keeping in memory size", scaleSet.Name, scaleSet.curSize)
+		return scaleSet.curSize, nil
+	}
+
 	if scaleSet.curSize != curSize {
 		// Invalidate the instance cache if the capacity has changed.
 		klog.V(5).Infof("VMSS %q size changed from: %d to %d, invalidating instance cache", scaleSet.Name, scaleSet.curSize, curSize)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -797,6 +797,62 @@ func TestScaleSetIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
 	}
 }
 
+// Related to #9452. Tests Azure API anomaly, where SKU.Capacity can return 0 which then causes drastic scale down of nodes.
+func TestGetCurSizeDoesNotScaleDownWhenAzureAPIReturnsZero(t *testing.T) {
+	testCases := map[string]struct {
+		apiCapacity             int64 // SKU.Capacity from Azure
+		inMemorySize            int64 // scaleSet.curSize before API call
+		expectedSize            int64
+		expectedRefreshAdvanced bool // should lastSizeRefresh continue
+	}{
+		"drastic zero is ignored, in memory size kept": {
+			apiCapacity:             0,
+			inMemorySize:            90,
+			expectedSize:            90,
+			expectedRefreshAdvanced: false,
+		},
+		"empty scale set still accepts zeros": {
+			apiCapacity:             0,
+			inMemorySize:            0,
+			expectedSize:            0,
+			expectedRefreshAdvanced: true,
+		},
+		"normal scale down is accepted": {
+			apiCapacity:             3,
+			inMemorySize:            90,
+			expectedSize:            3,
+			expectedRefreshAdvanced: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			provider := newTestProvider(t)
+			vmssName := "vmss-test"
+
+			vmss := newTestVMSSList(tc.apiCapacity, vmssName, "eastus", armcompute.OrchestrationModeUniform)[0]
+			provider.azureManager.azureCache.setScaleSet(vmssName, vmss)
+
+			scaleSet := newTestScaleSet(provider.azureManager, vmssName)
+			scaleSet.curSize = tc.inMemorySize
+
+			scaleSet.lastSizeRefresh = time.Time{}
+			scaleSet.sizeRefreshPeriod = time.Hour
+
+			size, err := scaleSet.getCurSize()
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedSize, size)
+
+			if tc.expectedRefreshAdvanced {
+				assert.False(t, scaleSet.lastSizeRefresh.IsZero(), "lastSizeRefresh should continue when value is accepted")
+			} else {
+				assert.True(t, scaleSet.lastSizeRefresh.IsZero(), "lastSizeRefresh should not continue on the VMSS drastic scale down")
+			}
+
+		})
+	}
+
+}
+
 func TestIncreaseSizeOnVMProvisioningFailedWithFastDelete(t *testing.T) {
 	testCases := map[string]struct {
 		expectInstanceRunning    bool


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Azure API briefly returns `SKU.Capacity=0` which causes autoscaler think it needs to scale up. This PR fixes autoscaler accepting the value without first checking the current in memory size. For example:

**Case 1 – `SKU.Capacity = 0` is briefly returned:**
- **Cycle 1:** `SKU.Capacity = 0`, `in_memory_size = 90` → `Capacity == 0`, but nothing will be done yet (this is the fix).
- **Cycle 2:** `SKU.Capacity = 90`, `in_memory_size = 90` → `SKU.Capacity = 90`, meaning the brief `0` is gone.

**Case 2 – `SKU.Capacity = 0` and stays `0`:**
- **Cycle 1:** `SKU.Capacity = 0`, `in_memory_size = 90` → `Capacity == 0`, but nothing will be done yet (this is the fix).
- **Cycle 2:** `SKU.Capacity = 0`, `in_memory_size = 0` → `in_memory_size == 0`, so the normal process continues.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9452

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Azure: Fix VMSS scale down when SKU.Capacity briefly returns zero
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented accidental scale-downs when Azure reports a temporary zero capacity for a non-empty virtual machine scale set.
  - Preserved the known current size until Azure provides a valid capacity value.
  - Continued to accept zero capacity when the scale set is genuinely empty and normal scale-downs when reported values are valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->