### PR TITLE
Ignore Go minor releases for VPA release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+
 ### VPA master branch
 - package-ecosystem: gomod
   directories:
@@ -45,6 +46,7 @@ updates:
       update-types:
         - "minor"
         - "patch"
+
 ### VPA release 1.7 branch
 - package-ecosystem: gomod
   target-branch: vpa-release-1.7
@@ -85,8 +87,8 @@ updates:
   groups:
     actions:
       update-types:
-        - "minor"
         - "patch"
+
 ### Addon-resizer
 - package-ecosystem: gomod
   directory: "/addon-resizer"
@@ -107,6 +109,7 @@ updates:
     - "area/dependency"
     - "release-note-none"
     - "ok-to-test"
+
 # Go - Cluster Autoscaler
 - directory: "/cluster-autoscaler"
   package-ecosystem: "gomod"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Dependabot made this PR: https://github.com/kubernetes/autoscaler/pull/10222

It's not the type of change we want, since release branches only get patch updates 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area vertical-pod-autoscaler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Dependency updates for the VPA 1.7 release branch are now limited to patch-level Docker updates.
  - Improved formatting and spacing in dependency update configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->