### PR TITLE
fix: guard optional AcceleratorCount when building the AWS template node

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -375,6 +375,14 @@ func (m *AwsManager) updateCapacityWithRequirementsOverrides(capacity *apiv1.Res
 		(*capacity)[apiv1.ResourceMemory] = *resource.NewQuantity(int64(*instanceRequirements.MemoryMiB.Min*1024*1024), resource.DecimalSI)
 	}
 
+	// AcceleratorCount is optional in InstanceRequirements, and so is its Min:
+	// AWS documents both as "no minimum limit" when unset. Requesting any NVIDIA
+	// GPU without pinning a count is an ordinary configuration, so guard both
+	// before dereferencing, the same way VCpuCount and MemoryMiB are guarded above.
+	if instanceRequirements.AcceleratorCount == nil || instanceRequirements.AcceleratorCount.Min == nil {
+		return
+	}
+
 	for _, manufacturer := range instanceRequirements.AcceleratorManufacturers {
 		if manufacturer == ec2types.AcceleratorManufacturerNvidia {
 			for _, acceleratorType := range instanceRequirements.AcceleratorTypes {

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -382,15 +382,13 @@ func (m *AwsManager) updateCapacityWithRequirementsOverrides(capacity *apiv1.Res
 	// AWS documents both as "no minimum limit" when unset. Requesting any NVIDIA
 	// GPU without pinning a count is an ordinary configuration, so guard both
 	// before dereferencing, the same way VCpuCount and MemoryMiB are guarded above.
-	if instanceRequirements.AcceleratorCount == nil || instanceRequirements.AcceleratorCount.Min == nil {
-		return
-	}
-
-	for _, manufacturer := range instanceRequirements.AcceleratorManufacturers {
-		if manufacturer == ec2types.AcceleratorManufacturerNvidia {
-			for _, acceleratorType := range instanceRequirements.AcceleratorTypes {
-				if acceleratorType == ec2types.AcceleratorTypeGpu {
-					(*capacity)[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(int64(*instanceRequirements.AcceleratorCount.Min), resource.DecimalSI)
+	if instanceRequirements.AcceleratorCount != nil && instanceRequirements.AcceleratorCount.Min != nil {
+		for _, manufacturer := range instanceRequirements.AcceleratorManufacturers {
+			if manufacturer == ec2types.AcceleratorManufacturerNvidia {
+				for _, acceleratorType := range instanceRequirements.AcceleratorTypes {
+					if acceleratorType == ec2types.AcceleratorTypeGpu {
+						(*capacity)[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(int64(*instanceRequirements.AcceleratorCount.Min), resource.DecimalSI)
+					}
 				}
 			}
 		}

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -360,6 +360,9 @@ func joinNodeLabelsChoosingUserValuesOverAPIValues(extractedLabels map[string]st
 	return result
 }
 
+// updateCapacityWithRequirementsOverrides fills the template node's capacity from an
+// ASG's attribute-based InstanceRequirements. Every requirement is optional, so each
+// is read only when present.
 func (m *AwsManager) updateCapacityWithRequirementsOverrides(capacity *apiv1.ResourceList, policy *mixedInstancesPolicy) {
 	if policy == nil || len(policy.instanceTypesOverrides) > 0 || policy.instanceRequirements == nil {
 		return

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager_test.go
@@ -951,3 +951,69 @@ func TestParseASGAutoDiscoverySpecs(t *testing.T) {
 		})
 	}
 }
+
+// AcceleratorCount and its Min are both optional in InstanceRequirements. AWS
+// documents each as "no minimum limit" when unset, so an ASG that asks for any
+// NVIDIA GPU without pinning a count is a valid configuration. Dereferencing
+// them unguarded crashed the autoscaler while building the template node.
+func TestUpdateCapacityWithRequirementsOverridesOptionalAcceleratorCount(t *testing.T) {
+	baseRequirements := func() *ec2types.InstanceRequirements {
+		return &ec2types.InstanceRequirements{
+			VCpuCount: &ec2types.VCpuCountRange{Min: aws.Int32(4)},
+			// Kept under 2048 MiB so this test does not also depend on the
+			// separate int32 overflow fix for MemoryMiB (#10167).
+			MemoryMiB:                &ec2types.MemoryMiB{Min: aws.Int32(1024)},
+			AcceleratorManufacturers: []ec2types.AcceleratorManufacturer{ec2types.AcceleratorManufacturerNvidia},
+			AcceleratorTypes:         []ec2types.AcceleratorType{ec2types.AcceleratorTypeGpu},
+		}
+	}
+
+	for _, tc := range []struct {
+		name             string
+		acceleratorCount *ec2types.AcceleratorCount
+		expectGPU        bool
+		expectedGPUCount int64
+	}{
+		{
+			name:             "count omitted entirely",
+			acceleratorCount: nil,
+		},
+		{
+			name:             "count present but Min unset",
+			acceleratorCount: &ec2types.AcceleratorCount{Max: aws.Int32(8)},
+		},
+		{
+			name:             "count with Min set",
+			acceleratorCount: &ec2types.AcceleratorCount{Min: aws.Int32(2), Max: aws.Int32(8)},
+			expectGPU:        true,
+			expectedGPUCount: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requirements := baseRequirements()
+			requirements.AcceleratorCount = tc.acceleratorCount
+
+			awsManager := &AwsManager{}
+			capacity := apiv1.ResourceList{}
+			require.NotPanics(t, func() {
+				awsManager.updateCapacityWithRequirementsOverrides(
+					&capacity,
+					&mixedInstancesPolicy{instanceRequirements: requirements},
+				)
+			})
+
+			observedGPU, gpuPresent := capacity[gpu.ResourceNvidiaGPU]
+			assert.Equal(t, tc.expectGPU, gpuPresent)
+			if tc.expectGPU {
+				assert.Equal(t, tc.expectedGPUCount, observedGPU.Value())
+			}
+
+			// CPU and memory are resolved before the accelerator block, so they
+			// must survive regardless of whether the count was supplied.
+			observedCPU := capacity[apiv1.ResourceCPU]
+			assert.Equal(t, int64(4), observedCPU.Value())
+			observedMemory := capacity[apiv1.ResourceMemory]
+			assert.Equal(t, int64(1024)*1024*1024, observedMemory.Value())
+		})
+	}
+}


### PR DESCRIPTION
**Which component this PR applies to?**

/area cluster-autoscaler
/area provider/aws

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

`updateCapacityWithRequirementsOverrides` dereferences `instanceRequirements.AcceleratorCount.Min` without checking either pointer, while the two blocks immediately above it guard theirs:

```go
if instanceRequirements.VCpuCount != nil && instanceRequirements.VCpuCount.Min != nil { ... }
if instanceRequirements.MemoryMiB != nil && instanceRequirements.MemoryMiB.Min != nil { ... }

for _, manufacturer := range instanceRequirements.AcceleratorManufacturers {
    if manufacturer == ec2types.AcceleratorManufacturerNvidia {
        for _, acceleratorType := range instanceRequirements.AcceleratorTypes {
            if acceleratorType == ec2types.AcceleratorTypeGpu {
                ... int64(*instanceRequirements.AcceleratorCount.Min) ...   // both unguarded
            }
        }
    }
}
```

Both are optional in the EC2 API. The SDK documents `AcceleratorCount` as `Default: No minimum or maximum limits`, and its `Min` as `If this parameter is not specified, there is no minimum limit`.

So an ASG using attribute-based `InstanceRequirements` that asks for any NVIDIA GPU without pinning a count reaches the accelerator block with a nil `AcceleratorCount` and panics. That is the ordinary way to express "any GPU instance", not an exotic configuration.

Because this runs while building the synthetic template node, the panic takes down the autoscaler rather than degrading the one node group.

**Which issue(s) this PR fixes**

None filed. I found this while reading the function for #10167 and confirmed it against the code rather than in the field. Happy to open a tracking issue first if SIG Autoscaling would prefer that ordering.

**Reproduction**

Both of these panic on `master` before this change, confirmed by calling `updateCapacityWithRequirementsOverrides` directly:

```
AcceleratorManufacturers=[nvidia], AcceleratorTypes=[gpu], AcceleratorCount omitted
AcceleratorManufacturers=[nvidia], AcceleratorTypes=[gpu], AcceleratorCount{Max: 8}

panic: runtime error: invalid memory address or nil pointer dereference
```

**Behaviour**

When no minimum is given there is no GPU count to advertise, so the capacity entry is omitted rather than defaulted. That matches what the ASG actually asked for; inventing a count would make the template node claim capacity the group never requested. CPU and memory resolve before this block and are unaffected.

**Testing**

`TestUpdateCapacityWithRequirementsOverridesOptionalAcceleratorCount` covers the count omitted, the count present with `Min` unset, and the count fully specified, asserting no panic, the right GPU capacity or its absence, and that CPU and memory survive either way. Removing the guard fails it with the panic above.

```
go test ./cloudprovider/aws/     ok  (full package)
gofmt, go vet                    clean
```

**Note on overlap with #10167**

While writing this I first pinned `MemoryMiB` at 8192 and the test failed with `expected 8589934592, actual 0`, independently reproducing the int32 overflow in the same function. That is already fixed by #10171, so I moved my fixture to 1024 MiB to keep this PR independent of it. The two changes touch the same function but different lines and should not conflict.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a panic in the AWS cloud provider when an ASG's InstanceRequirements requests NVIDIA GPUs without specifying AcceleratorCount.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing CSI drivers configured through AWS node group and scaling group tags.
  - Detects missing EBS volume limits for configured CSI drivers.

- **Bug Fixes**
  - Prevented a crash when AWS instance requirements omit accelerator count details.
  - CPU and memory capacity continue to be reported, while GPU capacity is reported only when a minimum accelerator count is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->