### PR TITLE
Fix CPU startup boost flake

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/actuation.go
@@ -867,8 +867,10 @@ var _ = ActuationSuiteE2eDescribe("Pods under VPA with CPUStartupBoost", func() 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Verifying container 1 is unboosted first")
-			// Wait for the VPA updater to unboost container1 while container2 remains boosted.
-			err = waitForResourceRequestsInRangeInPods(f, utils.PollTimeout, hamsterListOptions, []containerExpectation{
+			// Boost expiry is anchored to each pod's own Ready time, so pods pass
+			// through this state at different times; check each pod individually
+			// instead of requiring all pods to be in this state simultaneously.
+			err = waitForEachPodResourceRequestsInRange(f, utils.PollTimeout, hamsterListOptions, []containerExpectation{
 				{Index: 0, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie("10m"), UpperBound: ParseQuantityOrDie("10m")},   // Unboosted
 				{Index: 1, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie("400m"), UpperBound: ParseQuantityOrDie("400m")}, // Still boosted
 			})

--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -577,23 +577,60 @@ type containerExpectation struct {
 func waitForResourceRequestsInRangeInPods(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, expectations []containerExpectation) error {
 	err := waitForPodsMatch(f, timeout, listOptions,
 		func(pod apiv1.Pod) bool {
-			for _, exp := range expectations {
-				if exp.Index >= len(pod.Spec.Containers) {
-					return false
-				}
-				req, found := pod.Spec.Containers[exp.Index].Resources.Requests[exp.ResourceName]
-				framework.Logf("Pod %s container %d: Comparing %v request %v against range of (%v, %v)", pod.Name, exp.Index, exp.ResourceName, req, exp.LowerBound, exp.UpperBound)
-				if !found || req.MilliValue() < exp.LowerBound.MilliValue() || req.MilliValue() > exp.UpperBound.MilliValue() {
-					return false
-				}
-			}
-			return true
+			return podMatchesResourceRequests(pod, expectations)
 		})
 
 	if err != nil {
 		return fmt.Errorf("error waiting for resource requests in range %+v for pods: %+v", expectations, listOptions)
 	}
 	return nil
+}
+
+// waitForEachPodResourceRequestsInRange waits until every pod matching
+// listOptions has been observed with requests in the given ranges at least
+// once. Unlike waitForResourceRequestsInRangeInPods, pods do not need to be in
+// the expected state simultaneously.
+func waitForEachPodResourceRequestsInRange(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, expectations []containerExpectation) error {
+	matched := map[string]bool{}
+	err := wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, timeout, true, func(ctx context.Context) (done bool, err error) {
+		podList, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, listOptions)
+		if err != nil {
+			return false, err
+		}
+		if len(podList.Items) == 0 {
+			return false, nil
+		}
+		done = true
+		for _, pod := range podList.Items {
+			if matched[pod.Name] {
+				continue
+			}
+			if podMatchesResourceRequests(pod, expectations) {
+				matched[pod.Name] = true
+			} else {
+				done = false
+			}
+		}
+		return done, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error waiting for each pod's resource requests to be in range %+v for pods: %+v", expectations, listOptions)
+	}
+	return nil
+}
+
+func podMatchesResourceRequests(pod apiv1.Pod, expectations []containerExpectation) bool {
+	for _, exp := range expectations {
+		if exp.Index >= len(pod.Spec.Containers) {
+			return false
+		}
+		req, found := pod.Spec.Containers[exp.Index].Resources.Requests[exp.ResourceName]
+		framework.Logf("Pod %s container %d: Comparing %v request %v against range of (%v, %v)", pod.Name, exp.Index, exp.ResourceName, req, exp.LowerBound, exp.UpperBound)
+		if !found || req.MilliValue() < exp.LowerBound.MilliValue() || req.MilliValue() > exp.UpperBound.MilliValue() {
+			return false
+		}
+	}
+	return true
 }
 
 func waitForResourceRequestInRangeInPods(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, resourceName apiv1.ResourceName, lowerBound, upperBound resource.Quantity) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Since the pods can start at different times, it seems that the flake is caused when a pod starts late. The test assumes that the pods all start at the same time, which sometimes doesn't happen


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end validation for CPU startup boosts to verify each pod independently based on its readiness timing.
  * Improved resource-request checks so pods can reach expected ranges at different times while still requiring every matching pod to satisfy the conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->