### PR TITLE
Fix AWS placeholder deletion race

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -311,36 +311,26 @@ func (m *asgCache) DeleteInstances(instances []*AwsInstanceRef) error {
 	}
 
 	placeHolderInstancesCount := m.GetPlaceHolderInstancesCount(instances)
-	// Check if there are any placeholder instances in the list.
+
+	// Placeholder instances represent desired capacity that has not materialized
+	// as real instances yet. Do not unconditionally set desired capacity to the
+	// current number of real instances here.
+	//
+	// DescribeAutoScalingGroups() and SetDesiredCapacity() are separate AWS API
+	// calls. A legitimate scale-up can happen between them. Setting desired
+	// capacity to the value observed by DescribeAutoScalingGroups() can therefore
+	// race with the scale-up and cause Auto Scaling to terminate healthy
+	// instances.
+	//
+	// Placeholder instances are virtual cache entries and must not be terminated
+	// through TerminateInstanceInAutoScalingGroup. Real instances below are still
+	// terminated individually with ShouldDecrementDesiredCapacity=true.
 	if placeHolderInstancesCount > 0 {
-		// Log the check for placeholders in the ASG.
-		klog.V(4).Infof("Detected %d placeholder instance(s) in ASG %s",
-			placeHolderInstancesCount, commonAsg.Name)
-
-		asgNames := []string{commonAsg.Name}
-		asgDetail, err := m.awsService.getAutoscalingGroupsByNames(asgNames)
-
-		if err != nil {
-			klog.Errorf("Error retrieving ASG details %s: %v", commonAsg.Name, err)
-			return err
-		}
-
-		activeInstancesInAsg := len(asgDetail[0].Instances)
-		desiredCapacityInAsg := int(*asgDetail[0].DesiredCapacity)
-		klog.V(4).Infof("asg %s has placeholders instances with desired capacity = %d and active instances = %d. updating ASG to match active instances count",
-			commonAsg.Name, desiredCapacityInAsg, activeInstancesInAsg)
-
-		// If the difference between the active instances and the desired capacity is greater than 1,
-		// it means that the ASG is under-provisioned and the desired capacity is not being reached.
-		// In this case, we would reduce the size of ASG by the count of unprovisioned instances
-		// which is equal to the total count of active instances in ASG
-
-		err = m.setAsgSizeNoLock(commonAsg, activeInstancesInAsg)
-
-		if err != nil {
-			klog.Errorf("Error reducing ASG %s size to %d: %v", commonAsg.Name, activeInstancesInAsg, err)
-			return err
-		}
+		klog.V(4).Infof(
+			"Detected %d placeholder instance(s) in ASG %s; skipping desired-capacity reconciliation",
+			placeHolderInstancesCount,
+			commonAsg.Name,
+		)
 	}
 
 	for _, instance := range instances {

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -573,27 +573,13 @@ func TestDeleteNodesWithPlaceholder(t *testing.T) {
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:5:test-asg"}))
 	asgs := provider.NodeGroups(context.Background())
 
-	a.On("SetDesiredCapacity",
-		mock.Anything,
-		&autoscaling.SetDesiredCapacityInput{
-			AutoScalingGroupName: aws.String(asgs[0].Id()),
-			DesiredCapacity:      aws.Int32(1),
-			HonorCooldown:        aws.Bool(false),
-		},
-	).Return(&autoscaling.SetDesiredCapacityOutput{}, nil)
-
-	// Look up the current number of instances...
-	var expectedInstancesCount int32 = 2
 	a.On("DescribeAutoScalingGroups",
 		mock.Anything,
 		&autoscaling.DescribeAutoScalingGroupsInput{
 			AutoScalingGroupNames: []string{"test-asg"},
 			MaxRecords:            aws.Int32(maxRecordsReturnedByAPI),
 		},
-	).Run(func(args mock.Arguments) {
-		// we expect the instance count to be 1 after the call to DeleteNodes
-		expectedInstancesCount = 1
-	}).Return(testNamedDescribeAutoScalingGroupsOutput("test-asg", expectedInstancesCount, "test-instance-id"), nil)
+	).Return(testNamedDescribeAutoScalingGroupsOutput("test-asg", 2, "test-instance-id"), nil)
 
 	a.On("DescribeScalingActivities",
 		mock.Anything,
@@ -618,12 +604,13 @@ func TestDeleteNodesWithPlaceholder(t *testing.T) {
 	}
 	err = asgs[0].DeleteNodes(context.Background(), []*apiv1.Node{node})
 	assert.NoError(t, err)
-	a.AssertNumberOfCalls(t, "SetDesiredCapacity", 1)
-	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 2)
+
+	a.AssertNumberOfCalls(t, "SetDesiredCapacity", 0)
+	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 1)
 
 	newSize, err := asgs[0].TargetSize(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, 1, newSize)
