### PR TITLE
cherryservers: remove redundant rand.Seed call

### DIFF
--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_manager_rest.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_manager_rest.go
@@ -394,7 +394,6 @@ func (mgr *cherryManagerRest) nodeGroupSize(nodegroup string) (int, error) {
 
 func randString8() string {
 	n := 8
-	rand.Seed(time.Now().UnixNano())
 	letterRunes := []rune("acdefghijklmnopqrstuvwxyz")
 	b := make([]rune, n)
 	for i := range b {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

randString8 called rand.Seed(time.Now().UnixNano()) on every invocation. The global math/rand source has auto-seeded itself since Go 1.20, and this module is on Go 1.26, so the call is a deprecated no-op that runs on every node creation for no benefit.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Found by reading the code, not tied to an existing issue. Verified locally with go build and go vet on the cherryservers package, and the existing package tests still pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved random string generation consistency by avoiding repeated reseeding during each generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->