### PR TITLE
Modify NewVPADeployment into a generic VPA component deployment factory

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/integration/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/integration/recommender.go
@@ -55,10 +55,10 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		f.Namespace.Name = utils.VpaNamespace
-		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(), []string{
+		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(
 			"--recommender-interval=10s",
 			fmt.Sprintf("--vpa-object-namespace=%s", hamsterNamespace),
-		})
+		))
 		utils.StartDeploymentPods(f, vpaDeployment)
 
 		testIncludedAndIgnoredNamespaces(f, vpaClientSet, hamsterNamespace, ignoredNamespace.Name)
@@ -70,10 +70,10 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		f.Namespace.Name = utils.VpaNamespace
-		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(), []string{
+		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(
 			"--recommender-interval=10s",
 			fmt.Sprintf("--ignored-vpa-object-namespaces=%s", ignoredNamespace.Name),
-		})
+		))
 		utils.StartDeploymentPods(f, vpaDeployment)
 
 		testIncludedAndIgnoredNamespaces(f, vpaClientSet, hamsterNamespace, ignoredNamespace.Name)
@@ -84,10 +84,10 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 
 		ginkgo.By("Setting up VPA deployment")
 		f.Namespace.Name = utils.VpaNamespace
-		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(), []string{
+		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(
 			"--recommender-interval=10s",
 			fmt.Sprintf("--pod-recommendation-min-memory-mb=%d", minMemoryMb),
-		})
+		))
 		utils.StartDeploymentPods(f, vpaDeployment)
 
 		ginkgo.By("Setting up a hamster deployment")