+	assert.Equal(t, 2, newSize)
 }
 
 func TestDeleteNodesAfterMultipleRefreshes(t *testing.T) {
@@ -774,16 +761,6 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 		maxSize: asgs[0].MaxSize(context.Background()),
 	}
 
-	// desired capacity will be set as 6 as ASG has 4 placeholders
-	a.On("SetDesiredCapacity",
-		mock.Anything,
-		&autoscaling.SetDesiredCapacityInput{
-			AutoScalingGroupName: aws.String(asgs[0].Id()),
-			DesiredCapacity:      aws.Int32(6),
-			HonorCooldown:        aws.Bool(false),
-		},
-	).Return(&autoscaling.SetDesiredCapacityOutput{}, nil)
-
 	// Look up the current number of instances...
 	var expectedInstancesCount int32 = 10
 	a.On("DescribeAutoScalingGroups",
@@ -866,8 +843,7 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 	// calling delete nodes 2 nodes and remaining placeholders
 	err = asgs[0].DeleteNodes(context.Background(), nodes)
 	assert.NoError(t, err)
-	a.AssertNumberOfCalls(t, "SetDesiredCapacity", 1)
-	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 2)
+	a.AssertNumberOfCalls(t, "DescribeAutoScalingGroups", 1)
 
 	// This ensures only 2 instances are terminated which are mocked in this unit test
 	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 2)

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -755,11 +755,7 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 	a := &autoScalingMock{}
 	provider := testProvider(t, newTestAwsManagerWithAsgs(t, a, nil, []string{"1:10:test-asg"}))
 	asgs := provider.NodeGroups(context.Background())
-	commonAsg := &asg{
-		AwsRef:  AwsRef{Name: asgs[0].Id()},
-		minSize: asgs[0].MinSize(context.Background()),
-		maxSize: asgs[0].MaxSize(context.Background()),
-	}
+	commonAsg := asgs[0].(*AwsNodeGroup).asg
 
 	// Look up the current number of instances...
 	var expectedInstancesCount int32 = 10
@@ -847,5 +843,7 @@ func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {
 
 	// This ensures only 2 instances are terminated which are mocked in this unit test
 	a.AssertNumberOfCalls(t, "TerminateInstanceInAutoScalingGroup", 2)
+
+	assert.Equal(t, 8, commonAsg.curSize)
 
 }


### PR DESCRIPTION
## What this PR does

Fixes a race condition in the AWS Cluster Autoscaler placeholder reconciliation path that can cause healthy, running EC2 instances to be terminated.

When a scale-up partially fails, the AWS provider creates placeholder instances to represent capacity that has not materialized. During placeholder cleanup, the previous implementation queried the ASG's active instance count and then issued an absolute `SetDesiredCapacity` request using that snapshot.

Because `DescribeAutoScalingGroups` and `SetDesiredCapacity` are separate AWS API operations, additional instances from the same scale-up can successfully launch between the capacity check and the desired-capacity update. The stale `SetDesiredCapacity` request can then reduce the ASG below its actual capacity, causing AWS Auto Scaling to terminate healthy instances.

This change removes the absolute desired-capacity reconciliation from the placeholder deletion path. Placeholder instances are virtual cache entries and are no longer used to derive an ASG desired-capacity update.

Real EC2 instance deletion remains unchanged and continues to use targeted `TerminateInstanceInAutoScalingGroup` requests with `ShouldDecrementDesiredCapacity=true`.

## Why this fixes the issue

* Eliminates the TOCTOU race between the ASG capacity observation and the subsequent `SetDesiredCapacity` call.
* Prevents stale ASG instance-count snapshots from reducing desired capacity during placeholder cleanup.
* Prevents AWS Auto Scaling from selecting unrelated healthy instances to satisfy a stale desired-capacity reduction.
* Preserves normal ASG scale-up and scale-down behavior.
* Preserves targeted termination of real instances.

Fixes #10147.

## Testing

The following tests pass:

* `go test ./cloudprovider/aws -count=1`
* `go test -race ./cloudprovider/aws -count=1`
* `git diff --check`

The full repository test suite was also attempted. It is currently blocked by unrelated vet errors in OCI vendored code; no AWS-related test failures were observed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion handling for placeholder instances in AWS Auto Scaling Groups.
  * Placeholder removal no longer changes the group’s desired capacity.
  * Real instances continue to be terminated with the appropriate capacity adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->