### PR TITLE
fix: return (nil, nil) for non-GCE providerIDs in NodeGroupForNode

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -127,10 +127,16 @@ func (gce *GceCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.Nod
 // NodeGroupForNode returns the node group for the given node.
 func (gce *GceCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	logger := klog.FromContext(ctx)
+	if len(node.Spec.ProviderID) == 0 {
+		logger.V(5).Info("Node has no providerID, treating as unmanaged", "node", klog.KObj(node))
+		return nil, nil
+	}
 	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
-		logger.Error(err, "Error extracting node.Spec.ProviderID for node", "node", klog.KObj(node))
-		return nil, err
+		// Nodes from other providers (e.g. mixed-provider / hybrid clusters) or unrecognized formats
+		// are not managed by this provider. Per the CloudProvider contract, return nil instead of an error.
+		logger.V(5).Info("Node has non-GCE providerID, treating as unmanaged", "node", klog.KObj(node), "providerID", node.Spec.ProviderID)
+		return nil, nil
 	}
 	mig, err := gce.gceManager.GetMigForInstance(ctx, ref)
 	if err != nil {
@@ -201,14 +207,13 @@ func (ref GceRef) ToProviderId() string {
 // GceRefFromProviderId creates InstanceConfig object
 // from provider id which must be in format:
 // gce://<project-id>/<zone>/<name>
-// TODO(piosz): add better check whether the id is correct
 func GceRefFromProviderId(id string) (GceRef, error) {
-	if len(id) == 0 {
-		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got nil")
+	if !strings.HasPrefix(id, "gce://") {
+		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got %v", id)
 	}
 
 	splitted := strings.Split(id[6:], "/")
-	if len(splitted) != 3 {
+	if len(splitted) != 3 || splitted[0] == "" || splitted[1] == "" || splitted[2] == "" {
 		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got %v", id)
 	}
 	return GceRef{

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -154,6 +154,40 @@ func TestNodeGroupForNode(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 }
 
+func TestNodeGroupForNodeWithNonGceProviderId(t *testing.T) {
+	gceManagerMock := &gceManagerMock{}
+	gce := &GceCloudProvider{
+		gceManager: gceManagerMock,
+	}
+
+	// Hybrid / foreign provider node (e.g. k3s)
+	hybridNode := BuildTestNode("hybrid-node", 1000, 1000)
+	hybridNode.Spec.ProviderID = "k3s://raspberrypi-0"
+
+	nodeGroup, err := gce.NodeGroupForNode(context.Background(), hybridNode)
+	assert.NoError(t, err)
+	assert.Nil(t, nodeGroup)
+
+	// Node with empty providerID
+	emptyIdNode := BuildTestNode("no-provider-node", 1000, 1000)
+	emptyIdNode.Spec.ProviderID = ""
+
+	nodeGroup, err = gce.NodeGroupForNode(context.Background(), emptyIdNode)
+	assert.NoError(t, err)
+	assert.Nil(t, nodeGroup)
+
+	// Node with another cloud provider ID
+	awsNode := BuildTestNode("aws-node", 1000, 1000)
+	awsNode.Spec.ProviderID = "aws:///us-east-1a/i-0123456789abcdef0"
+
+	nodeGroup, err = gce.NodeGroupForNode(context.Background(), awsNode)
+	assert.NoError(t, err)
+	assert.Nil(t, nodeGroup)
+
+	// Ensure gceManagerMock was never called for unmanaged nodes
+	mock.AssertExpectationsForObjects(t, gceManagerMock)
+}
+
 func TestGetResourceLimiter(t *testing.T) {
 	gceManagerMock := &gceManagerMock{}
 	resourceLimiter := cloudprovider.NewResourceLimiter(
@@ -464,6 +498,24 @@ func TestGceRefFromProviderId(t *testing.T) {
 	ref, err := GceRefFromProviderId("gce://project1/us-central1-b/name1")
 	assert.NoError(t, err)
 	assert.Equal(t, GceRef{"project1", "us-central1-b", "name1"}, ref)
+
+	invalidIds := []string{
+		"",
+		"abc",
+		"gce://",
+		"gce://project1",
+		"gce://project1/us-central1-b",
+		"gce://project1/us-central1-b/name1/extra",
+		"gce:////",
+		"k3s://raspberrypi-0",
+		"aws:///us-east-1a/i-0123456789abcdef0",
+		"azure:///subscriptions/subid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+	}
+
+	for _, invalidId := range invalidIds {
+		_, err := GceRefFromProviderId(invalidId)
+		assert.Error(t, err, "Expected error for providerID %q", invalidId)
+	}
 }
 
 func createString(s string) *string {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area cluster-autoscaler
/area provider/gce

#### What this PR does / why we need it:
In mixed-provider or hybrid clusters (e.g., self-hosted k3s control plane nodes alongside GCE worker nodes, or multi-cloud setups), nodes may have non-GCE provider IDs (e.g. `k3s://...`, `aws:///...`) or empty provider IDs.

Previously, `GceCloudProvider.NodeGroupForNode` propagated the parse error returned by `GceRefFromProviderId` for any non-`gce://` provider ID. Because callers propagate that error, foreign nodes abort Cluster Autoscaler reconciliation loops (e.g. in resource quota tracking and node-info building), preventing scale-up decisions.

Per the `CloudProvider.NodeGroupForNode` interface contract:
> `NodeGroupForNode returns the node group for the given node, nil if the node should not be processed by cluster autoscaler, or non-nil error if such occurred.`

This PR aligns the GCE provider with the existing AWS and Azure provider implementations by:
1. Returning `(nil, nil)` and logging at `V(5)` when encountering empty or non-GCE provider IDs.
2. Hardening `GceRefFromProviderId` to check the `gce://` prefix and prevent slice out-of-bounds panics on malformed IDs.
3. Adding comprehensive unit test coverage in `gce_cloud_provider_test.go`.

#### Which issue(s) this PR fixes:
Fixes #10140

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
```release-note
Fix GCE provider in Cluster Autoscaler aborting reconciliation when nodes with non-GCE or empty providerIDs exist in the cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nodes with missing, non-GCE, or foreign-cloud provider IDs are now safely treated as unmanaged.
  * Invalid GCE provider IDs are rejected when they lack the required format or contain empty project, zone, or instance details.
  * Prevented unnecessary GCE manager calls for unsupported node identifiers.

* **Tests**
  * Added coverage for unmanaged nodes and malformed or non-GCE provider IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->