### PR TITLE
vpa: add TargetConflict status condition for VPAs targeting the same object

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -183,6 +183,9 @@ subjects:
   - kind: ServiceAccount
     name: vpa-recommender
     namespace: kube-system
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -435,6 +435,10 @@ var (
 	// ConfigUnsupported indicates that this VPA configuration is unsupported
 	// and recommendations will not be provided for it.
 	ConfigUnsupported VerticalPodAutoscalerConditionType = "ConfigUnsupported"
+	// TargetConflict indicates that multiple VerticalPodAutoscaler objects with an
+	// active update mode are targeting the same object, which can cause
+	// unpredictable behavior in the admission controller and updater.
+	TargetConflict VerticalPodAutoscalerConditionType = "TargetConflict"
 )
 
 // VerticalPodAutoscalerCondition describes the state of

--- a/vertical-pod-autoscaler/pkg/updater/logic/target_conflict.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/target_conflict.go
@@ -19,7 +19,6 @@ package logic
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,15 +42,18 @@ const noTargetConflictReason = "NoConflictingActiveVPATargets"
 // actually controls a pod (see vpa_api_util.Stronger for that logic).
 func (u *updater) reconcileTargetConflicts(vpaList []*vpa_types.VerticalPodAutoscaler) {
 	groups := make(map[string][]*vpa_types.VerticalPodAutoscaler)
+	var ineligible []*vpa_types.VerticalPodAutoscaler
 	for _, vpa := range vpaList {
 		if slices.Contains(u.ignoredNamespaces, vpa.Namespace) {
 			continue
 		}
 		if vpa.Spec.TargetRef == nil {
+			ineligible = append(ineligible, vpa)
 			continue
 		}
 		// "Off" VPAs don't update pods at all, so they can't conflict.
 		if vpa_api_util.GetUpdateMode(vpa) == vpa_types.UpdateModeOff {
+			ineligible = append(ineligible, vpa)
 			continue
 		}
 		key := vpa_api_util.TargetRefIndexKey(vpa.Namespace, vpa.Spec.TargetRef.Kind, vpa.Spec.TargetRef.Name)
@@ -66,12 +68,21 @@ func (u *updater) reconcileTargetConflicts(vpaList []*vpa_types.VerticalPodAutos
 			for _, vpa := range group {
 				names = append(names, vpa.Name)
 			}
-			sort.Strings(names)
+			slices.Sort(names)
 			message = fmt.Sprintf("Conflict: multiple active VPAs target the same object: %s", strings.Join(names, ", "))
 		}
 		for _, vpa := range group {
 			u.updateTargetConflictCondition(vpa, conflicting, message)
 		}
+	}
+
+	// VPAs that became ineligible (e.g. switched to Off, or dropped their
+	// targetRef) may still be carrying a stale TargetConflict=True condition
+	// from a previous run. Clear it since they can no longer be part of a
+	// conflict. updateTargetConflictCondition is a no-op if there was never
+	// a condition to begin with.
+	for _, vpa := range ineligible {
+		u.updateTargetConflictCondition(vpa, false, "")
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/updater/logic/target_conflict.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/target_conflict.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+)
+
+const targetConflictReason = "MultipleActiveVPATargetsFound"
+const noTargetConflictReason = "NoConflictingActiveVPATargets"
+
+// reconcileTargetConflicts groups the given VPAs by their targetRef and, for
+// any target with more than one VPA using an active update mode (anything
+// other than "Off"), sets the TargetConflict status condition to True on
+// each conflicting VPA. VPAs that are no longer part of a conflicting group
+// but previously had the condition set to True have it cleared.
+//
+// This surfaces the conflict to the user; it does not change which VPA
+// actually controls a pod (see vpa_api_util.Stronger for that logic).
+func (u *updater) reconcileTargetConflicts(vpaList []*vpa_types.VerticalPodAutoscaler) {
+	groups := make(map[string][]*vpa_types.VerticalPodAutoscaler)
+	for _, vpa := range vpaList {
+		if slices.Contains(u.ignoredNamespaces, vpa.Namespace) {
+			continue
+		}
+		if vpa.Spec.TargetRef == nil {
+			continue
+		}
+		// "Off" VPAs don't update pods at all, so they can't conflict.
+		if vpa_api_util.GetUpdateMode(vpa) == vpa_types.UpdateModeOff {
+			continue
+		}
+		key := vpa_api_util.TargetRefIndexKey(vpa.Namespace, vpa.Spec.TargetRef.Kind, vpa.Spec.TargetRef.Name)
+		groups[key] = append(groups[key], vpa)
+	}
+
+	for _, group := range groups {
+		conflicting := len(group) > 1
+		var message string
+		if conflicting {
+			names := make([]string, 0, len(group))
+			for _, vpa := range group {
+				names = append(names, vpa.Name)
+			}
+			sort.Strings(names)
+			message = fmt.Sprintf("Conflict: multiple active VPAs target the same object: %s", strings.Join(names, ", "))
+		}
+		for _, vpa := range group {
+			u.updateTargetConflictCondition(vpa, conflicting, message)
+		}
+	}
+}
+
+// updateTargetConflictCondition patches the TargetConflict condition on a
+// single VPA if it needs to change, and emits a Warning/Normal event only on
+// a state transition (conflict appearing or clearing).
+func (u *updater) updateTargetConflictCondition(vpa *vpa_types.VerticalPodAutoscaler, conflicting bool, message string) {
+	oldStatus := vpa.Status.DeepCopy()
+
+	wasConflicting := false
+	if c := getVpaCondition(oldStatus, vpa_types.TargetConflict); c != nil {
+		wasConflicting = c.Status == corev1.ConditionTrue
+	}
+
+	// Nothing to do: no conflict now and none previously recorded.
+	if !conflicting && !wasConflicting {
+		return
+	}
+
+	newStatus := oldStatus.DeepCopy()
+	condStatus := corev1.ConditionFalse
+	reason := noTargetConflictReason
+	if conflicting {
+		condStatus = corev1.ConditionTrue
+		reason = targetConflictReason
+	} else {
+		message = "No conflicting active VPAs found for this target."
+	}
+	setVpaCondition(newStatus, vpa_types.TargetConflict, condStatus, reason, message)
+
+	_, err := vpa_api_util.UpdateVpaStatusIfNeeded(
+		u.vpaClient.AutoscalingV1().VerticalPodAutoscalers(vpa.Namespace),
+		vpa.Name,
+		newStatus,
+		oldStatus,
+	)
+	if err != nil {
+		klog.ErrorS(err, "Failed to update VPA TargetConflict condition", "vpa", klog.KObj(vpa))
+		return
+	}
+
+	if conflicting != wasConflicting {
+		eventType := corev1.EventTypeWarning
+		if !conflicting {
+			eventType = corev1.EventTypeNormal
+		}
+		u.eventRecorder.Event(vpa, eventType, reason, message)
+	}
+}
+
+// getVpaCondition returns a pointer to the condition of the given type, or
+// nil if it isn't present.
+func getVpaCondition(status *vpa_types.VerticalPodAutoscalerStatus, condType vpa_types.VerticalPodAutoscalerConditionType) *vpa_types.VerticalPodAutoscalerCondition {
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == condType {
+			return &status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// setVpaCondition sets or updates a condition on the given status, bumping
+// LastTransitionTime only when the status value actually changes.
+func setVpaCondition(status *vpa_types.VerticalPodAutoscalerStatus, condType vpa_types.VerticalPodAutoscalerConditionType, condStatus corev1.ConditionStatus, reason, message string) {
+	now := metav1.Now()
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == condType {
+			if status.Conditions[i].Status != condStatus {
+				status.Conditions[i].LastTransitionTime = now
+			}
+			status.Conditions[i].Status = condStatus
+			status.Conditions[i].Reason = reason
+			status.Conditions[i].Message = message
+			return
+		}
+	}
+	status.Conditions = append(status.Conditions, vpa_types.VerticalPodAutoscalerCondition{
+		Type:               condType,
+		Status:             condStatus,
+		LastTransitionTime: now,
+		Reason:             reason,
+		Message:            message,
+	})
+}

--- a/vertical-pod-autoscaler/pkg/updater/logic/target_conflict_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/target_conflict_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	vpa_fake "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/fake"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+func deploymentRef(name string) *autoscalingv1.CrossVersionObjectReference {
+	return &autoscalingv1.CrossVersionObjectReference{
+		Kind: "Deployment",
+		Name: name,
+	}
+}
+
+func newConflictTestUpdater(vpaClient *vpa_fake.Clientset, ignoredNamespaces ...string) *updater {
+	return &updater{
+		vpaClient:         vpaClient,
+		eventRecorder:     record.NewFakeRecorder(10),
+		ignoredNamespaces: ignoredNamespaces,
+	}
+}
+
+func getVpa(t *testing.T, client *vpa_fake.Clientset, namespace, name string) *vpa_types.VerticalPodAutoscaler {
+	t.Helper()
+	vpa, err := client.AutoscalingV1().VerticalPodAutoscalers(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	return vpa
+}
+
+func findCondition(vpa *vpa_types.VerticalPodAutoscaler, condType vpa_types.VerticalPodAutoscalerConditionType) *vpa_types.VerticalPodAutoscalerCondition {
+	for i := range vpa.Status.Conditions {
+		if vpa.Status.Conditions[i].Type == condType {
+			return &vpa.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func TestReconcileTargetConflicts_TwoActiveVPAsConflict(t *testing.T) {
+	vpa1 := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).WithTargetRef(deploymentRef("app")).Get()
+	vpa2 := test.VerticalPodAutoscaler().WithName("vpa-2").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).WithTargetRef(deploymentRef("app")).Get()
+
+	client := vpa_fake.NewSimpleClientset(vpa1, vpa2)
+	u := newConflictTestUpdater(client)
+
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpa1, vpa2})
+
+	for _, name := range []string{"vpa-1", "vpa-2"} {
+		got := getVpa(t, client, "default", name)
+		cond := findCondition(got, vpa_types.TargetConflict)
+		require.NotNil(t, cond, "expected TargetConflict condition on %s", name)
+		assert.Equal(t, corev1.ConditionTrue, cond.Status)
+		assert.Equal(t, targetConflictReason, cond.Reason)
+		assert.Contains(t, cond.Message, "vpa-1")
+		assert.Contains(t, cond.Message, "vpa-2")
+	}
+}
+
+func TestReconcileTargetConflicts_InitialModeIncluded(t *testing.T) {
+	vpa1 := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeInitial).WithTargetRef(deploymentRef("app")).Get()
+	vpa2 := test.VerticalPodAutoscaler().WithName("vpa-2").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeInitial).WithTargetRef(deploymentRef("app")).Get()
+
+	client := vpa_fake.NewSimpleClientset(vpa1, vpa2)
+	u := newConflictTestUpdater(client)
+
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpa1, vpa2})
+
+	for _, name := range []string{"vpa-1", "vpa-2"} {
+		got := getVpa(t, client, "default", name)
+		cond := findCondition(got, vpa_types.TargetConflict)
+		require.NotNil(t, cond, "Initial-mode VPAs should still be flagged per maintainer decision")
+		assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	}
+}
+
+func TestReconcileTargetConflicts_OffModeExcluded(t *testing.T) {
+	vpa1 := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeOff).WithTargetRef(deploymentRef("app")).Get()
+	vpa2 := test.VerticalPodAutoscaler().WithName("vpa-2").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).WithTargetRef(deploymentRef("app")).Get()
+
+	client := vpa_fake.NewSimpleClientset(vpa1, vpa2)
+	u := newConflictTestUpdater(client)
+
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpa1, vpa2})
+
+	got1 := getVpa(t, client, "default", "vpa-1")
+	assert.Nil(t, findCondition(got1, vpa_types.TargetConflict), "Off-mode VPA should not be flagged")
+
+	got2 := getVpa(t, client, "default", "vpa-2")
+	assert.Nil(t, findCondition(got2, vpa_types.TargetConflict), "single active VPA on a target should not be flagged")
+}
+
+func TestReconcileTargetConflicts_NoConflictSingleVPA(t *testing.T) {
+	vpa1 := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).WithTargetRef(deploymentRef("app")).Get()
+
+	client := vpa_fake.NewSimpleClientset(vpa1)
+	u := newConflictTestUpdater(client)
+
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpa1})
+
+	got := getVpa(t, client, "default", "vpa-1")
+	assert.Nil(t, findCondition(got, vpa_types.TargetConflict), "single VPA should not get a TargetConflict condition")
+}
+
+func TestReconcileTargetConflicts_NamespaceIsolation(t *testing.T) {
+	vpa1 := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("ns-a").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).WithTargetRef(deploymentRef("app")).Get()
+	vpa2 := test.VerticalPodAutoscaler().WithName("vpa-2").WithNamespace("ns-b").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).WithTargetRef(deploymentRef("app")).Get()
+
+	client := vpa_fake.NewSimpleClientset(vpa1, vpa2)
+	u := newConflictTestUpdater(client)
+
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpa1, vpa2})
+
+	got1 := getVpa(t, client, "ns-a", "vpa-1")
+	assert.Nil(t, findCondition(got1, vpa_types.TargetConflict), "same name/kind in different namespaces should not conflict")
+
+	got2 := getVpa(t, client, "ns-b", "vpa-2")
+	assert.Nil(t, findCondition(got2, vpa_types.TargetConflict))
+}
+
+func TestReconcileTargetConflicts_IgnoredNamespaceRespected(t *testing.T) {
+	vpa1 := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("ignored-ns").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).WithTargetRef(deploymentRef("app")).Get()
+	vpa2 := test.VerticalPodAutoscaler().WithName("vpa-2").WithNamespace("ignored-ns").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).WithTargetRef(deploymentRef("app")).Get()
+
+	client := vpa_fake.NewSimpleClientset(vpa1, vpa2)
+	u := newConflictTestUpdater(client, "ignored-ns")
+
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpa1, vpa2})
+
+	got1 := getVpa(t, client, "ignored-ns", "vpa-1")
+	assert.Nil(t, findCondition(got1, vpa_types.TargetConflict), "VPAs in ignored namespaces should be skipped")
+}
+
+func TestReconcileTargetConflicts_ClearsOnResolution(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	// vpa1 previously had a recorded conflict; vpa2 (the other party) is gone now.
+	vpa1 := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).WithTargetRef(deploymentRef("app")).
+		AppendCondition(vpa_types.TargetConflict, corev1.ConditionTrue, targetConflictReason,
+			"Conflict: multiple active VPAs target the same object: vpa-1, vpa-2", past).Get()
+
+	client := vpa_fake.NewSimpleClientset(vpa1)
+	u := newConflictTestUpdater(client)
+
+	// Only vpa1 remains active on this target now.
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpa1})
+
+	got := getVpa(t, client, "default", "vpa-1")
+	cond := findCondition(got, vpa_types.TargetConflict)
+	require.NotNil(t, cond)
+	assert.Equal(t, corev1.ConditionFalse, cond.Status)
+	assert.Equal(t, noTargetConflictReason, cond.Reason)
+	assert.True(t, cond.LastTransitionTime.Time.After(past), "LastTransitionTime should be bumped on status change")
+}
+
+func TestReconcileTargetConflicts_NoEventOnRepeatedConflict(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	vpa1 := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).WithTargetRef(deploymentRef("app")).
+		AppendCondition(vpa_types.TargetConflict, corev1.ConditionTrue, targetConflictReason,
+			"Conflict: multiple active VPAs target the same object: vpa-1, vpa-2", past).Get()
+	vpa2 := test.VerticalPodAutoscaler().WithName("vpa-2").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).WithTargetRef(deploymentRef("app")).
+		AppendCondition(vpa_types.TargetConflict, corev1.ConditionTrue, targetConflictReason,
+			"Conflict: multiple active VPAs target the same object: vpa-1, vpa-2", past).Get()
+
+	client := vpa_fake.NewSimpleClientset(vpa1, vpa2)
+	recorder := record.NewFakeRecorder(10)
+	u := &updater{vpaClient: client, eventRecorder: recorder}
+
+	// Conflict still active on this run -- should not re-fire an event.
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpa1, vpa2})
+
+	select {
+	case ev := <-recorder.Events:
+		t.Fatalf("expected no event on unchanged conflict state, got: %s", ev)
+	default:
+		// expected: no event
+	}
+}

