### PR TITLE
azure: consolidate per-instance azureCache maps

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
@@ -333,7 +333,7 @@ func TestAgentPoolBelongs(t *testing.T) {
 	defer ctrl.Finish()
 
 	as := newTestAgentPool(newTestAzureManager(t), "as")
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID0}] = instanceCacheEntry{nodeGroup: as}
 
 	flag, err := as.Belongs(&apiv1.Node{Spec: apiv1.NodeSpec{ProviderID: testValidProviderID0}})
 	assert.NoError(t, err)
@@ -348,7 +348,7 @@ func TestAgentPoolBelongs(t *testing.T) {
 	assert.False(t, flag)
 
 	as1 := newTestAgentPool(newTestAzureManager(t), "as1")
-	as1.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
+	as1.manager.azureCache.instances[azureRef{Name: testValidProviderID0}] = instanceCacheEntry{nodeGroup: as}
 	flag, err = as1.Belongs(&apiv1.Node{Spec: apiv1.NodeSpec{ProviderID: testValidProviderID0}})
 	assert.NoError(t, err)
 	assert.False(t, flag)
@@ -360,9 +360,9 @@ func TestDeleteInstances(t *testing.T) {
 
 	as := newTestAgentPool(newTestAzureManager(t), "as")
 	as1 := newTestAgentPool(newTestAzureManager(t), "as1")
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID1}] = as1
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testInvalidProviderID}] = as
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID0}] = instanceCacheEntry{nodeGroup: as}
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID1}] = instanceCacheEntry{nodeGroup: as1}
+	as.manager.azureCache.instances[azureRef{Name: testInvalidProviderID}] = instanceCacheEntry{nodeGroup: as}
 
 	mockVMClient := NewMockInterface(ctrl)
 	as.manager.azClient.virtualMachinesClient = mockVMClient
@@ -410,9 +410,9 @@ func TestForceDeleteNodes(t *testing.T) {
 
 	as := newTestAgentPool(newTestAzureManager(t), "as")
 	as1 := newTestAgentPool(newTestAzureManager(t), "as1")
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID1}] = as1
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testInvalidProviderID}] = as
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID0}] = instanceCacheEntry{nodeGroup: as}
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID1}] = instanceCacheEntry{nodeGroup: as1}
+	as.manager.azureCache.instances[azureRef{Name: testInvalidProviderID}] = instanceCacheEntry{nodeGroup: as}
 
 	mockVMClient := NewMockInterface(ctrl)
 	as.manager.azClient.virtualMachinesClient = mockVMClient
@@ -449,7 +449,7 @@ func TestAgentPoolDeleteNodes(t *testing.T) {
 	defer ctrl.Finish()
 
 	as := newTestAgentPool(newTestAzureManager(t), "as")
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID0}] = instanceCacheEntry{nodeGroup: as}
 	expectedVMs := getExpectedVMs()
 	mockVMClient := NewMockInterface(ctrl)
 	as.manager.azClient.virtualMachinesClient = mockVMClient
