### PR TITLE
equinixmetal: remove redundant rand.Seed call

### DIFF
--- a/cluster-autoscaler/cloudprovider/equinixmetal/manager_rest.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/manager_rest.go
@@ -29,7 +29,6 @@ import (
 	"path"
 	"strings"
 	"text/template"
-	"time"
 
 	"gopkg.in/gcfg.v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -460,7 +459,6 @@ func (mgr *equinixMetalManagerRest) nodeGroupSize(nodegroup string) (int, error)
 
 func randString8() string {
 	n := 8
-	rand.Seed(time.Now().UnixNano())
 	letterRunes := []rune("acdefghijklmnopqrstuvwxyz")
 	b := make([]rune, n)
 	for i := range b {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

randString8 called rand.Seed(time.Now().UnixNano()) on every invocation. The global math/rand source has auto-seeded itself since Go 1.20, and this module is on Go 1.26, so the call is a deprecated no-op that runs on every node creation for no benefit. Also drops the now unused time import.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Same class of fix as #10257 for cherryservers, found while checking other providers for the same pattern. Verified locally with go build and go vet on the equinixmetal package, and the existing package tests still pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal random string generation by removing redundant time-based seeding.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->