### PR TITLE
cluster-autoscaler (GCE): Improve handling non-GCE ProviderId nodes.

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -127,6 +127,12 @@ func (gce *GceCloudProvider) NodeGroups(ctx context.Context) []cloudprovider.Nod
 // NodeGroupForNode returns the node group for the given node.
 func (gce *GceCloudProvider) NodeGroupForNode(ctx context.Context, node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	logger := klog.FromContext(ctx)
+
+	if !hasGceProviderId(node.Spec.ProviderID) {
+		logger.V(6).Info("Node has non-GCE providerID, treating as unmanaged", "node", klog.KObj(node), "providerID", node.Spec.ProviderID)
+		return nil, nil
+	}
+
 	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		logger.Error(err, "Error extracting node.Spec.ProviderID for node", "node", klog.KObj(node))
@@ -182,7 +188,13 @@ func (gce *GceCloudProvider) Refresh(ctx context.Context) error {
 	return gce.gceManager.Refresh(ctx)
 }
 
-// GceRef contains s reference to some entity in GCE world.
+const gceProviderIDPrefix = "gce://"
+
+func hasGceProviderId(id string) bool {
+	return strings.HasPrefix(id, gceProviderIDPrefix)
+}
+
+// GceRef contains a reference to some entity in GCE world.
 type GceRef struct {
 	Project string
 	Zone    string
@@ -195,21 +207,20 @@ func (ref GceRef) String() string {
 
 // ToProviderId converts GceRef to string in format used as ProviderId in Node object.
 func (ref GceRef) ToProviderId() string {
-	return fmt.Sprintf("gce://%s/%s/%s", ref.Project, ref.Zone, ref.Name)
+	return fmt.Sprintf("%s%s/%s/%s", gceProviderIDPrefix, ref.Project, ref.Zone, ref.Name)
 }
 
-// GceRefFromProviderId creates InstanceConfig object
+// GceRefFromProviderId creates GceRef object
 // from provider id which must be in format:
 // gce://<project-id>/<zone>/<name>
-// TODO(piosz): add better check whether the id is correct
 func GceRefFromProviderId(id string) (GceRef, error) {
-	if len(id) == 0 {
-		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got nil")
+	if !hasGceProviderId(id) {
+		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got %q", id)
 	}
 
-	splitted := strings.Split(id[6:], "/")
-	if len(splitted) != 3 {
-		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got %v", id)
+	splitted := strings.Split(strings.TrimPrefix(id, gceProviderIDPrefix), "/")
+	if len(splitted) != 3 || splitted[0] == "" || splitted[1] == "" || splitted[2] == "" {
+		return GceRef{}, fmt.Errorf("wrong id: expected format gce://<project-id>/<zone>/<name>, got %q", id)
 	}
 	return GceRef{
 		Project: splitted[0],
@@ -307,6 +318,9 @@ func (mig *gceMig) DecreaseTargetSize(ctx context.Context, delta int) error {
 
 // Belongs returns true if the given node belongs to the NodeGroup.
 func (mig *gceMig) Belongs(ctx context.Context, node *apiv1.Node) (bool, error) {
+	if !hasGceProviderId(node.Spec.ProviderID) {
+		return false, nil
+	}
 	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
 		return false, err
@@ -340,13 +354,12 @@ func (mig *gceMig) DeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 func (mig *gceMig) ForceDeleteNodes(ctx context.Context, nodes []*apiv1.Node) error {
 	refs := make([]GceRef, 0, len(nodes))
 	for _, node := range nodes {
-
 		belongs, err := mig.Belongs(ctx, node)
 		if err != nil {
 			return err
 		}
 		if !belongs {
-			return fmt.Errorf("%s belong to a different mig than %s", node.Name, mig.Id())
+			return fmt.Errorf("%s belongs to a different mig than %s", node.Name, mig.Id())
 		}
 		gceref, err := GceRefFromProviderId(node.Spec.ProviderID)
 		if err != nil {

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -143,15 +143,36 @@ func TestNodeGroupForNode(t *testing.T) {
 	gce := &GceCloudProvider{
 		gceManager: gceManagerMock,
 	}
-	n := BuildTestNode("n1", 1000, 1000)
-	n.Spec.ProviderID = "gce://project1/us-central1-b/n1"
+	n1 := BuildTestNode("n1", 1000, 1000)
+	n1.Spec.ProviderID = "gce://project1/us-central1-b/n1"
 	mig := gceMig{gceRef: GceRef{Name: "ng1"}}
 	gceManagerMock.On("GetMigForInstance", mock.AnythingOfType("gce.GceRef")).Return(&mig, nil).Once()
 
-	nodeGroup, err := gce.NodeGroupForNode(context.Background(), n)
+	nodeGroup, err := gce.NodeGroupForNode(context.Background(), n1)
 	assert.NoError(t, err)
 	assert.Equal(t, mig, *reflect.ValueOf(nodeGroup).Interface().(*gceMig))
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
+
+	// Node with empty providerID should return nil, nil.
+	n2 := BuildTestNode("n2", 1000, 1000)
+	n2.Spec.ProviderID = ""
+	nodeGroup, err = gce.NodeGroupForNode(context.Background(), n2)
+	assert.NoError(t, err)
+	assert.Nil(t, nodeGroup)
+
+	// Node without GCE providerID should return nil, nil.
+	n3 := BuildTestNode("n3", 1000, 1000)
+	n3.Spec.ProviderID = "k3s://node-3"
+	nodeGroup, err = gce.NodeGroupForNode(context.Background(), n3)
+	assert.NoError(t, err)
+	assert.Nil(t, nodeGroup)
+
+	// Malformed GCE providerID should return an error.
+	n4 := BuildTestNode("n4", 1000, 1000)
+	n4.Spec.ProviderID = "gce://invalid"
+	nodeGroup, err = gce.NodeGroupForNode(context.Background(), n4)
+	assert.Error(t, err)
+	assert.Nil(t, nodeGroup)
 }
 
 func TestGetResourceLimiter(t *testing.T) {
@@ -389,6 +410,13 @@ func TestMig(t *testing.T) {
 	assert.False(t, belongs)
 	mock.AssertExpectationsForObjects(t, gceManagerMock)
 
+	// Test Belongs - non-GCE node.
+	foreignNode := BuildTestNode("foreign-node", 1000, 1000)
+	foreignNode.Spec.ProviderID = "k3s://foreign-node"
+	belongs, err = mig1.Belongs(context.Background(), foreignNode)
+	assert.NoError(t, err)
+	assert.False(t, belongs)
+
 	// Test DeleteNodes.
 	n1 := BuildTestNode("gke-cluster-1-default-pool-f7607aac-9j4g", 1000, 1000)
 	n1.Spec.ProviderID = "gce://project1/us-central1-b/gke-cluster-1-default-pool-f7607aac-9j4g"
@@ -461,9 +489,62 @@ func TestMig(t *testing.T) {
 }
 
 func TestGceRefFromProviderId(t *testing.T) {
-	ref, err := GceRefFromProviderId("gce://project1/us-central1-b/name1")
-	assert.NoError(t, err)
-	assert.Equal(t, GceRef{"project1", "us-central1-b", "name1"}, ref)
+	testCases := []struct {
+		desc      string
+		id        string
+		expectErr bool
+		expectRef GceRef
+	}{
+		{
+			desc:      "valid provider id",
+			id:        "gce://project1/us-central1-b/name1",
+			expectErr: false,
+			expectRef: GceRef{Project: "project1", Zone: "us-central1-b", Name: "name1"},
+		},
+		{
+			desc:      "empty id",
+			id:        "",
+			expectErr: true,
+		},
+		{
+			desc:      "short id",
+			id:        "x",
+			expectErr: true,
+		},
+		{
+			desc:      "foreign prefix",
+			id:        "k3s://project1/us-central1-b/name1",
+			expectErr: true,
+		},
+		{
+			desc:      "too few parts",
+			id:        "gce://project1/us-central1-b",
+			expectErr: true,
+		},
+		{
+			desc:      "too many parts",
+			id:        "gce://project1/us-central1-b/name1/extra",
+			expectErr: true,
+		},
+		{
+			desc:      "empty component",
+			id:        "gce:///us-central1-b/name1",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ref, err := GceRefFromProviderId(tc.id)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectRef, ref)
+				assert.Equal(t, tc.id, ref.ToProviderId())
+			}
+		})
+	}
 }
 
 func createString(s string) *string {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/area cluster-autoscaler

#### What this PR does / why we need it:
Current logic of NodeGroupForNode in GCE cloud provider causes issues where it returns an error when called with an upcoming or non-GCE node. In this case, the error may be propagated up and until https://github.com/kubernetes-sigs/cluster-autoscaler/pull/103 caused the scale up to fail. While this should be no longer the case, this change is a follow up which makes it more resilient to such issues not occurring in the future and in other places.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10140

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
GCE cloud provider: gracefully handle nodes with non-GCE or empty provider IDs by treating them as unmanaged instead of returning an error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nodes with missing, non-GCE, or malformed provider IDs.
  * Nodes from other cloud providers are now correctly treated as unmanaged.
  * Added stricter validation for GCE provider IDs, including project, zone, and node components.
* **Tests**
  * Expanded coverage for invalid, foreign, incomplete, and empty provider ID values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->