--- a/vertical-pod-autoscaler/test/e2e/integration/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/integration/recommender.go
@@ -55,7 +55,7 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		f.Namespace.Name = utils.VpaNamespace
-		vpaDeployment := utils.NewVPADeployment(f, []string{
+		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(), []string{
 			"--recommender-interval=10s",
 			fmt.Sprintf("--vpa-object-namespace=%s", hamsterNamespace),
 		})
@@ -70,7 +70,7 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		f.Namespace.Name = utils.VpaNamespace
-		vpaDeployment := utils.NewVPADeployment(f, []string{
+		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(), []string{
 			"--recommender-interval=10s",
 			fmt.Sprintf("--ignored-vpa-object-namespaces=%s", ignoredNamespace.Name),
 		})
@@ -84,7 +84,7 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 
 		ginkgo.By("Setting up VPA deployment")
 		f.Namespace.Name = utils.VpaNamespace
-		vpaDeployment := utils.NewVPADeployment(f, []string{
+		vpaDeployment := utils.NewVPAComponentDeployment(f, utils.RecommenderComponentConfig(), []string{
 			"--recommender-interval=10s",
 			fmt.Sprintf("--pod-recommendation-min-memory-mb=%d", minMemoryMb),
 		})

--- a/vertical-pod-autoscaler/test/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/test/e2e/utils/common.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 	framework_deployment "k8s.io/kubernetes/test/e2e/framework/deployment"
@@ -173,27 +174,34 @@ type VPAComponentConfig struct {
 	// MetricsPort is the port serving prometheus metrics and health checks,
 	// e.g. 8942 for the recommender. Must be within 1-65535. Required.
 	MetricsPort int32
+	// Flags are the command line flags of the component,
+	// e.g. "--recommender-interval=10s".
+	Flags []string
 }
 
 // RecommenderComponentConfig returns a VPAComponentConfig for deploying the
 // VPA recommender in e2e tests, mirroring deploy/recommender-deployment.yaml.
-func RecommenderComponentConfig() VPAComponentConfig {
+func RecommenderComponentConfig(flags ...string) VPAComponentConfig {
 	return VPAComponentConfig{
 		ComponentName: recommenderComponent,
 		Image:         "localhost:5001/vpa-recommender",
 		MetricsPort:   8942,
+		Flags:         flags,
 	}
 }
 
-// NewVPAComponentDeployment creates a deployment of a VPA component with the
-// provided command line flags, for e2e test purposes.
-func NewVPAComponentDeployment(f *framework.Framework, config VPAComponentConfig, flags []string) *appsv1.Deployment {
-	gomega.Expect(config.ComponentName).NotTo(gomega.BeEmpty(), "VPAComponentConfig.ComponentName must be set")
+// NewVPAComponentDeployment creates a deployment of a VPA component for e2e
+// test purposes.
+func NewVPAComponentDeployment(f *framework.Framework, config VPAComponentConfig) *appsv1.Deployment {
+	gomega.Expect(utilvalidation.IsDNS1123Label(config.ComponentName)).To(gomega.BeEmpty(),
+		"VPAComponentConfig.ComponentName must be a valid DNS-1123 label (got %q)", config.ComponentName)
+	deploymentName := fmt.Sprintf("vpa-%s", config.ComponentName)
+	gomega.Expect(utilvalidation.IsDNS1123Label(deploymentName)).To(gomega.BeEmpty(),
+		"deployment name %q derived from ComponentName must be a valid DNS-1123 label", deploymentName)
 	gomega.Expect(config.Image).NotTo(gomega.BeEmpty(), "VPAComponentConfig.Image must be set")
 	gomega.Expect(config.MetricsPort).Should(gomega.SatisfyAll(gomega.BeNumerically(">=", 1), gomega.BeNumerically("<=", 65535)),
 		"VPAComponentConfig.MetricsPort must be set to a valid port number (1-65535)")
 
-	deploymentName := fmt.Sprintf("vpa-%s", config.ComponentName)
 	d := framework_deployment.NewDeployment(
 		deploymentName,                           /*deploymentName*/
 		1,                                        /*replicas*/
@@ -206,7 +214,7 @@ func NewVPAComponentDeployment(f *framework.Framework, config VPAComponentConfig
 	d.Spec.Template.Spec.Containers[0].ImagePullPolicy = apiv1.PullNever // Image must be loaded first
 	d.Spec.Template.Spec.ServiceAccountName = deploymentName
 	d.Spec.Template.Spec.Containers[0].Command = []string{fmt.Sprintf("/%s", config.ComponentName)}
-	d.Spec.Template.Spec.Containers[0].Args = flags
+	d.Spec.Template.Spec.Containers[0].Args = config.Flags
 
 	runAsNonRoot := true
 	var runAsUser int64 = 65534 // nobody

--- a/vertical-pod-autoscaler/test/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/test/e2e/utils/common.go
@@ -159,35 +159,20 @@ func PatchVpaRecommendation(f *framework.Framework, vpa *vpa_types.VerticalPodAu
 }
 
 // VPAComponentConfig describes a VPA component to deploy for e2e test
-// purposes. It currently covers what the recommender deployment needs;
-// extend it when a component requires extra wiring, such as the TLS
-// volumes of the admission controller.
+// purposes. Extend it when a component requires extra wiring, such as the
+// TLS volumes of the admission controller.
 type VPAComponentConfig struct {
 	// ComponentName is the short name of the component, e.g. "recommender".
-	// It is used as the container name and to build defaults for the fields
-	// left empty.
+	// The deployment name and service account are "vpa-" + ComponentName,
+	// the container name and command are "/" + ComponentName, mirroring the
+	// manifests in deploy/.
 	ComponentName string
-	// DeploymentName is the name of the deployment, e.g. "vpa-recommender".
-	// Defaults to "vpa-" + ComponentName.
-	DeploymentName string
 	// Image is the container image to run, e.g. "localhost:5001/vpa-recommender".
 	// Required.
 	Image string
-	// Command is the container command, e.g. []string{"/recommender"}.
-	// Defaults to []string{"/" + ComponentName}.
-	Command []string
-	// ServiceAccountName is the service account to run the component with.
-	// Defaults to "vpa-" + ComponentName.
-	ServiceAccountName string
-	// MetricsPortName is the name of the port serving prometheus metrics and
-	// health checks. Defaults to "prometheus".
-	MetricsPortName string
 	// MetricsPort is the port serving prometheus metrics and health checks,
 	// e.g. 8942 for the recommender. Must be within 1-65535. Required.
 	MetricsPort int32
-	// ProbePath is the HTTP path of the liveness and readiness probes.
-	// Defaults to "/health-check".
-	ProbePath string
 }
 
 // RecommenderComponentConfig returns a VPAComponentConfig for deploying the
@@ -205,43 +190,22 @@ func RecommenderComponentConfig() VPAComponentConfig {
 func NewVPAComponentDeployment(f *framework.Framework, config VPAComponentConfig, flags []string) *appsv1.Deployment {
 	gomega.Expect(config.ComponentName).NotTo(gomega.BeEmpty(), "VPAComponentConfig.ComponentName must be set")
 	gomega.Expect(config.Image).NotTo(gomega.BeEmpty(), "VPAComponentConfig.Image must be set")
-	gomega.Expect(config.MetricsPort).Should(gomega.BeNumerically(">=", 1), "VPAComponentConfig.MetricsPort must be set to a valid port number (1-65535)")
-	gomega.Expect(config.MetricsPort).Should(gomega.BeNumerically("<=", 65535), "VPAComponentConfig.MetricsPort must be set to a valid port number (1-65535)")
+	gomega.Expect(config.MetricsPort).Should(gomega.SatisfyAll(gomega.BeNumerically(">=", 1), gomega.BeNumerically("<=", 65535)),
+		"VPAComponentConfig.MetricsPort must be set to a valid port number (1-65535)")
 
-	deploymentName := config.DeploymentName
-	if deploymentName == "" {
-		deploymentName = fmt.Sprintf("vpa-%s", config.ComponentName)
-	}
-	labels := map[string]string{"app": deploymentName}
-	serviceAccountName := config.ServiceAccountName
-	if serviceAccountName == "" {
-		serviceAccountName = fmt.Sprintf("vpa-%s", config.ComponentName)
-	}
-	command := config.Command
-	if len(command) == 0 {
-		command = []string{fmt.Sprintf("/%s", config.ComponentName)}
-	}
-	metricsPortName := config.MetricsPortName
-	if metricsPortName == "" {
-		metricsPortName = "prometheus"
-	}
-	probePath := config.ProbePath
-	if probePath == "" {
-		probePath = "/health-check"
-	}
-
+	deploymentName := fmt.Sprintf("vpa-%s", config.ComponentName)
 	d := framework_deployment.NewDeployment(
-		deploymentName,       /*deploymentName*/
-		1,                    /*replicas*/
-		labels,               /*podLabels*/
-		config.ComponentName, /*imageName*/
-		config.Image,         /*image*/
+		deploymentName,                           /*deploymentName*/
+		1,                                        /*replicas*/
+		map[string]string{"app": deploymentName}, /*podLabels*/
+		config.ComponentName,                     /*imageName*/
+		config.Image,                             /*image*/
 		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
 	d.Spec.Template.Spec.Containers[0].ImagePullPolicy = apiv1.PullNever // Image must be loaded first
-	d.Spec.Template.Spec.ServiceAccountName = serviceAccountName
-	d.Spec.Template.Spec.Containers[0].Command = command
+	d.Spec.Template.Spec.ServiceAccountName = deploymentName
+	d.Spec.Template.Spec.Containers[0].Command = []string{fmt.Sprintf("/%s", config.ComponentName)}
 	d.Spec.Template.Spec.Containers[0].Args = flags
 
 	runAsNonRoot := true
@@ -264,15 +228,15 @@ func NewVPAComponentDeployment(f *framework.Framework, config VPAComponentConfig
 	}
 
 	d.Spec.Template.Spec.Containers[0].Ports = []apiv1.ContainerPort{{
-		Name:          metricsPortName,
+		Name:          "prometheus",
 		ContainerPort: config.MetricsPort,
 	}}
 
 	d.Spec.Template.Spec.Containers[0].LivenessProbe = &apiv1.Probe{
 		ProbeHandler: apiv1.ProbeHandler{
 			HTTPGet: &apiv1.HTTPGetAction{
-				Path:   probePath,
-				Port:   intstr.FromString(metricsPortName),
+				Path:   "/health-check",
+				Port:   intstr.FromString("prometheus"),
 				Scheme: apiv1.URISchemeHTTP,
 			},
 		},
@@ -283,8 +247,8 @@ func NewVPAComponentDeployment(f *framework.Framework, config VPAComponentConfig
 	d.Spec.Template.Spec.Containers[0].ReadinessProbe = &apiv1.Probe{
 		ProbeHandler: apiv1.ProbeHandler{
 			HTTPGet: &apiv1.HTTPGetAction{
-				Path:   probePath,
-				Port:   intstr.FromString(metricsPortName),
+				Path:   "/health-check",
+				Port:   intstr.FromString("prometheus"),
 				Scheme: apiv1.URISchemeHTTP,
 			},
 		},

--- a/vertical-pod-autoscaler/test/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/test/e2e/utils/common.go
@@ -158,8 +158,10 @@ func PatchVpaRecommendation(f *framework.Framework, vpa *vpa_types.VerticalPodAu
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch VPA.")
 }
 
-// VPAComponentConfig describes a VPA component (recommender, updater or
-// admission controller) to deploy for e2e test purposes.
+// VPAComponentConfig describes a VPA component to deploy for e2e test
+// purposes. It currently covers what the recommender deployment needs;
+// extend it when a component requires extra wiring, such as the TLS
+// volumes of the admission controller.
 type VPAComponentConfig struct {
 	// ComponentName is the short name of the component, e.g. "recommender".
 	// It is used as the container name and to build defaults for the fields
@@ -181,7 +183,7 @@ type VPAComponentConfig struct {
 	// health checks. Defaults to "prometheus".
 	MetricsPortName string
 	// MetricsPort is the port serving prometheus metrics and health checks,
-	// e.g. 8942 for the recommender. Required.
+	// e.g. 8942 for the recommender. Must be within 1-65535. Required.
 	MetricsPort int32
 	// ProbePath is the HTTP path of the liveness and readiness probes.
 	// Defaults to "/health-check".
@@ -198,13 +200,13 @@ func RecommenderComponentConfig() VPAComponentConfig {
 	}
 }
 
-// NewVPAComponentDeployment creates a deployment of a VPA component
-// (recommender, updater or admission controller) with the provided command
-// line flags, for e2e test purposes.
+// NewVPAComponentDeployment creates a deployment of a VPA component with the
+// provided command line flags, for e2e test purposes.
 func NewVPAComponentDeployment(f *framework.Framework, config VPAComponentConfig, flags []string) *appsv1.Deployment {
 	gomega.Expect(config.ComponentName).NotTo(gomega.BeEmpty(), "VPAComponentConfig.ComponentName must be set")
 	gomega.Expect(config.Image).NotTo(gomega.BeEmpty(), "VPAComponentConfig.Image must be set")
-	gomega.Expect(config.MetricsPort).NotTo(gomega.BeZero(), "VPAComponentConfig.MetricsPort must be set")
+	gomega.Expect(config.MetricsPort).Should(gomega.BeNumerically(">=", 1), "VPAComponentConfig.MetricsPort must be set to a valid port number (1-65535)")
+	gomega.Expect(config.MetricsPort).Should(gomega.BeNumerically("<=", 65535), "VPAComponentConfig.MetricsPort must be set to a valid port number (1-65535)")
 
 	deploymentName := config.DeploymentName
 	if deploymentName == "" {

--- a/vertical-pod-autoscaler/test/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/test/e2e/utils/common.go
@@ -75,9 +75,6 @@ var HamsterTargetRef = &autoscaling.CrossVersionObjectReference{
 	Name:       "hamster-deployment",
 }
 
-// RecommenderLabels are labels of VPA recommender
-var RecommenderLabels = map[string]string{"app": "vpa-recommender"}
-
 // HamsterLabels are labels of hamster app
 var HamsterLabels = map[string]string{"app": "hamster"}
 
@@ -161,21 +158,88 @@ func PatchVpaRecommendation(f *framework.Framework, vpa *vpa_types.VerticalPodAu
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch VPA.")
 }
 
-// NewVPADeployment creates a VPA deployment with n containers
-// for e2e test purposes.
-func NewVPADeployment(f *framework.Framework, flags []string) *appsv1.Deployment {
+// VPAComponentConfig describes a VPA component (recommender, updater or
+// admission controller) to deploy for e2e test purposes.
+type VPAComponentConfig struct {
+	// ComponentName is the short name of the component, e.g. "recommender".
+	// It is used as the container name and to build defaults for the fields
+	// left empty.
+	ComponentName string
+	// DeploymentName is the name of the deployment, e.g. "vpa-recommender".
+	// Defaults to "vpa-" + ComponentName.
+	DeploymentName string
+	// Image is the container image to run, e.g. "localhost:5001/vpa-recommender".
+	// Required.
+	Image string
+	// Command is the container command, e.g. []string{"/recommender"}.
+	// Defaults to []string{"/" + ComponentName}.
+	Command []string
+	// ServiceAccountName is the service account to run the component with.
+	// Defaults to "vpa-" + ComponentName.
+	ServiceAccountName string
+	// MetricsPortName is the name of the port serving prometheus metrics and
+	// health checks. Defaults to "prometheus".
+	MetricsPortName string
+	// MetricsPort is the port serving prometheus metrics and health checks,
+	// e.g. 8942 for the recommender. Required.
+	MetricsPort int32
+	// ProbePath is the HTTP path of the liveness and readiness probes.
+	// Defaults to "/health-check".
+	ProbePath string
+}
+
+// RecommenderComponentConfig returns a VPAComponentConfig for deploying the
+// VPA recommender in e2e tests, mirroring deploy/recommender-deployment.yaml.
+func RecommenderComponentConfig() VPAComponentConfig {
+	return VPAComponentConfig{
+		ComponentName: recommenderComponent,
+		Image:         "localhost:5001/vpa-recommender",
+		MetricsPort:   8942,
+	}
+}
+
+// NewVPAComponentDeployment creates a deployment of a VPA component
+// (recommender, updater or admission controller) with the provided command
+// line flags, for e2e test purposes.
+func NewVPAComponentDeployment(f *framework.Framework, config VPAComponentConfig, flags []string) *appsv1.Deployment {
+	gomega.Expect(config.ComponentName).NotTo(gomega.BeEmpty(), "VPAComponentConfig.ComponentName must be set")
+	gomega.Expect(config.Image).NotTo(gomega.BeEmpty(), "VPAComponentConfig.Image must be set")
+	gomega.Expect(config.MetricsPort).NotTo(gomega.BeZero(), "VPAComponentConfig.MetricsPort must be set")
+
+	deploymentName := config.DeploymentName
+	if deploymentName == "" {
+		deploymentName = fmt.Sprintf("vpa-%s", config.ComponentName)
+	}
+	labels := map[string]string{"app": deploymentName}
+	serviceAccountName := config.ServiceAccountName
+	if serviceAccountName == "" {
+		serviceAccountName = fmt.Sprintf("vpa-%s", config.ComponentName)
+	}
+	command := config.Command
+	if len(command) == 0 {
+		command = []string{fmt.Sprintf("/%s", config.ComponentName)}
+	}
+	metricsPortName := config.MetricsPortName
+	if metricsPortName == "" {
+		metricsPortName = "prometheus"
+	}
+	probePath := config.ProbePath
+	if probePath == "" {
+		probePath = "/health-check"
+	}
+
 	d := framework_deployment.NewDeployment(
-		RecommenderDeploymentName,        /*deploymentName*/
-		1,                                /*replicas*/
-		RecommenderLabels,                /*podLabels*/
-		"recommender",                    /*imageName*/
-		"localhost:5001/vpa-recommender", /*image*/
+		deploymentName,       /*deploymentName*/
+		1,                    /*replicas*/
+		labels,               /*podLabels*/
+		config.ComponentName, /*imageName*/
+		config.Image,         /*image*/
 		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
 	d.Spec.Template.Spec.Containers[0].ImagePullPolicy = apiv1.PullNever // Image must be loaded first
-	d.Spec.Template.Spec.ServiceAccountName = "vpa-recommender"
-	d.Spec.Template.Spec.Containers[0].Command = []string{"/recommender"}
+	d.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+	d.Spec.Template.Spec.Containers[0].Command = command
 	d.Spec.Template.Spec.Containers[0].Args = flags
 
 	runAsNonRoot := true
@@ -185,7 +249,7 @@ func NewVPADeployment(f *framework.Framework, flags []string) *appsv1.Deployment
 		RunAsUser:    &runAsUser,
 	}
 
-	// Same as deploy/recommender-deployment.yaml
+	// Same as deploy/recommender-deployment.yaml and deploy/updater-deployment.yaml
 	d.Spec.Template.Spec.Containers[0].Resources = apiv1.ResourceRequirements{
 		Limits: apiv1.ResourceList{
 			apiv1.ResourceCPU:    resource.MustParse("200m"),
@@ -198,15 +262,15 @@ func NewVPADeployment(f *framework.Framework, flags []string) *appsv1.Deployment
 	}
 
 	d.Spec.Template.Spec.Containers[0].Ports = []apiv1.ContainerPort{{
-		Name:          "prometheus",
-		ContainerPort: 8942,
+		Name:          metricsPortName,
+		ContainerPort: config.MetricsPort,
 	}}
 
 	d.Spec.Template.Spec.Containers[0].LivenessProbe = &apiv1.Probe{
 		ProbeHandler: apiv1.ProbeHandler{
 			HTTPGet: &apiv1.HTTPGetAction{
-				Path:   "/health-check",
-				Port:   intstr.FromString("prometheus"),
+				Path:   probePath,
+				Port:   intstr.FromString(metricsPortName),
 				Scheme: apiv1.URISchemeHTTP,
 			},
 		},
@@ -217,8 +281,8 @@ func NewVPADeployment(f *framework.Framework, flags []string) *appsv1.Deployment
 	d.Spec.Template.Spec.Containers[0].ReadinessProbe = &apiv1.Probe{
 		ProbeHandler: apiv1.ProbeHandler{
 			HTTPGet: &apiv1.HTTPGetAction{
-				Path:   "/health-check",
-				Port:   intstr.FromString("prometheus"),
+				Path:   probePath,
+				Port:   intstr.FromString(metricsPortName),
 				Scheme: apiv1.URISchemeHTTP,
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`NewVPADeployment` in `vertical-pod-autoscaler/test/e2e/utils/common.go` was named generically but hardcoded everything for the recommender (deployment name, image, command, service account, port and probe paths). This is misleading and would encourage copy-paste duplication once integration tests need to deploy other VPA components such as the updater or the admission controller.

This PR replaces it with a generic, configurable factory:

- `VPAComponentConfig` describes the component to deploy: `ComponentName`, `Image`, `MetricsPort` and `Flags` — everything that varies per component or per test.
- `NewVPAComponentDeployment(f, config)` builds the deployment. Everything else is either derived from `ComponentName` (deployment name, service account `vpa-<component>`, command `/<component>`) or identical across components (prometheus port name, `/health-check` probe path), mirroring the manifests in `deploy/`. Config is validated with gomega assertions (DNS-1123 label naming, non-empty image, port range), consistent with the surrounding test utilities.
- `RecommenderComponentConfig(flags ...string)` preserves the exact previous recommender behavior (image `localhost:5001/vpa-recommender`, metrics port 8942).
- The only caller, `test/e2e/integration/recommender.go`, is migrated, and the now-unused `RecommenderLabels` package variable is removed (`RecommenderDeploymentName` stays, as it is still used by the tests' cleanup).

Deployment behavior (replicas, security context, resources, probes, `ImagePullPolicy: Never`, and the `StartDeploymentPods` flow) is unchanged, so this is a pure refactor with no functional change to the tests.

#### Which issue(s) this PR fixes:

Fixes #10244

#### Special notes for your reviewer:

Verified locally: `gofmt -s`, `go build ./...`, `go vet ./e2e/...` and `go test -run=None ./...` all pass in `vertical-pod-autoscaler/test`; `go mod tidy -diff` is clean for both modules (no dependency changes).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end tests for recommender configuration flags, including namespace filtering and minimum memory recommendation settings.
  * Standardized deployment configuration across Vertical Pod Autoscaler components used in integration tests.
  * Added validation for component names, container images, metrics ports, and health-check settings in test deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->