### PR TITLE
Fix huaweicloud scale-up cancelled by a still-booting instance

### DIFF
--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_service_manager.go
@@ -426,11 +426,18 @@ func (csm *cloudServiceManager) transformInstanceState(lifeCycleState huaweiclou
 		}
 		return instanceStatus
 	default:
-		instanceStatus.ErrorInfo = &cloudprovider.InstanceErrorInfo{
-			ErrorClass:   cloudprovider.OtherErrorClass,
-			ErrorMessage: fmt.Sprintf("invalid instance health state: %v", healthStatus),
-		}
-		return instanceStatus
+		// Not an error. The API returns "INITIALIZING" for an instance that is
+		// still starting, while the enum above spells that state INITAILIZING
+		// and carries that spelling as its value, so every booting instance
+		// reaches this branch.
+		//
+		// Reporting it through ErrorInfo made Cluster Autoscaler remove the
+		// instance at once instead of waiting for maxNodeProvisionTime, so an
+		// instance was deleted a few seconds into a multi-minute boot and a
+		// single pending pod became a create-and-delete loop. Health status is
+		// advisory: only ERROR, which the API documents as a real fault, should
+		// mark an instance failed. Anything else is logged and left alone.
+		klog.Warningf("unrecognized instance health status, treating the instance as healthy: %v", healthStatus)
 	}
 
 	return instanceStatus


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Scale-up on the `huaweicloud` provider can never complete. Every instance the provider creates is deleted roughly twenty seconds into its boot, so a single pending pod becomes an endless create-and-delete loop.

The AS API returns `INITIALIZING` as the health status of an instance that is still starting:

```
instance_name:    rke2-agent-...-3M6PKSBO
life_cycle_state: PENDING
health_status:    INITIALIZING
```

The SDK enum spells that same state `INITAILIZING`, and carries that spelling as its value:

```go
INITAILIZING: ScalingGroupInstanceHealthStatus{
    value: "INITAILIZING",
},
```

So a booting instance matches neither `NORMAL`, `INITAILIZING` nor `ERROR` in `transformInstanceState`, falls through to `default:`, and is reported to Cluster Autoscaler through `ErrorInfo`. Cluster Autoscaler removes instances that report an error immediately rather than waiting for `maxNodeProvisionTime`, so the instance is deleted while it is still booting.

Observed against a live scaling group (Cluster Autoscaler 1.35.0, region `ap-southeast-3`):

```
21:45:40  TriggeredScaleUp 0->1
21:45:51  AS activity: SCHEDULED 0 -> 1
21:46:01  DeleteScalingInstances -> AS.4015 "The instance is not in the inservice status"
21:46:38  AS activity: MANNUAL_DELETE 1 -> 0
```

With Cluster Autoscaler stopped and the group's desired count set by hand, the same scaling configuration produced a node that booted and joined normally in about 50 seconds. The instance is fine; only the status mapping is wrong.

**The change**

Only `default:` changes. Health status is advisory, so only `ERROR` — which the API documents as a real fault — marks an instance failed. Any other status, recognised or not, is logged and the instance is left alone.

I deliberately did not add a comparison against the correctly spelled `INITIALIZING`. The vendored enum type has only `MarshalJSON`/`UnmarshalJSON` and no exported accessor, so matching the string would mean marshalling the value or building one through `UnmarshalJSON` — more machinery than the bug needs. Making `default:` non-fatal fixes this case and any future status string, which is the property that actually matters: an unfamiliar advisory value should never delete a node.

`life_cycle_state` is left as it is. An unknown lifecycle state does say something about whether the instance exists, whereas health status does not.

**Which issue(s) this PR fixes**:

None filed. Happy to open one if that is preferred.

**Special notes for your reviewer**:

The misspelling is in the SDK enum, both as vendored here and in `huaweicloud-sdk-go-v3` upstream, where it also appears in the doc comment. Correcting the SDK would be the deeper fix, but the provider should not depend on that.

**Does this PR introduce a user-facing change?**

```release-note
Fix the huaweicloud provider deleting every newly created instance during scale-up. The AS API reports a booting instance as INITIALIZING while the SDK enum defines INITAILIZING, so the instance was treated as errored and removed before it could register as a node.
```
