### PR TITLE
AWS example manifest: bump image tag to v1.36.1

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+++ b/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
@@ -149,7 +149,7 @@ spec:
           type: RuntimeDefault
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.1
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.36.1
           name: cluster-autoscaler
           resources:
             limits:


### PR DESCRIPTION
   /kind cleanup

   #### What this PR does / why we need it:
   The AWS example manifest's cluster-autoscaler image tag was stale and did not match this release branch. This updates it to v1.36.1 to match the current cluster-autoscaler-release-1.36 branch.

   #### Which issue(s) this PR fixes:
   Fixes #10279

   #### Does this PR introduce a user-facing change?

```release-note
NONE
```