### PR TITLE
VPA: add e2e coverage for --pod-recommendation-min-memory-mb

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/integration/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/integration/recommender.go
@@ -78,6 +78,42 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 
 		testIncludedAndIgnoredNamespaces(f, vpaClientSet, hamsterNamespace, ignoredNamespace.Name)
 	})
+
+	ginkgo.It("starts recommender with --pod-recommendation-min-memory-mb parameter", func() {
+		const minMemoryMb = 250
+
+		ginkgo.By("Setting up VPA deployment")
+		f.Namespace.Name = utils.VpaNamespace
+		vpaDeployment := utils.NewVPADeployment(f, []string{
+			"--recommender-interval=10s",
+			fmt.Sprintf("--pod-recommendation-min-memory-mb=%d", minMemoryMb),
+		})
+		utils.StartDeploymentPods(f, vpaDeployment)
+
+		ginkgo.By("Setting up a hamster deployment")
+		f.Namespace.Name = hamsterNamespace
+		d := utils.NewNHamstersDeployment(f, 1)
+		_ = utils.StartDeploymentPods(f, d)
+
+		ginkgo.By("Setting up VPA")
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("hamster-vpa").
+			WithNamespace(hamsterNamespace).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithContainer(containerName).
+			Get()
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Waiting for recommendation to be filled")
+		vpa, err := utils.WaitForRecommendationPresent(vpaClientSet, vpaCRD)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(vpa.Status.Recommendation.ContainerRecommendations).Should(gomega.HaveLen(1))
+
+		memoryMb := vpa.Status.Recommendation.ContainerRecommendations[0].Target.Memory().Value() / (1024 * 1024)
+		gomega.Expect(memoryMb).Should(gomega.BeNumerically(">=", minMemoryMb),
+			"recommended memory should respect the --pod-recommendation-min-memory-mb floor even though actual usage is far below it")
+	})
 })
 
 // Create VPA and deployment in 2 namespaces, 1 should be ignored

--- a/vertical-pod-autoscaler/test/e2e/integration/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/integration/recommender.go
@@ -80,7 +80,7 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 	})
 
 	ginkgo.It("starts recommender with --pod-recommendation-min-memory-mb parameter", func() {
-		const minMemoryMb = 250
+		const minMemoryMb = 500
 
 		ginkgo.By("Setting up VPA deployment")
 		f.Namespace.Name = utils.VpaNamespace


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The VPA recommender flags e2e suite (`vertical-pod-autoscaler/test/e2e/integration/recommender.go`) only covers the namespace filtering flags (`--vpa-object-namespace`, `--ignored-vpa-object-namespaces`). Every other recommender flag is only ever exercised with its default value, so a flag whose behavior regresses wouldn't be caught by e2e tests.

This PR adds a test that starts the recommender with `--pod-recommendation-min-memory-mb` set well above what the test workload actually uses, and asserts the resulting recommendation respects that floor.

#### Which issue(s) this PR fixes:

Part of #7723

#### Special notes for your reviewer:

This adds one additional flag to the suite rather than trying to cover every recommender flag in one PR, to keep the change reviewable. Verified locally that the test compiles and vets cleanly (`go build ./e2e/...`, `go vet ./e2e/integration/...` from `vertical-pod-autoscaler/test`); running it end to end requires a kind cluster via the existing e2e harness.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage verifying that the recommender enforces a configured minimum memory recommendation when observed usage is lower than the minimum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
