### PR TITLE
VPA: add e2e coverage for --pod-recommendation-min-cpu-millicores

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/integration/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/integration/recommender.go
@@ -114,6 +114,42 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 		gomega.Expect(memoryMb).Should(gomega.BeNumerically(">=", minMemoryMb),
 			"recommended memory should respect the --pod-recommendation-min-memory-mb floor even though actual usage is far below it")
 	})
+
+	ginkgo.It("starts recommender with --pod-recommendation-min-cpu-millicores parameter", func() {
+		const minCPUMillicores = 500
+
+		ginkgo.By("Setting up VPA deployment")
+		f.Namespace.Name = utils.VpaNamespace
+		vpaDeployment := utils.NewVPADeployment(f, []string{
+			"--recommender-interval=10s",
+			fmt.Sprintf("--pod-recommendation-min-cpu-millicores=%d", minCPUMillicores),
+		})
+		utils.StartDeploymentPods(f, vpaDeployment)
+
+		ginkgo.By("Setting up a hamster deployment")
+		f.Namespace.Name = hamsterNamespace
+		d := utils.NewNHamstersDeployment(f, 1)
+		_ = utils.StartDeploymentPods(f, d)
+
+		ginkgo.By("Setting up VPA")
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("hamster-vpa").
+			WithNamespace(hamsterNamespace).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithContainer(containerName).
+			Get()
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Waiting for recommendation to be filled")
+		vpa, err := utils.WaitForRecommendationPresent(vpaClientSet, vpaCRD)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(vpa.Status.Recommendation.ContainerRecommendations).Should(gomega.HaveLen(1))
+
+		cpuMillicores := vpa.Status.Recommendation.ContainerRecommendations[0].Target.Cpu().MilliValue()
+		gomega.Expect(cpuMillicores).Should(gomega.BeNumerically(">=", minCPUMillicores),
+			"recommended CPU should respect the --pod-recommendation-min-cpu-millicores floor even though actual usage is far below it")
+	})
 })
 
 // Create VPA and deployment in 2 namespaces, 1 should be ignored


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The VPA recommender flags e2e suite only ever exercises `--pod-recommendation-min-memory-mb` beyond the namespace filtering flags, per #10243. Every other recommender flag, including its direct CPU counterpart, is still only exercised with its default value. This adds a test that starts the recommender with `--pod-recommendation-min-cpu-millicores` set well above what the test workload actually uses, and asserts the resulting recommendation respects that floor, mirroring the memory test exactly.

#### Which issue(s) this PR fixes:

Part of #7723

#### Special notes for your reviewer:

This adds one additional flag to the suite rather than trying to cover every recommender flag in one PR, to keep the change reviewable, matching #10243's approach. Verified locally that the test compiles and vets cleanly (`go build ./e2e/...`, `go vet ./e2e/integration/...`, `go test -c ./e2e/integration/...` from `vertical-pod-autoscaler/test`); running it end to end requires a kind cluster via the existing e2e harness.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test verifying that CPU recommendations respect the configured minimum of 500 millicores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->