### PR TITLE
vpa: add helm-unittest tooling and first test for recommender leader-election logic

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,10 +35,6 @@ jobs:
         run: git fetch --prune --unshallow
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
-      - name: Set up helm-unittest
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2
-      - name: Run Helm unit tests for VPA
-        run: helm unittest vertical-pod-autoscaler/charts/vertical-pod-autoscaler
       - name: Run chart-testing for CA (lint)
         run: ct lint --chart-dirs cluster-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }}
       - name: Run chart-testing for VPA (lint)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,6 +35,10 @@ jobs:
         run: git fetch --prune --unshallow
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+      - name: Set up helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2
+      - name: Run Helm unit tests for VPA
+        run: helm unittest vertical-pod-autoscaler/charts/vertical-pod-autoscaler
       - name: Run chart-testing for CA (lint)
         run: ct lint --chart-dirs cluster-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }}
       - name: Run chart-testing for VPA (lint)

--- a/.github/workflows/vpa-helm-unittest.yaml
+++ b/.github/workflows/vpa-helm-unittest.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Set up helm-unittest

--- a/.github/workflows/vpa-helm-unittest.yaml
+++ b/.github/workflows/vpa-helm-unittest.yaml
@@ -1,0 +1,23 @@
+name: VPA Helm Unit Tests
+
+on:
+  pull_request:
+    paths:
+      - 'vertical-pod-autoscaler/charts/**'
+
+permissions:
+  contents: read
+
+jobs:
+  helm-unittest:
+    name: Run Helm unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+      - name: Set up helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2
+      - name: Run Helm unit tests for VPA
+        run: helm unittest vertical-pod-autoscaler/charts/vertical-pod-autoscaler

--- a/.github/workflows/vpa-helm-unittest.yaml
+++ b/.github/workflows/vpa-helm-unittest.yaml
@@ -18,6 +18,6 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Set up helm-unittest
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2 --verify=false
       - name: Run Helm unit tests for VPA
         run: helm unittest vertical-pod-autoscaler/charts/vertical-pod-autoscaler

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -131,6 +131,11 @@ helm upgrade <release-name> <chart> \
   --set admissionController.registerWebhook=false \
   --set admissionController.certGen.enabled=true
 ```
+
+## Testing
+
+This chart includes [helm-unittest](https://github.com/helm-unittest/helm-unittest) test suites under `tests/` that validate template rendering logic (e.g. recommender leader-election defaults). See [TESTING.md](./TESTING.md) for setup instructions, how to run the tests, and how to add new ones.
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md.gotmpl
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md.gotmpl
@@ -128,4 +128,9 @@ helm upgrade <release-name> <chart> \
   --set admissionController.registerWebhook=false \
   --set admissionController.certGen.enabled=true
 ```