@@ -472,7 +472,7 @@ func TestAgentPoolDeleteNodes(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 
 	as1 := newTestAgentPool(newTestAzureManager(t), "as1")
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as1
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID0}] = instanceCacheEntry{nodeGroup: as1}
 	err = as.DeleteNodes(context.Background(), []*apiv1.Node{
 		{
 			Spec:       apiv1.NodeSpec{ProviderID: testValidProviderID0},
@@ -546,7 +546,7 @@ func TestAgentPoolDeleteInstancesProactivelyMarksDeletion(t *testing.T) {
 	defer ctrl.Finish()
 
 	as := newTestAgentPool(newTestAzureManager(t), "as")
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID0}] = instanceCacheEntry{nodeGroup: as}
 
 	mockVMClient := NewMockInterface(ctrl)
 	as.manager.azClient.virtualMachinesClient = mockVMClient
@@ -580,7 +580,7 @@ func TestAgentPoolDeleteInstancesStrictCacheDoesNotProactivelyMarkDeletion(t *te
 
 	as := newTestAgentPool(newTestAzureManager(t), "as")
 	as.manager.config.StrictCacheUpdates = true
-	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
+	as.manager.azureCache.instances[azureRef{Name: testValidProviderID0}] = instanceCacheEntry{nodeGroup: as}
 
 	mockVMClient := NewMockInterface(ctrl)
 	as.manager.azClient.virtualMachinesClient = mockVMClient

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -50,7 +50,7 @@ var (
 // It backs efficient responds to
 //   - cloudprovider.NodeGroups() (= registeredNodeGroups)
 //   - cloudprovider.NodeGroupForNode (via azureManager.GetNodeGroupForInstance => FindForInstance,
-//     using instanceToNodeGroup and unownedInstances)
+//     using instances and unownedInstances)
 //
 // CloudProvider.Refresh, called before every autoscaler loop (every 10s by defaul),
 // is implemented by AzureManager.Refresh which makes the cache refresh decision,
@@ -91,25 +91,31 @@ type azureCache struct {
 	// registeredNodeGroups represents all known NodeGroups.
 	registeredNodeGroups []cloudprovider.NodeGroup
 
-	// instanceToNodeGroup maintains a mapping from instance Ids to nodegroups.
-	// It is populated from the results of calling Nodes() on each nodegroup.
-	// It is used (together with unownedInstances) when looking up the nodegroup
-	// for a given instance id (see FindForInstance).
-	instanceToNodeGroup map[azureRef]cloudprovider.NodeGroup
-
-	// instanceStates maintains a mapping from instance Ids to their last known
-	// cloudprovider.InstanceState. It is populated alongside instanceToNodeGroup
-	// from the results of calling Nodes() on each nodegroup. It is used by
-	// HasInstance to not include instances in an active state of deletion.
-	instanceStates map[azureRef]cloudprovider.InstanceState
+	// instances maintains a mapping from instance Ids to the nodegroup they belong to
+	// and their last known cloudprovider.InstanceState. It is populated from the results
+	// of calling Nodes() on each nodegroup. It is used (together with unownedInstances)
+	// when looking up the nodegroup for a given instance id (see FindForInstance), and by
+	// HasInstance to not include instances in an active state of deletion. Keeping both
+	// pieces of data in a single map, instead of two maps keyed by the same instance id,
+	// means they can't drift out of sync with each other.
+	instances map[azureRef]instanceCacheEntry
 
 	// unownedInstance maintains a set of instance ids not belonging to any nodegroup.
-	// It is used (together with instanceToNodeGroup) when looking up the nodegroup for a given instance id.
+	// It is used (together with instances) when looking up the nodegroup for a given instance id.
 	// It is reset by invalidateUnownedInstanceCache().
 	unownedInstances map[azureRef]bool
 
 	autoscalingOptions map[azureRef]map[string]string
 	skus               *skewer.Cache
+}
+
+// instanceCacheEntry holds everything the azureCache tracks about a single instance,
+// keyed by azureRef in azureCache.instances.
+type instanceCacheEntry struct {
+	nodeGroup cloudprovider.NodeGroup
+	// state is the last known cloudprovider.InstanceState for the instance, or the zero
+	// value if unknown (the zero value doesn't collide with a real InstanceState).
+	state cloudprovider.InstanceState
 }
 
 func newAzureCache(client *azClient, cacheTTL time.Duration, config Config) (*azureCache, error) {
@@ -132,8 +138,7 @@ func newAzureCache(client *azClient, cacheTTL time.Duration, config Config) (*az
 		scaleSets:            make(map[string]*armcompute.VirtualMachineScaleSet),
 		virtualMachines:      make(map[string][]*armcompute.VirtualMachine),
 		registeredNodeGroups: make([]cloudprovider.NodeGroup, 0),
-		instanceToNodeGroup:  make(map[azureRef]cloudprovider.NodeGroup),
-		instanceStates:       make(map[azureRef]cloudprovider.InstanceState),
+		instances:            make(map[azureRef]instanceCacheEntry),
 		unownedInstances:     make(map[azureRef]bool),
 		autoscalingOptions:   make(map[azureRef]map[string]string),
 		skus:                 &skewer.Cache{}, // populated iff config.EnableDynamicInstanceList
@@ -197,8 +202,7 @@ func (m *azureCache) regenerate() error {
 	}
 
 	// Regenerate instance to node groups mapping.
-	newInstanceToNodeGroupCache := make(map[azureRef]cloudprovider.NodeGroup)
-	newInstanceStates := make(map[azureRef]cloudprovider.InstanceState)
+	newInstances := make(map[azureRef]instanceCacheEntry)
 	for _, ng := range m.registeredNodeGroups {
 		klog.V(4).Infof("regenerate: finding nodes for node group %s", ng.Id())
 		instances, err := ng.Nodes(context.TODO())
@@ -209,10 +213,11 @@ func (m *azureCache) regenerate() error {
 
 		for _, instance := range instances {
 			ref := azureRef{Name: instance.Id}
-			newInstanceToNodeGroupCache[ref] = ng
+			entry := instanceCacheEntry{nodeGroup: ng}
 			if instance.Status != nil {
-				newInstanceStates[ref] = instance.Status.State
+				entry.state = instance.Status.State
 			}
+			newInstances[ref] = entry
 		}
 	}
 
@@ -230,8 +235,7 @@ func (m *azureCache) regenerate() error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	m.instanceToNodeGroup = newInstanceToNodeGroupCache
-	m.instanceStates = newInstanceStates
+	m.instances = newInstances
 	m.autoscalingOptions = newAutoscalingOptions
 
 	// Reset unowned instances cache.
@@ -479,16 +483,14 @@ func (m *azureCache) HasInstance(providerID string) (bool, error) {
 		return false, err
 	}
 
-	// A single pass over instanceToNodeGroup locates the instance. The matched key
-	// also indexes instanceStates, which setInstanceStateByProviderID keeps aligned
-	// with instanceToNodeGroup, so the state can be retrieved with a direct lookup.
-	for instanceID := range m.instanceToNodeGroup {
+	// A single pass over instances locates the instance and its last known state.
+	for instanceID, entry := range m.instances {
 		if !strings.EqualFold(instanceID.GetKey(), resourceID) {
 			continue
 		}
 		// An instance that is actively being deleted is reported as gone so that
 		// ClusterStateRegistry stops counting it as an upcoming node.
-		if state, found := m.instanceStates[instanceID]; found && state == cloudprovider.InstanceDeleting {
+		if entry.state == cloudprovider.InstanceDeleting {
 			return false, nil
 		}
 		return true, nil
@@ -540,7 +542,7 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 	}
 
 	// Look up caches for the instance.
-	klog.V(6).Infof("FindForInstance: attempting to retrieve instance %v from cache", m.instanceToNodeGroup)
+	klog.V(6).Infof("FindForInstance: attempting to retrieve instance %v from cache", m.instances)
 	if nodeGroup := m.getInstanceFromCache(inst.Name); nodeGroup != nil {
 		klog.V(4).Infof("FindForInstance: found node group %q in cache", nodeGroup.Id())
 		return nodeGroup, nil
@@ -564,9 +566,9 @@ func (m *azureCache) areAllScaleSetsUniform() bool {
 // getInstanceFromCache gets the node group from cache. Returns nil if not found.
 // Should be called with lock.
 func (m *azureCache) getInstanceFromCache(providerID string) cloudprovider.NodeGroup {
-	for instanceID, nodeGroup := range m.instanceToNodeGroup {
+	for instanceID, entry := range m.instances {
 		if strings.EqualFold(instanceID.GetKey(), providerID) {
-			return nodeGroup
+			return entry.nodeGroup
 		}
 	}
 
@@ -585,9 +587,10 @@ func (m *azureCache) setInstanceStateByProviderID(providerID string, state cloud
 		return
 	}
 
-	for instanceID := range m.instanceToNodeGroup {
+	for instanceID, entry := range m.instances {
 		if strings.EqualFold(instanceID.GetKey(), resourceID) {
-			m.instanceStates[instanceID] = state
+			entry.state = state
+			m.instances[instanceID] = entry
 			return
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The Azure cloud provider's `azureCache` kept two separate maps, `instanceToNodeGroup` and `instanceStates`, both keyed by the same `azureRef`, populated together and read together everywhere they are used. Nothing enforced that they stayed in sync, they were just written next to each other by convention in `regenerate()` and `setInstanceStateByProviderID()`.

This folds them into a single `instances` map of a new `instanceCacheEntry` struct holding both the node group and the instance state, so the two pieces of data about one instance can no longer drift apart. Behavior is unchanged, this is a data structure refactor only.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

No functional change. Verified `go build`, `go vet`, and `go test ./cloudprovider/azure/...` all pass.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal Azure instance caching by consolidating related instance information into a unified cache structure.
  * Updated cache lookups and state tracking to use the consolidated representation.
  * Updated automated tests to reflect the revised caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
