### PR TITLE
feat(vpa-chart): support unhealthyPodEvictionPolicy on the PodDisruptionBudgets

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -184,6 +184,7 @@ helm upgrade <release-name> <chart> \
 | admissionController.podDisruptionBudget.enabled | bool | `true` |  |
 | admissionController.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | admissionController.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
+| admissionController.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `nil` | Policy used to evict unhealthy pods, either 'IfHealthyBudget' or 'AlwaysAllow'. Defaults to the Kubernetes default, 'IfHealthyBudget', when unset. |
 | admissionController.podLabels | object | `{}` |  |
 | admissionController.priorityClassName | string | `nil` |  |
 | admissionController.registerWebhook | bool | `false` | Whether to register webhook via the application itself or via Helm. Set to false when using Helm-managed webhook. Security issue: granting delete on mutatingwebhookconfigurations is a potential security risk as it allows the admission controller to remove any webhook configurations. |
@@ -252,6 +253,7 @@ helm upgrade <release-name> <chart> \
 | recommender.podDisruptionBudget.enabled | bool | `true` |  |
 | recommender.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | recommender.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
+| recommender.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `nil` | Policy used to evict unhealthy pods, either 'IfHealthyBudget' or 'AlwaysAllow'. Defaults to the Kubernetes default, 'IfHealthyBudget', when unset. |
 | recommender.podLabels | object | `{}` |  |
 | recommender.priorityClassName | string | `nil` |  |
 | recommender.replicas | int | `2` |  |
@@ -285,6 +287,7 @@ helm upgrade <release-name> <chart> \
 | updater.podDisruptionBudget.enabled | bool | `true` |  |
 | updater.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | updater.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
+| updater.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `nil` | Policy used to evict unhealthy pods, either 'IfHealthyBudget' or 'AlwaysAllow'. Defaults to the Kubernetes default, 'IfHealthyBudget', when unset. |
 | updater.podLabels | object | `{}` |  |
 | updater.priorityClassName | string | `nil` |  |
 | updater.replicas | int | `2` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-pdb.yaml
@@ -19,4 +19,7 @@ spec:
   {{- if and .Values.admissionController.podDisruptionBudget.maxUnavailable (not .Values.admissionController.podDisruptionBudget.minAvailable) }}
   maxUnavailable: {{ .Values.admissionController.podDisruptionBudget.maxUnavailable }}
   {{- end }}
+  {{- with .Values.admissionController.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
@@ -16,4 +16,7 @@ spec:
   {{- if .Values.recommender.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.recommender.podDisruptionBudget.maxUnavailable }}
   {{- end }}
+  {{- with .Values.recommender.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
@@ -19,4 +19,7 @@ spec:
   {{- if .Values.updater.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.updater.podDisruptionBudget.maxUnavailable }}
   {{- end }}
+  {{- with .Values.updater.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -230,6 +230,10 @@ admissionController:
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
     maxUnavailable:
     # maxUnavailable: 1
+    # -- (string) Policy used to evict unhealthy pods, either 'IfHealthyBudget' or 'AlwaysAllow'.
+    # Defaults to the Kubernetes default, 'IfHealthyBudget', when unset.
+    unhealthyPodEvictionPolicy:
+    # unhealthyPodEvictionPolicy: AlwaysAllow
 
   # name of priorityclass for scheduling
   priorityClassName:
@@ -336,6 +340,10 @@ recommender:
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
     maxUnavailable:
     # maxUnavailable: 1
+    # -- (string) Policy used to evict unhealthy pods, either 'IfHealthyBudget' or 'AlwaysAllow'.
+    # Defaults to the Kubernetes default, 'IfHealthyBudget', when unset.
+    unhealthyPodEvictionPolicy:
+    # unhealthyPodEvictionPolicy: AlwaysAllow
 
   # name of priorityclass for scheduling
   priorityClassName:
@@ -429,6 +437,10 @@ updater:
     # -- (int or string) Maximum number/percentage of pods that can be unavailable after the eviction.
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
     maxUnavailable:
+    # -- (string) Policy used to evict unhealthy pods, either 'IfHealthyBudget' or 'AlwaysAllow'.
+    # Defaults to the Kubernetes default, 'IfHealthyBudget', when unset.
+    unhealthyPodEvictionPolicy:
+    # unhealthyPodEvictionPolicy: AlwaysAllow
 
   # Resources for the updater Controller
   resources: {}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `podDisruptionBudget.unhealthyPodEvictionPolicy` to the admission controller, recommender, and updater PodDisruptionBudgets in the `vertical-pod-autoscaler` chart. Only rendered when set, so existing releases keep the Kubernetes default of `IfHealthyBudget`. Setting it to `AlwaysAllow` lets a not-Ready replica be evicted during a node drain instead of blocking it, per the [Kubernetes drain recommendation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#pdb-unhealthy-pod-eviction-policy).

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

Chart-only change (`vertical-pod-autoscaler/charts/vertical-pod-autoscaler`). `ct lint` and `helm-docs` both pass; verified `helm template` renders byte-identical output to the base commit when the new field is left unset.

#### Does this PR introduce a user-facing change?
```release-note
Add `podDisruptionBudget.unhealthyPodEvictionPolicy` to the vertical-pod-autoscaler Helm chart's admission controller, recommender, and updater PodDisruptionBudgets.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable unhealthy pod eviction policies for the admission controller, recommender, and updater PodDisruptionBudgets.
  * Supports `IfHealthyBudget` and `AlwaysAllow`, with Kubernetes’ default behavior used when unset.

* **Documentation**
  * Documented the new setting, supported values, and default behavior in the chart configuration reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->