--- a/vertical-pod-autoscaler/pkg/updater/logic/target_conflict_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/target_conflict_test.go
@@ -188,7 +188,7 @@ func TestReconcileTargetConflicts_ClearsOnResolution(t *testing.T) {
 	require.NotNil(t, cond)
 	assert.Equal(t, corev1.ConditionFalse, cond.Status)
 	assert.Equal(t, noTargetConflictReason, cond.Reason)
-	assert.True(t, cond.LastTransitionTime.Time.After(past), "LastTransitionTime should be bumped on status change")
+	assert.True(t, cond.LastTransitionTime.After(past), "LastTransitionTime should be bumped on status change")
 }
 
 func TestReconcileTargetConflicts_NoEventOnRepeatedConflict(t *testing.T) {
@@ -215,4 +215,40 @@ func TestReconcileTargetConflicts_NoEventOnRepeatedConflict(t *testing.T) {
 	default:
 		// expected: no event
 	}
+}
+
+func TestReconcileTargetConflicts_ClearsOnIneligibleTransition(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+
+	// vpa1 flips from Recreate to Off. It was previously flagged as
+	// conflicting and should have that condition cleared even though it no
+	// longer participates in grouping.
+	vpaTurnedOff := test.VerticalPodAutoscaler().WithName("vpa-1").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeOff).WithTargetRef(deploymentRef("app")).
+		AppendCondition(vpa_types.TargetConflict, corev1.ConditionTrue, targetConflictReason,
+			"Conflict: multiple active VPAs target the same object: vpa-1, vpa-2", past).Get()
+
+	// vpa2 drops its targetRef entirely. Same expectation: stale condition
+	// should be cleared.
+	vpaNoTargetRef := test.VerticalPodAutoscaler().WithName("vpa-2").WithNamespace("default").WithContainer("main").
+		WithUpdateMode(vpa_types.UpdateModeRecreate).
+		AppendCondition(vpa_types.TargetConflict, corev1.ConditionTrue, targetConflictReason,
+			"Conflict: multiple active VPAs target the same object: vpa-1, vpa-2", past).Get()
+	vpaNoTargetRef.Spec.TargetRef = nil
+
+	client := vpa_fake.NewSimpleClientset(vpaTurnedOff, vpaNoTargetRef)
+	u := newConflictTestUpdater(client)
+
+	u.reconcileTargetConflicts([]*vpa_types.VerticalPodAutoscaler{vpaTurnedOff, vpaNoTargetRef})
+
+	got1 := getVpa(t, client, "default", "vpa-1")
+	cond1 := findCondition(got1, vpa_types.TargetConflict)
+	require.NotNil(t, cond1, "Off-mode VPA should still have its stale condition updated, not left dangling")
+	assert.Equal(t, corev1.ConditionFalse, cond1.Status, "condition should be cleared once VPA turns Off")
+	assert.Equal(t, noTargetConflictReason, cond1.Reason)
+
+	got2 := getVpa(t, client, "default", "vpa-2")
+	cond2 := findCondition(got2, vpa_types.TargetConflict)
+	require.NotNil(t, cond2, "VPA with no targetRef should still have its stale condition updated, not left dangling")
+	assert.Equal(t, corev1.ConditionFalse, cond2.Status, "condition should be cleared once targetRef is removed")
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -86,7 +86,7 @@ type Updater interface {
 
 type updater struct {
 	vpaLister                    vpa_lister.VerticalPodAutoscalerLister
-	vpaClient                    *vpa_clientset.Clientset
+	vpaClient                    vpa_clientset.Interface
 	podLister                    listersv1.PodLister
 	eventRecorder                record.EventRecorder
 	restrictionFactory           restriction.PodsRestrictionFactory

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -86,6 +86,7 @@ type Updater interface {
 
 type updater struct {
 	vpaLister                    vpa_lister.VerticalPodAutoscalerLister
+	vpaClient                    *vpa_clientset.Clientset
 	podLister                    listersv1.PodLister
 	eventRecorder                record.EventRecorder
 	restrictionFactory           restriction.PodsRestrictionFactory
@@ -149,6 +150,7 @@ func NewUpdater(
 
 	u := &updater{
 		vpaLister:                    vpa_api_util.NewVpasLister(vpaClient, make(chan struct{}), namespace),
+		vpaClient:                    vpaClient,
 		podLister:                    podInformerFactory.Core().V1().Pods().Lister(),
 		eventRecorder:                newEventRecorder(kubeClient),
 		restrictionFactory:           factory,
@@ -216,6 +218,9 @@ func (u *updater) RunOnce(ctx context.Context) {
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	timer.ObserveStep("ListVPAs")
+
+	u.reconcileTargetConflicts(vpaList)
+	timer.ObserveStep("ReconcileTargetConflicts")
 
 	vpas := make([]*vpa_api_util.VpaWithSelector, 0)
 


### PR DESCRIPTION

/kind feature

If multiple VPAs with an active update mode target the same workload, the admission controller and updater can end up acting on the same pod in different ways. One VPA can try an in-place resize while another evicts the pod.
This adds a `TargetConflict` status condition to make this configuration visible on the VPA.
The conflict is detected in the updater since it is the component that actually acts on the conflicting VPAs.
Only `Off` mode is ignored. `Initial` is still considered a conflict, since having multiple VPAs targeting the same workload is not a valid configuration. `Auto` is also treated as active since it is not `Off`.
The condition is only changed when the conflict state changes. A Warning event is emitted when the conflict starts, so the updater does not generate the same event on every loop.
The condition message includes all conflicting VPA names.

### RBAC -
The updater did not have permission to patch `verticalpodautoscalers/status`.
I added the updater to the existing `system:vpa-status-actor` ClusterRoleBinding instead of creating another role.
Also changed `vpaClient` to `vpa_clientset.Interface` so the fake client can be used in the tests.

### Tests -
Added `target_conflict_test.go` covering -

* multiple active VPAs targeting the same object
* `Initial` mode and `Off` mode
* single VPA
* different namespaces
* `ignoredNamespaces`
* clearing the condition after the conflict is gone
* no duplicate event while the conflict remains

`gofmt`, `go build`, `go vet` and the full test suite pass.

Fixes #10135

### Special notes for the reviewers -

**Two things I'm not completely sure about -**

1. The condition message includes all conflicting VPA names instead of just two.
2. `Auto` is treated as active because it is not `Off`. This wasn't explicitly discussed in the issue.

```release-note
Added a TargetConflict status condition when multiple VPAs with an active update mode target the same object. The updater also emits a Warning event when the conflict starts.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detection for multiple active VerticalPodAutoscalers targeting the same workload.
  - Conflicting VPAs now receive a `TargetConflict` status condition listing the affected VPA names.
  - Conflict conditions are cleared when conflicts resolve or VPAs become ineligible, with events emitted only when the conflict state changes.
  - The VPA updater service account now has access to VPA status resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->