+
+## Testing
+
+This chart includes [helm-unittest](https://github.com/helm-unittest/helm-unittest) test suites under `tests/` that validate template rendering logic (e.g. recommender leader-election defaults). See [TESTING.md](./TESTING.md) for setup instructions, how to run the tests, and how to add new ones.
+
 {{ template "chart.valuesSection" . }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/TESTING.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/TESTING.md
@@ -1,0 +1,46 @@
+# Helm Chart Unit Tests
+
+The `vertical-pod-autoscaler` chart uses [helm-unittest](https://github.com/helm-unittest/helm-unittest)
+to test template rendering logic, for example, the recommender's automatic
+leader-election defaults based on replica count.
+
+## 1. Installing helm-unittest
+
+Check your Helm major version first:
+
+```bash
+helm version --short
+```
+
+Then install accordingly:
+
+```bash
+# Helm 4.x (plugin verification enabled by default)
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2 --verify=false
+
+# Helm 3.x (no --verify flag exists, omit it)
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.1.2
+```
+
+Confirm with `helm plugin list`; it should show a plugin named `unittest`.
+
+## 2. Running the tests
+
+```bash
+helm unittest vertical-pod-autoscaler/charts/vertical-pod-autoscaler
+```
+
+## 3. Writing new test cases
+
+Test suites live under `tests/` and follow the `<template-name>_test.yaml`
+naming convention. See `tests/recommender-deployment_test.yaml` for examples
+using `equal`, `contains`, `notContains`, and `matchRegex` assertions.
+
+## 4. Troubleshooting
+
+- `unknown flag: --verify` means you're on Helm 3; omit the flag.
+- `plugin already exists` means check `helm plugin list`; the plugin registers as
+  `unittest`, not `helm-unittest`. Run `helm plugin uninstall unittest`, then
+  reinstall.
+- Unexpected `helm version --short` output; run `which -a helm` to check for
+  multiple binaries competing on your `PATH`.

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/TESTING.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/TESTING.md
@@ -1,5 +1,12 @@
 # Helm Chart Unit Tests
 
+<!-- toc -->
+- [1. Installing helm-unittest](#1-installing-helm-unittest)
+- [2. Running the tests](#2-running-the-tests)
+- [3. Writing new test cases](#3-writing-new-test-cases)
+- [4. Troubleshooting](#4-troubleshooting)
+<!-- /toc -->
+
 The `vertical-pod-autoscaler` chart uses [helm-unittest](https://github.com/helm-unittest/helm-unittest)
 to test template rendering logic, for example, the recommender's automatic
 leader-election defaults based on replica count.

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/tests/recommender-deployment_test.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/tests/recommender-deployment_test.yaml
@@ -47,9 +47,9 @@ tests:
 
   - it: sets a deterministic default image and namespace env var
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: registry.k8s.io/autoscaling/vpa-recommender:1.7.1
+          pattern: ^registry\.k8s\.io/autoscaling/vpa-recommender:.+$
       - equal:
           path: spec.template.spec.containers[0].env[0].name
           value: NAMESPACE

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/tests/recommender-deployment_test.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/tests/recommender-deployment_test.yaml
@@ -2,6 +2,15 @@ suite: recommender deployment - leader election
 templates:
   - recommender-deployment.yaml
 tests:
+  - it: enables leader election by default (no overrides) since default replicas is 2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+      - equal:
+          path: spec.replicas
+          value: 2
+
   - it: enables leader election automatically when replicas > 1 and enabled is unset
     set:
       recommender.replicas: 2
@@ -44,3 +53,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[0].name
           value: NAMESPACE
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.fieldRef.fieldPath
+          value: metadata.namespace

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/tests/recommender-deployment_test.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/tests/recommender-deployment_test.yaml
@@ -1,0 +1,46 @@
+suite: recommender deployment - leader election
+templates:
+  - recommender-deployment.yaml
+tests:
+  - it: enables leader election automatically when replicas > 1 and enabled is unset
+    set:
+      recommender.replicas: 2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+
+  - it: does not enable leader election when replicas is 1 and enabled is unset
+    set:
+      recommender.replicas: 1
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+
+  - it: respects an explicit false even with replicas > 1
+    set:
+      recommender.replicas: 3
+      recommender.leaderElection.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+
+  - it: respects an explicit true even with replicas = 1
+    set:
+      recommender.replicas: 1
+      recommender.leaderElection.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+
+  - it: sets a deterministic default image and namespace env var
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.k8s.io/autoscaling/vpa-recommender:1.7.1
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: NAMESPACE

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/tests/updater-deployment_test.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/tests/updater-deployment_test.yaml
@@ -1,0 +1,76 @@
+suite: updater deployment and rbac - leader election
+templates:
+  - updater-deployment.yaml
+  - updater-role.yaml
+  - updater-rolebinding.yaml
+tests:
+  - it: enables leader election by default since default replicas is 2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+        template: updater-deployment.yaml
+      - hasDocuments:
+          count: 1
+        template: updater-role.yaml
+      - hasDocuments:
+          count: 1
+        template: updater-rolebinding.yaml
+
+  - it: does not enable leader election when replicas is 1 and enabled is unset
+    set:
+      updater.replicas: 1
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+        template: updater-deployment.yaml
+      - hasDocuments:
+          count: 0
+        template: updater-role.yaml
+      - hasDocuments:
+          count: 0
+        template: updater-rolebinding.yaml
+
+  - it: respects an explicit false even with replicas > 1
+    set:
+      updater.replicas: 3
+      updater.leaderElection.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+        template: updater-deployment.yaml
+      - hasDocuments:
+          count: 0
+        template: updater-role.yaml
+      - hasDocuments:
+          count: 0
+        template: updater-rolebinding.yaml
+
+  - it: respects an explicit true even with replicas = 1
+    set:
+      updater.replicas: 1
+      updater.leaderElection.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+        template: updater-deployment.yaml
+      - hasDocuments:
+          count: 1
+        template: updater-role.yaml
+      - hasDocuments:
+          count: 1
+        template: updater-rolebinding.yaml
+
+  - it: does not create leader-locking rbac when rbac.create is false, even with leader election active
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: updater-role.yaml
+      - hasDocuments:
+          count: 0
+        template: updater-rolebinding.yaml


### PR DESCRIPTION
## What this does

Sets up [helm-unittest](https://github.com/helm-unittest/helm-unittest) for the vertical-pod-autoscaler chart and adds one test suite to start with.

The test covers the recommender's leader election auto enable logic in recommender-deployment.yaml -
- leaderElection.enabled is unset (null) and replicas > 1 so it auto enables
- leaderElection.enabled is unset and replicas == 1 so it stays disabled
- explicit true/false always wins over the replica based default, both ways

## How to run it

```bash
helm plugin install https://github.com/helm-unittest/helm-unittest
helm unittest vertical-pod-autoscaler/charts/vertical-pod-autoscaler
```

## Scope

Keeping this small on purpose, just the tooling plus one test suite. Not wired into CI yet, wanted to get the approach checked before adding more.

## Next up (once this looks okay)

- Same pattern for the updater, including whether updater-role.yaml / updater-rolebinding.yaml get created at all
- The fail guards in admission-controller-validations.yaml (certManager vs certGen, the --reload-cert=false conflict)
- PDB minAvailable / maxUnavailable mutual exclusivity
- Adding helm unittest as a step in .github/workflows/pr.yaml

cc @adrianmoisey

```release-note
Helm unit tests have been added for the VPA chart, with CI coverage for chart changes.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for recommender leader-election behavior across replica counts and explicit configuration overrides.
  * Added validation for the recommender image pattern and namespace environment settings.

* **Chores**
  * Added automated Helm chart unit tests for pull requests affecting chart files.
  * Helm chart changes are now validated automatically in the project’s continuous integration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->