### PR TITLE
Migrate request_latencies metric from closed-source and deprecate gce_request_count

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -217,14 +217,16 @@ func NewCustomAutoscalingGceClientV1(client *http.Client, projectId, serverUrl, 
 }
 
 func (client *autoscalingGceClientV1) FetchMachineType(zone, machineType string) (*gce.MachineType, error) {
-	registerRequest("machine_types", "get")
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
 	defer cancel()
-	return client.gceService.MachineTypes.Get(client.projectId, zone, machineType).Context(ctx).Do()
+	resp, err := client.gceService.MachineTypes.Get(client.projectId, zone, machineType).Context(ctx).Do()
+	emitGceLatency("machine_types", "get", resp, err, start)
+	return resp, err
 }
 
 func (client *autoscalingGceClientV1) FetchMachineTypes(zone string) ([]*gce.MachineType, error) {
-	registerRequest("machine_types", "list")
+	start := time.Now()
 	var machineTypes []*gce.MachineType
 	err := client.gceService.MachineTypes.List(client.projectId, zone).Pages(
 		context.TODO(),
@@ -232,6 +234,7 @@ func (client *autoscalingGceClientV1) FetchMachineTypes(zone string) ([]*gce.Mac
 			machineTypes = append(machineTypes, page.Items...)
 			return nil
 		})
+	emitGceLatency("machine_types", "list", nil, err, start)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +242,7 @@ func (client *autoscalingGceClientV1) FetchMachineTypes(zone string) ([]*gce.Mac
 }
 
 func (client *autoscalingGceClientV1) FetchAllMigs(zone string) ([]*gce.InstanceGroupManager, error) {
-	registerRequest("instance_group_managers", "list")
+	start := time.Now()
 	var migs []*gce.InstanceGroupManager
 	err := client.gceService.InstanceGroupManagers.List(client.projectId, zone).Pages(
 		context.TODO(),
@@ -247,6 +250,7 @@ func (client *autoscalingGceClientV1) FetchAllMigs(zone string) ([]*gce.Instance
 			migs = append(migs, page.Items...)
 			return nil
 		})
+	emitGceLatency("instance_group_managers", "list", nil, err, start)
 	if err != nil {
 		return nil, err
 	}
@@ -254,10 +258,11 @@ func (client *autoscalingGceClientV1) FetchAllMigs(zone string) ([]*gce.Instance
 }
 
 func (client *autoscalingGceClientV1) FetchMig(migRef GceRef) (*gce.InstanceGroupManager, error) {
-	registerRequest("instance_group_managers", "get")
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
 	defer cancel()
 	igm, err := client.gceService.InstanceGroupManagers.Get(migRef.Project, migRef.Zone, migRef.Name).Context(ctx).Do()
+	emitGceLatency("instance_group_managers", "get", igm, err, start)
 	if err != nil {
 		if err, ok := err.(*googleapi.Error); ok {
 			if err.Code == http.StatusNotFound {
@@ -294,10 +299,11 @@ func (client *autoscalingGceClientV1) FetchListManagedInstancesResults(migRef Gc
 }
 
 func (client *autoscalingGceClientV1) ResizeMig(migRef GceRef, size int64) error {
-	registerRequest("instance_group_managers", "resize")
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
 	defer cancel()
 	op, err := client.gceService.InstanceGroupManagers.Resize(migRef.Project, migRef.Zone, migRef.Name, size).Context(ctx).Do()
+	emitGceLatency("instance_group_managers", "resize", op, err, start)
 	if err != nil {
 		return err
 	}
@@ -305,7 +311,7 @@ func (client *autoscalingGceClientV1) ResizeMig(migRef GceRef, size int64) error
 }
 
 func (client *autoscalingGceClientV1) CreateInstances(migRef GceRef, baseName string, delta int64, existingInstanceProviderIds []string) ([]string, error) {
-	registerRequest("instance_group_managers", "create_instances")
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
 	defer cancel()
 	req := gce.InstanceGroupManagersCreateInstancesRequest{}
@@ -321,6 +327,7 @@ func (client *autoscalingGceClientV1) CreateInstances(migRef GceRef, baseName st
 	}
 
 	op, err := client.gceService.InstanceGroupManagers.CreateInstances(migRef.Project, migRef.Zone, migRef.Name, &req).Context(ctx).Do()
+	emitGceLatency("instance_group_managers", "create_instances", op, err, start)
 	if err != nil {
 		return nil, err
 	}
@@ -350,8 +357,9 @@ func (client *autoscalingGceClientV1) WaitForOperation(operationName, operationT
 
 	for {
 		klog.V(4).Infof("Waiting for operation %s/%s (%s/%s)", operationType, operationName, project, zone)
-		registerRequest("zone_operations", "wait")
+		start := time.Now()
 		op, err := client.gceService.ZoneOperations.Wait(project, zone, operationName).Context(ctx).Do()
+		emitGceLatency("zone_operations", "wait", op, err, start)
 		if err != nil {
 			return fmt.Errorf("error while waiting for operation %s/%s: %w", operationType, operationName, err)
 		}
@@ -375,7 +383,7 @@ func (client *autoscalingGceClientV1) WaitForOperation(operationName, operationT
 }
 
 func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances []GceRef) error {
-	registerRequest("instance_group_managers", "delete_instances")
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
 	defer cancel()
 	req := gce.InstanceGroupManagersDeleteInstancesRequest{
@@ -386,6 +394,7 @@ func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances [
 		req.Instances = append(req.Instances, GenerateInstanceUrl(client.domainUrl, i))
 	}
 	op, err := client.gceService.InstanceGroupManagers.DeleteInstances(migRef.Project, migRef.Zone, migRef.Name, &req).Context(ctx).Do()
+	emitGceLatency("instance_group_managers", "delete_instances", op, err, start)
 	if err != nil {
 		return err
 	}
@@ -393,7 +402,7 @@ func (client *autoscalingGceClientV1) DeleteInstances(migRef GceRef, instances [
 }
 
 func (client *autoscalingGceClientV1) FetchAllInstances(project, zone, filter string) ([]GceInstance, error) {
-	registerRequest("instances", "list")
+	start := time.Now()
 	instances := make([]GceInstance, 0)
 	loggingQuota := klogx.NewLoggingQuota(MaxInstancesLogged)
 	err := client.gceService.Instances.List(project, zone).Filter(filter).Pages(context.Background(), func(page *gce.InstanceList) error {
@@ -407,6 +416,7 @@ func (client *autoscalingGceClientV1) FetchAllInstances(project, zone, filter st
 		}
 		return nil
 	})
+	emitGceLatency("instances", "list", nil, err, start)
 	if err != nil {
 		klog.Errorf("Failed listing Instances in zone %s, project %s: %v", zone, project, err)
 		return nil, err
@@ -459,9 +469,10 @@ func createIgmRef(gceInstance *gce.Instance, project string, loggingQuota *klogx
 }
 
 func (client *autoscalingGceClientV1) FetchMigInstances(migRef GceRef) ([]GceInstance, error) {
-	registerRequest("instance_group_managers", "list_managed_instances")
+	start := time.Now()
 	b := newInstanceListBuilder(migRef)
 	err := client.gceService.InstanceGroupManagers.ListManagedInstances(migRef.Project, migRef.Zone, migRef.Name).Pages(context.Background(), b.loadPage)
+	emitGceLatency("instance_group_managers", "list_managed_instances", nil, err, start)
 	if err != nil {
 		klog.V(4).Infof("Failed MIG info request for %s %s %s: %v", migRef.Project, migRef.Zone, migRef.Name, err)
 		return nil, err
@@ -754,10 +765,11 @@ func generateInstanceName(baseName string, existingNames map[string]bool) string
 }
 
 func (client *autoscalingGceClientV1) FetchZones(region string) ([]string, error) {
-	registerRequest("regions", "get")
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
 	defer cancel()
 	r, err := client.gceService.Regions.Get(client.projectId, region).Context(ctx).Do()
+	emitGceLatency("regions", "get", r, err, start)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get zones for GCE region %s: %v", region, err)
 	}
@@ -809,30 +821,35 @@ func (client *autoscalingGceClientV1) FetchMigTemplateName(migRef GceRef) (Insta
 }
 
 func (client *autoscalingGceClientV1) FetchMigTemplate(migRef GceRef, templateName string, regional bool) (*gce.InstanceTemplate, error) {
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), client.operationPerCallTimeout)
 	defer cancel()
 	if regional {
 		zoneHyphenIndex := strings.LastIndex(migRef.Zone, "-")
 		region := migRef.Zone[:zoneHyphenIndex]
-		registerRequest("region_instance_templates", "get")
-		return client.gceService.RegionInstanceTemplates.Get(migRef.Project, region, templateName).Context(ctx).Do()
+		tmpl, err := client.gceService.RegionInstanceTemplates.Get(migRef.Project, region, templateName).Context(ctx).Do()
+		emitGceLatency("region_instance_templates", "get", tmpl, err, start)
+		return tmpl, err
 	}
-	registerRequest("instance_templates", "get")
-	return client.gceService.InstanceTemplates.Get(migRef.Project, templateName).Context(ctx).Do()
+	tmpl, err := client.gceService.InstanceTemplates.Get(migRef.Project, templateName).Context(ctx).Do()
+	emitGceLatency("instance_templates", "get", tmpl, err, start)
+	return tmpl, err
 }
 
 func (client *autoscalingGceClientV1) FetchMigsWithName(zone string, name *regexp.Regexp) ([]string, error) {
+	start := time.Now()
 	filter := fmt.Sprintf("name eq %s", name)
 	links := make([]string, 0)
-	registerRequest("instance_groups", "list")
 	req := client.gceService.InstanceGroups.List(client.projectId, zone).Filter(filter)
-	if err := req.Pages(context.TODO(), func(page *gce.InstanceGroupList) error {
+	err := req.Pages(context.TODO(), func(page *gce.InstanceGroupList) error {
 		for _, ig := range page.Items {
 			links = append(links, ig.SelfLink)
 			klog.V(3).Infof("found managed instance group %s matching regexp %s", ig.Name, name)
 		}
 		return nil
-	}); err != nil {
+	})
+	emitGceLatency("instance_groups", "list", nil, err, start)
+	if err != nil {
 		return nil, fmt.Errorf("cannot list managed instance groups: %v", err)
 	}
 	return links, nil

--- a/cluster-autoscaler/cloudprovider/gce/error_mapping.go
+++ b/cluster-autoscaler/cloudprovider/gce/error_mapping.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"google.golang.org/api/googleapi"
+	"k8s.io/klog/v2"
+)
+
+// reasonWeights contains an integer for each of the important error reasons,
+// the higher the number the more important the reason. Those outside of the
+// map will get 0, values with the same weight will be sorted lexicographically.
+var reasonWeights = map[string]int{
+	"badRequest":             1,
+	"backendError":           2,
+	"quotaExceeded":          3,
+	"insufficientCapacity":   4,
+	"requestExceedsCapacity": 5,
+}
+
+// PickReason returns the most significant reason from a list of ErrorItems.
+func PickReason(errors []googleapi.ErrorItem) string {
+	if len(errors) == 0 {
+		return ""
+	}
+	reasons := make([]string, 0, len(errors))
+	for _, err := range errors {
+		reasons = append(reasons, err.Reason)
+	}
+	sort.Slice(reasons, func(i, j int) bool {
+		iWeight := reasonWeights[reasons[i]]
+		jWeight := reasonWeights[reasons[j]]
+		if iWeight == jWeight {
+			return reasons[i] < reasons[j]
+		}
+		return iWeight > jWeight
+	})
+	return reasons[0]
+}
+
+func determineResponseStatusForLatencyMetric(rsp any, err error, withReason bool) string {
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "timeout"
+		} else if gErr, ok := err.(*googleapi.Error); ok {
+			if withReason && len(gErr.Errors) > 0 {
+				return fmt.Sprintf("%d_%s", gErr.Code, PickReason(gErr.Errors))
+			}
+			return fmt.Sprintf("%d", gErr.Code)
+		}
+		return "internal_error"
+	}
+
+	serverResponse := serverResponseFromAny(rsp)
+	if serverResponse != nil {
+		return fmt.Sprintf("%d", serverResponse.HTTPStatusCode)
+	}
+
+	// If no ServerResponse was found and there was no error, assume 200 OK
+	return "200"
+}
+
+func serverResponseFromAny(obj any) *googleapi.ServerResponse {
+	if obj == nil {
+		return nil
+	}
+	if sr, ok := obj.(*googleapi.ServerResponse); ok {
+		return sr
+	}
+	if sr, ok := obj.(googleapi.ServerResponse); ok {
+		return &sr
+	}
+
+	fieldname := "ServerResponse"
+	fieldInterface, err := structFieldByName(obj, fieldname)
+	if err != nil {
+		return nil
+	}
+	if fieldInterface == nil {
+		return nil
+	}
+	serverResponse, ok := fieldInterface.(googleapi.ServerResponse)
+	if !ok {
+		klog.V(5).Infof("Field value for fieldname %s is not of expected type googleapi.ServerResponse, but %T", fieldname, fieldInterface)
+		return nil
+	}
+	return &serverResponse
+}
+
+func structFieldByName(obj any, fieldname string) (any, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	val := reflect.ValueOf(obj)
+	if val.Kind() == reflect.Pointer {
+		if val.IsNil() {
+			return nil, nil
+		}
+		val = val.Elem()
+	}
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("type %T is not a struct", obj)
+	}
+	fieldVal := val.FieldByName(fieldname)
+	if !fieldVal.IsValid() {
+		return nil, fmt.Errorf("for struct of type %T, field value for fieldname %s is not valid", obj, fieldname)
+	}
+	if !fieldVal.CanInterface() {
+		return nil, fmt.Errorf("for struct of type %T, field value for fieldname %s is not addressable", obj, fieldname)
+	}
+	return fieldVal.Interface(), nil
+}

--- a/cluster-autoscaler/cloudprovider/gce/error_mapping_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/error_mapping_test.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/googleapi"
+)
+
+func TestPickReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		errors []googleapi.ErrorItem
+		want   string
+	}{
+		{
+			"simple test, all reasons from map",
+			[]googleapi.ErrorItem{
+				{Reason: "badRequest"},
+				{Reason: "quotaExceeded"},
+				{Reason: "requestExceedsCapacity"},
+				{Reason: "insufficientCapacity"},
+				{Reason: "backendError"},
+			},
+			"requestExceedsCapacity",
+		},
+		{
+			"simple test, some reasons from map",
+			[]googleapi.ErrorItem{
+				{Reason: "insufficientCapacity"},
+				{Reason: "badRequest"},
+			},
+			"insufficientCapacity",
+		},
+		{
+			"simple test, some reasons outside from map",
+			[]googleapi.ErrorItem{
+				{Reason: "badRequest"},
+				{Reason: "test2"},
+				{Reason: "quotaExceeded"},
+				{Reason: "test3"},
+			},
+			"quotaExceeded",
+		},
+		{
+			"simple test, all reasons outside from map",
+			[]googleapi.ErrorItem{
+				{Reason: "ctest"},
+				{Reason: "test2"},
+				{Reason: "btest"},
+				{Reason: "test2"},
+			},
+			"btest",
+		},
+		{
+			"empty list",
+			[]googleapi.ErrorItem{},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PickReason(tt.errors); got != tt.want {
+				t.Errorf("PickReason() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetermineResponseStatusForLatencyMetric(t *testing.T) {
+	type args struct {
+		rsp        any
+		err        error
+		withReason bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "simple test, nil err, nil response",
+			args: args{
+				rsp:        nil,
+				err:        nil,
+				withReason: false,
+			},
+			want: "200",
+		},
+		{
+			name: "simple test, nil err, not nil response",
+			args: args{
+				rsp: &googleapi.ServerResponse{
+					HTTPStatusCode: http.StatusOK,
+				},
+				err:        nil,
+				withReason: false,
+			},
+			want: "200",
+		},
+		{
+			name: "simple test, err is context.DeadlineExceeded",
+			args: args{
+				rsp:        nil,
+				err:        context.DeadlineExceeded,
+				withReason: false,
+			},
+			want: "timeout",
+		},
+		{
+			name: "simple test, err is context.Canceled",
+			args: args{
+				rsp:        nil,
+				err:        context.Canceled,
+				withReason: false,
+			},
+			want: "timeout",
+		},
+		{
+			name: "simple test, err is googleapi.Error",
+			args: args{
+				rsp: nil,
+				err: &googleapi.Error{
+					Code: http.StatusNotFound,
+				},
+				withReason: false,
+			},
+			want: "404",
+		},
+		{
+			name: "simple test, err is googleapi.Error, withReason is false",
+			args: args{
+				rsp: nil,
+				err: &googleapi.Error{
+					Code: http.StatusBadRequest,
+					Errors: []googleapi.ErrorItem{
+						{Reason: "quotaExceeded"},
+					},
+				},
+				withReason: false,
+			},
+			want: "400",
+		},
+		{
+			name: "simple test, err is googleapi.Error, withReason is true, with errors",
+			args: args{
+				rsp: nil,
+				err: &googleapi.Error{
+					Code: http.StatusBadRequest,
+					Errors: []googleapi.ErrorItem{
+						{Reason: "badRequest"},
+						{Reason: "SomeRandomString"},
+						{Reason: "quotaExceeded"},
+					},
+				},
+				withReason: true,
+			},
+			want: "400_quotaExceeded",
+		},
+		{
+			name: "simple test, err is unknown error",
+			args: args{
+				rsp:        nil,
+				err:        errors.New("some other error"),
+				withReason: false,
+			},
+			want: "internal_error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineResponseStatusForLatencyMetric(tt.args.rsp, tt.args.err, tt.args.withReason)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStructFieldByName(t *testing.T) {
+	type testStruct struct {
+		ExportedField   string
+		unexportedField string
+	}
+
+	testCases := []struct {
+		name        string
+		obj         any
+		fieldname   string
+		expectedVal any
+		expectedErr bool
+	}{
+		{
+			name: "get exported field from struct",
+			obj: testStruct{
+				ExportedField:   "exported value",
+				unexportedField: "unexported value",
+			},
+			fieldname:   "ExportedField",
+			expectedVal: "exported value",
+			expectedErr: false,
+		},
+		{
+			name: "get exported field from pointer to struct",
+			obj: &testStruct{
+				ExportedField:   "exported value",
+				unexportedField: "unexported value",
+			},
+			fieldname:   "ExportedField",
+			expectedVal: "exported value",
+			expectedErr: false,
+		},
+		{
+			name:        "nil object",
+			obj:         nil,
+			fieldname:   "ExportedField",
+			expectedVal: nil,
+			expectedErr: false,
+		},
+		{
+			name:        "nil pointer to struct",
+			obj:         (*testStruct)(nil),
+			fieldname:   "ExportedField",
+			expectedVal: nil,
+			expectedErr: false,
+		},
+		{
+			name:        "not a struct",
+			obj:         "this is a string",
+			fieldname:   "ExportedField",
+			expectedVal: nil,
+			expectedErr: true,
+		},
+		{
+			name: "field does not exist",
+			obj: testStruct{
+				ExportedField:   "exported value",
+				unexportedField: "unexported value",
+			},
+			fieldname:   "NonExistentField",
+			expectedVal: nil,
+			expectedErr: true,
+		},
+		{
+			name: "unexported field",
+			obj: testStruct{
+				ExportedField:   "exported value",
+				unexportedField: "unexported value",
+			},
+			fieldname:   "unexportedField",
+			expectedVal: nil,
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := structFieldByName(tc.obj, tc.fieldname)
+			assert.Equal(t, tc.expectedVal, val)
+			if tc.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServerResponseFromAny(t *testing.T) {
+	type structWithServerResponse struct {
+		ServerResponse googleapi.ServerResponse
+	}
+
+	type structWithWrongType struct {
+		ServerResponse string
+	}
+
+	type structWithoutServerResponse struct {
+		SomeOtherField string
+	}
+
+	testCases := []struct {
+		name     string
+		obj      any
+		expected *googleapi.ServerResponse
+	}{
+		{
+			name: "struct with ServerResponse",
+			obj: &structWithServerResponse{
+				ServerResponse: googleapi.ServerResponse{
+					HTTPStatusCode: 200,
+				},
+			},
+			expected: &googleapi.ServerResponse{
+				HTTPStatusCode: 200,
+			},
+		},
+		{
+			name: "direct ServerResponse struct",
+			obj: googleapi.ServerResponse{
+				HTTPStatusCode: 200,
+			},
+			expected: &googleapi.ServerResponse{
+				HTTPStatusCode: 200,
+			},
+		},
+		{
+			name: "direct ServerResponse pointer",
+			obj: &googleapi.ServerResponse{
+				HTTPStatusCode: 200,
+			},
+			expected: &googleapi.ServerResponse{
+				HTTPStatusCode: 200,
+			},
+		},
+		{
+			name: "struct with wrong type for ServerResponse",
+			obj: &structWithWrongType{
+				ServerResponse: "not a server response",
+			},
+			expected: nil,
+		},
+		{
+			name: "struct without ServerResponse field",
+			obj: &structWithoutServerResponse{
+				SomeOtherField: "some value",
+			},
+			expected: nil,
+		},
+		{
+			name:     "nil object",
+			obj:      nil,
+			expected: nil,
+		},
+		{
+			name:     "nil pointer to struct",
+			obj:      (*structWithServerResponse)(nil),
+			expected: nil,
+		},
+		{
+			name:     "not a struct",
+			obj:      "this is a string",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := serverResponseFromAny(tc.obj)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/cluster-autoscaler/cloudprovider/gce/gce_metrics.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gce
 
 import (
+	"time"
+
 	k8smetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -31,17 +33,47 @@ var (
 		&k8smetrics.CounterOpts{
 			Namespace: caNamespace,
 			Name:      "gce_request_count",
-			Help:      "Counter of GCE API requests for each verb and API resource.",
+			Help:      "Deprecated: Counter of GCE API requests for each verb and API resource. Use request_latencies instead.",
 		}, []string{"resource", "verb"},
+	)
+
+	requestLatencies = k8smetrics.NewHistogramVec(
+		&k8smetrics.HistogramOpts{
+			Namespace: caNamespace,
+			Name:      "request_latencies",
+			Help:      "Latencies of requests made by Cluster Autoscaler, measured in seconds.",
+			Buckets: []float64{
+				0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128,
+				256, 512, 1024, 2048, 4096,
+			},
+		}, []string{"service", "resource", "verb", "status"},
 	)
 )
 
 // RegisterMetrics registers all GCE metrics.
 func RegisterMetrics() {
 	legacyregistry.MustRegister(requestCounter)
+	legacyregistry.MustRegister(requestLatencies)
 }
 
 // registerRequest registers request to GCE API.
 func registerRequest(resource string, verb string) {
 	requestCounter.WithLabelValues(resource, verb).Add(1.0)
+}
+
+// EmitRequestLatencyMetric emits to request_latencies histogram metric.
+// It is exported to allow downstream GKE cloudprovider packages to emit
+// latency metrics with appropriate service labels ("gce", "gke", "service_control").
+func EmitRequestLatencyMetric(service, resource, verb string, response any, err error, start time.Time, withReason bool) {
+	duration := time.Since(start)
+	status := determineResponseStatusForLatencyMetric(response, err, withReason)
+	requestLatencies.WithLabelValues(service, resource, verb, status).Observe(duration.Seconds())
+	if service == "gce" {
+		registerRequest(resource, verb)
+	}
+}
+
+// emitGceLatency emits both request latency and legacy request counter for GCE API calls.
+func emitGceLatency(resource, verb string, response any, err error, start time.Time) {
+	EmitRequestLatencyMetric("gce", resource, verb, response, err, start, false)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add the `request_latencies` histogram metric in the GCE cloudprovider to measure latency and track response statuses (HTTP status codes, timeout, internal_error) for all GCE API calls.
This deprecates `gce_request_count`, while maintaining dual-emission during the transition period for backwards compatibility. Summary of changes:
- Register `request_latencies` histogram metric (`service`, `resource`, `verb`, `status`).
- Mark `gce_request_count` as deprecated in description comments.
- Add error and HTTP status extraction helper (`error_mapping.go`) with unit tests.
- Export `EmitRequestLatencyMetric` to allow cloudprovider extensions to record latency.
- Instrument all GCE client calls in `autoscaling_gce_client.go` with latency tracking.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed latency monitoring for Google Cloud API requests.
  * Metrics now include the service, resource type, operation, response status, and request duration.
  * Error metrics provide more consistent status and reason information across Google Cloud API responses.

* **Bug Fixes**
  * Improved classification of Google Cloud API errors, including responses returned through different error formats.

* **Tests**
  * Added coverage for latency status reporting, error-reason selection, and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->