### PR TITLE
Add topology.kubernetes.io/zone to CAPI extracted template labels

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -655,6 +655,7 @@ func extractNodeLabels(node *corev1.Node) map[string]string {
 	setLabelIfNotEmpty(m, node.Labels, corev1.LabelZoneRegionStable)
 
 	setLabelIfNotEmpty(m, node.Labels, corev1.LabelZoneFailureDomain)
+	setLabelIfNotEmpty(m, node.Labels, corev1.LabelTopologyZone)
 
 	return m
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -1589,6 +1589,7 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 					"kubernetes.io/os":                 "windows",
 					"kubernetes.io/arch":               "arm64",
 					"node.kubernetes.io/instance-type": "instance1",
+					"topology.kubernetes.io/zone":      "us-east-1a",
 				},
 				expectedCapacity: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    2,
@@ -1600,6 +1601,7 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 					"kubernetes.io/os":                 "windows",
 					"kubernetes.io/arch":               "arm64",
 					"node.kubernetes.io/instance-type": "instance1",
+					"topology.kubernetes.io/zone":      "us-east-1a",
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The extractNodeLabels function in the clusterapi cloudprovider copies a predefined set of labels from existing nodes into the template node used for scale-up simulation. It included the deprecated `failure-domain.beta.kubernetes.io/zone` label but omitted the stable `topology.kubernetes.io/zone` label.

#### Special notes for your reviewer:

This is my first PR for kubernetes autoscaler, let me know if anything needs adjustments.

#### Does this PR introduce a user-facing change?
```release-note
Fixed cluster-api scale-up not triggering for pods requiring `topology.kubernetes.io/zone` due to lack of simulation metadata.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the availability zone label when generating scale-from-zero node templates from existing nodes.
  - Ensures autoscaled nodes retain the correct topology information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->