### PR TITLE
CAPI: document which client writes the status configmap

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -95,6 +95,12 @@ To specify the kubeconfig path for the management cluster to monitor, use the
 `--cloud-config` option is not specified it will fall back to using the kubeconfig
 that was provided with the `--kubeconfig` option.
 
+> [!NOTE]
+> The status configmap (`--write-status-configmap`) is written using the same
+> client as Nodes and Pods, ie the cluster pointed at by `--kubeconfig` (the
+> workload cluster, when management and workload clusters are separate). It is
+> not written to the cluster pointed at by `--cloud-config`.
+
 ### Autoscaler running in a joined cluster using service account credentials
 ```
 +-----------------+


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Users expect the status configmap to follow --cloud-config since that is the client used to talk to the CAPI management cluster, but it actually gets written with the same client used for Nodes and Pods (--kubeconfig). Documents this so people running CA against separate management and workload clusters know where to look for it.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Docs only change, found while reading the clusterapi provider's client setup.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance clarifying which cluster receives the status ConfigMap when management and workload clusters use separate configurations.
  - Documented that the status ConfigMap follows the cluster specified by the Kubernetes configuration, rather than the cloud configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->